### PR TITLE
Add per-server tmux executable paths

### DIFF
--- a/RemuxApp/Sources/App/RemuxAppDependencies.swift
+++ b/RemuxApp/Sources/App/RemuxAppDependencies.swift
@@ -171,7 +171,7 @@ struct RemuxAppDependencies: Sendable {
         )
     }
 
-    private static func sshConfiguration(
+    static func sshConfiguration(
         for target: TmuxConnectionTarget,
         trustedHostStore: TrustedHostStore,
         traceFlowID: String?
@@ -185,6 +185,7 @@ struct RemuxAppDependencies: Sendable {
             hostKeyValidator: trustedHostStore.validator(for: target.server),
             connectTimeout: RemuxConnectionTimeouts.terminalSSHConnect,
             controlNoResponseTimeout: RemuxConnectionTimeouts.tmuxControlNoResponse,
+            tmuxExecutable: target.server.tmuxExecutablePath ?? "tmux",
             sessionName: target.workspace.sessionName,
             traceFlowID: traceFlowID,
             sshRootKey: RemuxSSHRootKey(target: target)

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1370,6 +1370,7 @@ private struct ConnectionSetupView: View {
         case host
         case port
         case username
+        case tmuxExecutablePath
         case password
         case privateKeyPassphrase
         case sessionName
@@ -1464,18 +1465,24 @@ private struct ConnectionSetupView: View {
                 .libraryHomeListRowSurface()
             }
 
-            if showsSessionFields {
+            if showsEditableServerFields {
                 Section {
-                    textInputRow(
-                        title: "Name",
-                        placeholder: "e.g. main, work",
-                        keyPath: \.sessionName,
-                        field: .sessionName,
-                        validationMessage: validation.sessionName,
-                        textStyle: .monospaced,
-                        submitLabel: .go,
-                        accessibilityIdentifier: "connection.session"
-                    )
+                    tmuxExecutableInputRow()
+
+                    if showsSessionFields {
+                        sessionNameInputRow(title: "First Session")
+                    }
+                } header: {
+                    Text("tmux")
+                } footer: {
+                    if showsSessionFields {
+                        Text("After connecting, Remux attaches to this session or creates it if needed.")
+                    }
+                }
+                .libraryHomeListRowSurface()
+            } else if showsSessionFields {
+                Section {
+                    sessionNameInputRow(title: "Name")
                 } header: {
                     Text(sessionSectionTitle)
                 } footer: {
@@ -1556,11 +1563,13 @@ private struct ConnectionSetupView: View {
                     return .privateKeyPassphrase
                 }
             }
+            if showsEditableServerFields { return .tmuxExecutablePath }
             if showsSessionFields { return .sessionName }
             return nil
-        case .password:
+        case .password, .privateKeyPassphrase:
+            if showsEditableServerFields { return .tmuxExecutablePath }
             return showsSessionFields ? .sessionName : nil
-        case .privateKeyPassphrase:
+        case .tmuxExecutablePath:
             return showsSessionFields ? .sessionName : nil
         case .sessionName:
             return nil
@@ -1775,6 +1784,33 @@ private struct ConnectionSetupView: View {
         }
     }
 
+    private func tmuxExecutableInputRow() -> some View {
+        textInputRow(
+            title: "Executable Path (Optional)",
+            placeholder: "/absolute/path/to/tmux",
+            keyPath: \.tmuxExecutablePath,
+            field: .tmuxExecutablePath,
+            validationMessage: validation.tmuxExecutablePath,
+            textStyle: .monospaced,
+            keyboardType: .URL,
+            submitLabel: showsSessionFields ? .next : .go,
+            accessibilityIdentifier: "connection.tmux-executable"
+        )
+    }
+
+    private func sessionNameInputRow(title: String) -> some View {
+        textInputRow(
+            title: title,
+            placeholder: "e.g. main, work",
+            keyPath: \.sessionName,
+            field: .sessionName,
+            validationMessage: validation.sessionName,
+            textStyle: .monospaced,
+            submitLabel: .go,
+            accessibilityIdentifier: "connection.session"
+        )
+    }
+
     private func passwordInputRow(validationMessage: String?) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Password")
@@ -1787,7 +1823,7 @@ private struct ConnectionSetupView: View {
                 .textContentType(.oneTimeCode)
                 .multilineTextAlignment(.leading)
                 .focused($focusedField, equals: .password)
-                .submitLabel(showsSessionFields ? .next : .go)
+                .submitLabel(nextField(after: .password) == nil ? .go : .next)
                 .onSubmit { advance(from: .password) }
                 .frame(minHeight: 28)
                 .accessibilityIdentifier("connection.password")
@@ -2030,7 +2066,7 @@ private struct ConnectionSetupView: View {
                 .textContentType(.oneTimeCode)
                 .multilineTextAlignment(.leading)
                 .focused($focusedField, equals: .privateKeyPassphrase)
-                .submitLabel(showsSessionFields ? .next : .go)
+                .submitLabel(nextField(after: .privateKeyPassphrase) == nil ? .go : .next)
                 .onSubmit { advance(from: .privateKeyPassphrase) }
                 .frame(minHeight: 28)
                 .accessibilityIdentifier("connection.private-key.passphrase")

--- a/RemuxApp/Sources/App/TerminalRuntimeStatusPresentation.swift
+++ b/RemuxApp/Sources/App/TerminalRuntimeStatusPresentation.swift
@@ -60,6 +60,8 @@ struct TerminalRuntimeStatusPresentation: Equatable, Sendable {
             "Host Key"
         case .profile:
             "Profile Error"
+        case .tmuxUnavailable:
+            "tmux Error"
         case .remoteExit:
             "Exited"
         case .runtime:

--- a/RemuxApp/Sources/Domain/TmuxConnectionTarget.swift
+++ b/RemuxApp/Sources/Domain/TmuxConnectionTarget.swift
@@ -181,6 +181,7 @@ struct TerminalDisconnectReason: Equatable, Sendable {
         case authentication
         case hostKey
         case profile
+        case tmuxUnavailable
         case remoteExit
         case runtime
         case userClosed
@@ -198,6 +199,8 @@ struct TerminalDisconnectReason: Equatable, Sendable {
                 "host_key"
             case .profile:
                 "profile"
+            case .tmuxUnavailable:
+                "tmux_unavailable"
             case .remoteExit:
                 "remote_exit"
             case .runtime:
@@ -232,6 +235,7 @@ struct TerminalDisconnectReason: Equatable, Sendable {
              .authentication,
              .hostKey,
              .profile,
+             .tmuxUnavailable,
              .remoteExit,
              .runtime,
              .userClosed,

--- a/RemuxApp/Sources/Domain/TmuxConnectionTarget.swift
+++ b/RemuxApp/Sources/Domain/TmuxConnectionTarget.swift
@@ -100,6 +100,7 @@ struct SavedServer: Identifiable, Equatable, Codable, Sendable {
     var port: Int
     var username: String
     var identityID: SSHIdentity.ID
+    var tmuxExecutablePath: String?
 
     init(
         id: UUID = UUID(),
@@ -107,7 +108,8 @@ struct SavedServer: Identifiable, Equatable, Codable, Sendable {
         host: String,
         port: Int = 22,
         username: String,
-        identityID: SSHIdentity.ID
+        identityID: SSHIdentity.ID,
+        tmuxExecutablePath: String? = nil
     ) {
         self.id = id
         self.displayName = displayName
@@ -115,6 +117,7 @@ struct SavedServer: Identifiable, Equatable, Codable, Sendable {
         self.port = port
         self.username = username
         self.identityID = identityID
+        self.tmuxExecutablePath = tmuxExecutablePath
     }
 }
 
@@ -359,6 +362,7 @@ struct TmuxConnectionDraft: Equatable, Sendable {
     var host: String = ""
     var port: String = "22"
     var username: String = ""
+    var tmuxExecutablePath: String = ""
     var authenticationKind: SSHAuthenticationKind = .password
     var password: String = ""
     var privateKeyPEM: String = ""
@@ -373,6 +377,7 @@ struct TmuxConnectionDraft: Equatable, Sendable {
         self.host = server.host
         self.port = String(server.port)
         self.username = server.username
+        self.tmuxExecutablePath = server.tmuxExecutablePath ?? ""
         self.sessionName = workspace.sessionName
     }
 
@@ -400,6 +405,7 @@ struct TmuxConnectionDraftValidation: Equatable, Sendable {
     var host: String?
     var port: String?
     var username: String?
+    var tmuxExecutablePath: String?
     var password: String?
     var privateKey: String?
     var privateKeyPassphrase: String?
@@ -412,6 +418,7 @@ struct TmuxConnectionDraftValidation: Equatable, Sendable {
             host == nil &&
             port == nil &&
             username == nil &&
+            tmuxExecutablePath == nil &&
             password == nil &&
             privateKey == nil &&
             privateKeyPassphrase == nil &&
@@ -444,6 +451,7 @@ struct ValidatedTmuxServerDraft: Equatable, Sendable {
     let host: String
     let port: Int
     let username: String
+    let tmuxExecutablePath: String?
     let credential: Credential
 
     func savedServer(identityID: SSHIdentity.ID) -> SavedServer {
@@ -453,7 +461,8 @@ struct ValidatedTmuxServerDraft: Equatable, Sendable {
             host: host,
             port: port,
             username: username,
-            identityID: identityID
+            identityID: identityID,
+            tmuxExecutablePath: tmuxExecutablePath
         )
     }
 }
@@ -525,6 +534,11 @@ enum TmuxConnectionDraftValidator {
         let displayName = draft.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let host = draft.host.trimmingCharacters(in: .whitespacesAndNewlines)
         let username = draft.username.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedTmuxExecutablePath = draft.tmuxExecutablePath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let tmuxExecutablePath = trimmedTmuxExecutablePath.isEmpty
+            ? nil
+            : trimmedTmuxExecutablePath
         let password = draft.password
         let privateKeyPEM = draft.privateKeyPEM.trimmingCharacters(in: .whitespacesAndNewlines)
         let privateKeyPassphrase = draft.privateKeyPassphrase.isEmpty ? nil : draft.privateKeyPassphrase
@@ -545,6 +559,16 @@ enum TmuxConnectionDraftValidator {
         let serverID = existingServerID ?? UUID()
         if username.isEmpty {
             validation.username = "Username is required."
+        }
+
+        if let tmuxExecutablePath {
+            if !tmuxExecutablePath.hasPrefix("/") {
+                validation.tmuxExecutablePath = "Enter an absolute path beginning with /."
+            } else if tmuxExecutablePath.contains("\n") ||
+                        tmuxExecutablePath.contains("\r") ||
+                        tmuxExecutablePath.contains("\0") {
+                validation.tmuxExecutablePath = "Executable path contains invalid characters."
+            }
         }
 
         let credential: ValidatedTmuxServerDraft.Credential
@@ -591,6 +615,7 @@ enum TmuxConnectionDraftValidator {
                 host: host,
                 port: port,
                 username: username,
+                tmuxExecutablePath: tmuxExecutablePath,
                 credential: credential
             )
         )
@@ -631,6 +656,7 @@ private extension TmuxConnectionDraftValidation {
         host = host ?? other.host
         port = port ?? other.port
         username = username ?? other.username
+        tmuxExecutablePath = tmuxExecutablePath ?? other.tmuxExecutablePath
         password = password ?? other.password
         privateKey = privateKey ?? other.privateKey
         privateKeyPassphrase = privateKeyPassphrase ?? other.privateKeyPassphrase

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceStatusOverlay.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceStatusOverlay.swift
@@ -164,12 +164,13 @@ struct GhosttySurfaceStatusOverlay: View {
                 )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-        } else if reason?.kind == .serverUnreachable {
+        } else if reason?.kind == .serverUnreachable || reason?.kind == .tmuxUnavailable {
+            let identifierKind = reason?.kind == .tmuxUnavailable ? "tmux" : "unreachable"
             HStack(spacing: 12) {
                 GhosttyRepairActionButton(
                     title: "Retry",
                     systemName: "arrow.clockwise",
-                    accessibilityIdentifier: "terminal.status.unreachable.retry",
+                    accessibilityIdentifier: "terminal.status.\(identifierKind).retry",
                     chromeStyle: chromeStyle,
                     isPrimary: true,
                     action: onReconnect
@@ -178,7 +179,7 @@ struct GhosttySurfaceStatusOverlay: View {
                 GhosttyRepairActionButton(
                     title: "Edit Server",
                     systemName: "slider.horizontal.3",
-                    accessibilityIdentifier: "terminal.status.unreachable.editServer",
+                    accessibilityIdentifier: "terminal.status.\(identifierKind).editServer",
                     chromeStyle: chromeStyle,
                     action: onEditServer
                 )
@@ -217,6 +218,10 @@ struct GhosttySurfaceStatusOverlay: View {
             return "Server Unreachable"
         }
 
+        if reason?.kind == .tmuxUnavailable {
+            return "tmux Unavailable"
+        }
+
         return "Disconnected"
     }
 
@@ -231,6 +236,10 @@ struct GhosttySurfaceStatusOverlay: View {
 
         if reason?.kind == .serverUnreachable {
             return "CONNECTION"
+        }
+
+        if reason?.kind == .tmuxUnavailable {
+            return "TMUX"
         }
 
         return "TERMINAL"

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalDisconnectReasonClassifier.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalDisconnectReasonClassifier.swift
@@ -25,7 +25,16 @@ enum GhosttyTerminalDisconnectReasonClassifier {
 
         if let sshError = error as? SSHTmuxControlTransportError {
             switch sshError {
-            case .remoteExit:
+            case .remoteExit(let status, let diagnostics):
+                if let message = tmuxExecutableFailureMessage(
+                    status: status,
+                    diagnostics: diagnostics
+                ) {
+                    return TerminalDisconnectReason(
+                        kind: .tmuxUnavailable,
+                        message: message
+                    )
+                }
                 return TerminalDisconnectReason(kind: .remoteExit, message: message)
             case .channelRequestFailed:
                 return TerminalDisconnectReason(kind: .profile, message: message)
@@ -46,6 +55,25 @@ enum GhosttyTerminalDisconnectReasonClassifier {
         }
 
         return TerminalDisconnectReason(kind: .unknown, message: message)
+    }
+
+    private static func tmuxExecutableFailureMessage(
+        status: Int,
+        diagnostics: SSHTmuxStartupDiagnostics?
+    ) -> String? {
+        guard status == 126 || status == 127 else {
+            return nil
+        }
+
+        let stderr = diagnostics?.stderrPreview?.lowercased() ?? ""
+        let tmuxWasNotFound = stderr.contains("command not found") ||
+            stderr.contains("no such file or directory")
+
+        if status == 127 || tmuxWasNotFound {
+            return "Install tmux on this server or update Executable Path."
+        }
+
+        return "Check the tmux executable and its permissions, then try again."
     }
 
     private static func isServerUnreachable(_ error: any Error) -> Bool {

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
@@ -1,5 +1,5 @@
 enum SSHTmuxControlCommandBuilder {
-    private static let remotePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    private static let fallbackRemotePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     static func attachOrCreateControlSessionCommand(
         tmuxExecutable: String,
@@ -14,7 +14,7 @@ enum SSHTmuxControlCommandBuilder {
         // requirement). The session channel is a bare exec stream feeding
         // Ghostty's tmux session parser directly.
         return """
-        export PATH=\(remotePath) TERM=xterm-256color; exec \(tmux) -C new-session -A -s \(session) -x \(initialViewport.columns) -y \(initialViewport.rows)
+        export PATH="${PATH:+$PATH:}\(fallbackRemotePath)" TERM=xterm-256color; exec \(tmux) -C new-session -A -s \(session) -x \(initialViewport.columns) -y \(initialViewport.rows)
         """
     }
 

--- a/RemuxAppTests/ConnectionProfileRepositoryTests.swift
+++ b/RemuxAppTests/ConnectionProfileRepositoryTests.swift
@@ -200,7 +200,8 @@ final class ConnectionProfileRepositoryTests: XCTestCase {
             displayName: "Example",
             host: "example.test",
             username: "deploy",
-            identityID: identityID
+            identityID: identityID,
+            tmuxExecutablePath: "/home/deploy/.local/bin/tmux"
         )
 
         let encoded = try JSONEncoder().encode(server)
@@ -208,6 +209,28 @@ final class ConnectionProfileRepositoryTests: XCTestCase {
 
         XCTAssertEqual(decoded, server)
         XCTAssertEqual(decoded.identityID, identityID)
+        XCTAssertEqual(decoded.tmuxExecutablePath, "/home/deploy/.local/bin/tmux")
+    }
+
+    func testSavedServerDecodesMissingTmuxExecutablePathAsDefault() throws {
+        let id = UUID()
+        let identityID = UUID()
+        let data = Data(
+            """
+            {
+              "id": "\(id.uuidString)",
+              "displayName": "Existing Server",
+              "host": "server.example.test",
+              "port": 22,
+              "username": "demo",
+              "identityID": "\(identityID.uuidString)"
+            }
+            """.utf8
+        )
+
+        let server = try JSONDecoder().decode(SavedServer.self, from: data)
+
+        XCTAssertNil(server.tmuxExecutablePath)
     }
 
     func testSSHIdentityCodablePreservesFields() throws {

--- a/RemuxAppTests/GhosttyTerminalDisconnectReasonClassifierTests.swift
+++ b/RemuxAppTests/GhosttyTerminalDisconnectReasonClassifierTests.swift
@@ -41,6 +41,25 @@ final class GhosttyTerminalDisconnectReasonClassifierTests: XCTestCase {
         )
         XCTAssertEqual(
             GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
+                SSHTmuxControlTransportError.remoteExit(127)
+            ).kind,
+            .tmuxUnavailable
+        )
+        let missingPathDiagnostics = SSHTmuxStartupDiagnostics(
+            stdoutByteCount: 0,
+            stderrByteCount: 45,
+            extendedDataByteCount: 0,
+            stderrPreview: "sh: /missing/tmux: No such file or directory\\x0A",
+            extendedDataPreview: nil
+        )
+        XCTAssertEqual(
+            GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
+                SSHTmuxControlTransportError.remoteExit(126, diagnostics: missingPathDiagnostics)
+            ).kind,
+            .tmuxUnavailable
+        )
+        XCTAssertEqual(
+            GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
                 SSHTmuxControlTransportError.channelRequestFailed(.exec)
             ).kind,
             .profile

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -68,6 +68,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         )
         XCTAssertNil(defaultConfiguration.traceFlowID)
         XCTAssertEqual(defaultConfiguration.controlNoResponseTimeout, .seconds(15))
+        XCTAssertEqual(defaultConfiguration.tmuxExecutable, "tmux")
 
         let tracedConfiguration = SSHTmuxControlConfiguration(
             host: server.host,
@@ -83,6 +84,35 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         XCTAssertEqual(tracedConfiguration.traceFlowID, "session.open.test")
         XCTAssertEqual(tracedConfiguration.connectTimeout, .seconds(10))
         XCTAssertEqual(tracedConfiguration.controlNoResponseTimeout, .seconds(12))
+    }
+
+    func testAppDependenciesTmuxConfigurationUsesSavedServerExecutable() {
+        let executablePath = "/home/deploy/.local/share/mise/shims/tmux"
+        let server = SavedServer(
+            displayName: "Custom tmux",
+            host: "example.com",
+            username: "deploy",
+            identityID: UUID(),
+            tmuxExecutablePath: executablePath
+        )
+        let workspace = SavedWorkspace(serverID: server.id, sessionName: "base")
+        let target = TmuxConnectionTarget(
+            server: server,
+            workspace: workspace,
+            sshAuth: makePasswordAuth(server: server, password: "pw")
+        )
+        let trustedHostStore = TrustedHostStore(
+            rootURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        )
+
+        let configuration = RemuxAppDependencies.sshConfiguration(
+            for: target,
+            trustedHostStore: trustedHostStore,
+            traceFlowID: nil
+        )
+
+        XCTAssertEqual(configuration.tmuxExecutable, executablePath)
     }
 
     func testSFTPLeaseOpenTimeoutReturnsSuccessfulOperation() async throws {

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -1311,13 +1311,13 @@ final class SSHTmuxControlTransportTests: XCTestCase {
 
         XCTAssertEqual(
             command,
-            "export PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin TERM=xterm-256color; exec 'tmux' -C new-session -A -s 'base' -x 45 -y 37"
+            "export PATH=\"${PATH:+$PATH:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" TERM=xterm-256color; exec 'tmux' -C new-session -A -s 'base' -x 45 -y 37"
         )
     }
 
     func testControlSessionCommandShellEscapesValues() {
         let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
-            tmuxExecutable: "/opt/homebrew/bin/tmux",
+            tmuxExecutable: "/home/owner's tools/tmux",
             sessionName: "owner's base",
             initialViewport: TmuxControlViewport(
                 columns: 120,
@@ -1329,7 +1329,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
 
         XCTAssertEqual(
             command,
-            "export PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin TERM=xterm-256color; exec '/opt/homebrew/bin/tmux' -C new-session -A -s 'owner'\"'\"'s base' -x 120 -y 40"
+            "export PATH=\"${PATH:+$PATH:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" TERM=xterm-256color; exec '/home/owner'\"'\"'s tools/tmux' -C new-session -A -s 'owner'\"'\"'s base' -x 120 -y 40"
         )
     }
 

--- a/RemuxAppTests/TmuxConnectionDraftValidatorTests.swift
+++ b/RemuxAppTests/TmuxConnectionDraftValidatorTests.swift
@@ -9,6 +9,7 @@ final class TmuxConnectionDraftValidatorTests: XCTestCase {
         draft.port = "22"
         draft.username = "demo"
         draft.password = "demo-password"
+        draft.tmuxExecutablePath = "  /home/demo/.local/share/mise/shims/tmux  "
         draft.sessionName = "base"
 
         let result = TmuxConnectionDraftValidator.validate(
@@ -26,6 +27,14 @@ final class TmuxConnectionDraftValidatorTests: XCTestCase {
         XCTAssertEqual(submission.server.host, "server.example.com")
         XCTAssertEqual(submission.server.port, 22)
         XCTAssertEqual(submission.server.username, "demo")
+        XCTAssertEqual(
+            submission.server.tmuxExecutablePath,
+            "/home/demo/.local/share/mise/shims/tmux"
+        )
+        XCTAssertEqual(
+            submission.server.savedServer(identityID: UUID()).tmuxExecutablePath,
+            "/home/demo/.local/share/mise/shims/tmux"
+        )
         XCTAssertEqual(submission.workspace.serverID, submission.server.serverID)
         XCTAssertEqual(submission.workspace.sessionName, "base")
         XCTAssertEqual(submission.server.credential, .password("demo-password"))
@@ -121,7 +130,46 @@ final class TmuxConnectionDraftValidatorTests: XCTestCase {
 
         XCTAssertEqual(submission.serverID, serverID)
         XCTAssertEqual(submission.displayName, "Laptop")
+        XCTAssertNil(submission.tmuxExecutablePath)
         XCTAssertEqual(submission.credential, .password("demo-password"))
+    }
+
+    func testServerDraftRejectsInvalidTmuxExecutablePaths() {
+        for path in [
+            "~/.local/share/mise/shims/tmux",
+            "/usr/local/bin/tmux\nwhoami",
+            "/usr/local/bin/tmux\0",
+        ] {
+            var draft = validServerDraft()
+            draft.tmuxExecutablePath = path
+
+            let result = TmuxConnectionDraftValidator.validateServer(
+                draft,
+                existingServerID: nil
+            )
+
+            guard case .invalid(let validation) = result else {
+                XCTFail("expected invalid server submission for \(path.debugDescription)")
+                continue
+            }
+
+            XCTAssertNotNil(validation.tmuxExecutablePath)
+        }
+    }
+
+    func testConnectionDraftLoadsSavedTmuxExecutablePathForEditing() {
+        let server = SavedServer(
+            displayName: "Laptop",
+            host: "laptop.example.com",
+            username: "demo",
+            identityID: UUID(),
+            tmuxExecutablePath: "/opt/tmux/bin/tmux"
+        )
+        let workspace = SavedWorkspace(serverID: server.id, sessionName: "ops")
+
+        let draft = TmuxConnectionDraft(server: server, workspace: workspace)
+
+        XCTAssertEqual(draft.tmuxExecutablePath, "/opt/tmux/bin/tmux")
     }
 
     func testValidPrivateKeyDraftProducesPrivateKeyCredential() {


### PR DESCRIPTION
## Summary

- Add an optional absolute tmux executable path per server.
- Support configuring the path when creating or editing a server.
- Preserve the server’s existing `PATH` when adding Remux’s fallback paths.
- Show an actionable error when tmux cannot be started.
- Keep existing saved servers compatible.

Closes #1.

## Testing

- 832 unit tests passed.
- Verified the New Server and Edit Server forms in the simulator.
- Verified custom executable paths and preserved PATH behavior through SSH tmux control connections.

## Screenshots

<table>
  <tr>
    <th>New Server</th>
    <th>Edit Server</th>
  </tr>
  <tr>
    <td>
      <img width="400" alt="New Server" src="https://github.com/user-attachments/assets/2679d2a6-b70e-415c-a046-5e0f2eada89c" />
    </td>
    <td>
      <img width="400" alt="Edit Server" src="https://github.com/user-attachments/assets/8fbf753b-a0f5-4967-96c1-b864fb05460d" />
    </td>
  </tr>
</table>