### PR TITLE
support CJK input methods by implementing UITextInput marked text

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderTextInputShim.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderTextInputShim.swift
@@ -1,17 +1,15 @@
 import UIKit
 
-// The terminal responder needs to conform to `UITextInput` so iOS will deliver
-// the spacebar long-press floating-cursor gesture (`beginFloatingCursor` /
-// `updateFloatingCursor` / `endFloatingCursor`). The terminal has no editable
-// document, so this file provides safe stubs over a virtual one-character
-// document. Everything here exists solely to keep UIKit's protocol-required
-// calls happy without surfacing autocorrect, marked text, an edit menu, or
-// other text-input behaviors. UIKit may still deliver committed software
-// keyboard input through `replace(_:withText:)`, so committed replacement text
-// is forwarded to the same terminal path as `insertText`.
+// The terminal responder conforms to `UITextInput` so iOS will deliver the
+// spacebar long-press floating-cursor gesture AND support CJK input methods
+// (Pinyin, Wubi, etc.) that require a marked-text (composing) region.
+//
+// The terminal has no editable document, so this file maintains a lightweight
+// virtual document: empty when idle, containing the composing string while an
+// IME is active. Committed text flows through `insertText` / `replace` into
+// the terminal.
 
-/// Stub UITextPosition backed by an integer offset in a virtual document of
-/// length 1.
+/// Stub UITextPosition backed by an integer offset in the virtual document.
 final class GhosttyVirtualTextPosition: UITextPosition {
     let offset: Int
     init(offset: Int) {
@@ -36,40 +34,105 @@ final class GhosttyVirtualTextRange: UITextRange {
 }
 
 extension GhosttyTerminalResponderUIView: UITextInput {
+
+    // MARK: - Virtual document length
+
+    private var documentLength: Int {
+        storedMarkedText?.count ?? 0
+    }
+
+    // MARK: - Selected / marked text
+
     var selectedTextRange: UITextRange? {
         get {
+            if let marked = storedMarkedText {
+                let loc = storedMarkedSelectedRange.location == NSNotFound
+                    ? marked.count
+                    : min(storedMarkedSelectedRange.location, marked.count)
+                let pos = GhosttyVirtualTextPosition(offset: loc)
+                return GhosttyVirtualTextRange(from: pos, to: pos)
+            }
             let zero = GhosttyVirtualTextPosition(offset: 0)
             return GhosttyVirtualTextRange(from: zero, to: zero)
         }
         set { _ = newValue }
     }
 
-    var markedTextRange: UITextRange? { nil }
+    var markedTextRange: UITextRange? {
+        guard let marked = storedMarkedText, !marked.isEmpty else { return nil }
+        return GhosttyVirtualTextRange(
+            from: GhosttyVirtualTextPosition(offset: 0),
+            to: GhosttyVirtualTextPosition(offset: marked.count)
+        )
+    }
+
     var markedTextStyle: [NSAttributedString.Key: Any]? {
         get { nil }
         set { _ = newValue }
     }
 
     var beginningOfDocument: UITextPosition { GhosttyVirtualTextPosition(offset: 0) }
-    var endOfDocument: UITextPosition { GhosttyVirtualTextPosition(offset: 1) }
+    var endOfDocument: UITextPosition { GhosttyVirtualTextPosition(offset: documentLength) }
     var tokenizer: UITextInputTokenizer { floatingCursorTokenizer }
     var selectionAffinity: UITextStorageDirection {
         get { .forward }
         set { _ = newValue }
     }
 
-    func text(in range: UITextRange) -> String? { "" }
+    // MARK: - Reading text
+
+    func text(in range: UITextRange) -> String? {
+        guard let marked = storedMarkedText,
+              let vRange = range as? GhosttyVirtualTextRange else {
+            return ""
+        }
+        let lower = max(0, vRange.from.offset)
+        let upper = min(marked.count, vRange.to.offset)
+        guard lower < upper else { return "" }
+        let start = marked.index(marked.startIndex, offsetBy: lower)
+        let end = marked.index(marked.startIndex, offsetBy: upper)
+        return String(marked[start..<end])
+    }
 
     func replace(_ range: UITextRange, withText text: String) {
         _ = range
+        if storedMarkedText != nil {
+            inputDelegate?.textWillChange(self)
+            storedMarkedText = nil
+            storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+            inputDelegate?.textDidChange(self)
+        }
         submitTextInput(text, source: "replaceText")
     }
 
+    // MARK: - Marked text (IME composing)
+
     func setMarkedText(_ markedText: String?, selectedRange: NSRange) {
-        _ = (markedText, selectedRange)
+        inputDelegate?.textWillChange(self)
+        if let text = markedText, !text.isEmpty {
+            storedMarkedText = text
+            storedMarkedSelectedRange = selectedRange
+        } else {
+            storedMarkedText = nil
+            storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        }
+        inputDelegate?.textDidChange(self)
     }
 
-    func unmarkText() {}
+    func unmarkText() {
+        guard let text = storedMarkedText, !text.isEmpty else {
+            storedMarkedText = nil
+            storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+            return
+        }
+        inputDelegate?.textWillChange(self)
+        storedMarkedText = nil
+        storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        inputDelegate?.textDidChange(self)
+        submitTextInput(text, source: "unmarkText")
+    }
+
+    // MARK: - Position / range geometry
 
     func textRange(from fromPosition: UITextPosition, to toPosition: UITextPosition) -> UITextRange? {
         guard
@@ -83,7 +146,7 @@ extension GhosttyTerminalResponderUIView: UITextInput {
 
     func position(from position: UITextPosition, offset: Int) -> UITextPosition? {
         guard let position = position as? GhosttyVirtualTextPosition else { return nil }
-        let next = max(0, min(1, position.offset + offset))
+        let next = max(0, min(documentLength, position.offset + offset))
         return GhosttyVirtualTextPosition(offset: next)
     }
 
@@ -92,9 +155,6 @@ extension GhosttyTerminalResponderUIView: UITextInput {
         in direction: UITextLayoutDirection,
         offset: Int
     ) -> UITextPosition? {
-        // Direction is meaningless against a single-character virtual document;
-        // delegate to the linear offset variant so UIKit's tokenizer keeps
-        // receiving non-nil positions.
         self.position(from: position, offset: offset)
     }
 
@@ -143,14 +203,16 @@ extension GhosttyTerminalResponderUIView: UITextInput {
         _ = (writingDirection, range)
     }
 
+    // MARK: - Hit-testing / rects
+
     func firstRect(for range: UITextRange) -> CGRect {
         _ = range
-        return .zero
+        return CGRect(x: 0, y: bounds.maxY - 2, width: 1, height: 2)
     }
 
     func caretRect(for position: UITextPosition) -> CGRect {
         _ = position
-        return .zero
+        return CGRect(x: 0, y: bounds.maxY - 2, width: 1, height: 2)
     }
 
     func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -105,6 +105,9 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         UITextInputStringTokenizer(textInput: self)
     weak var inputDelegate: UITextInputDelegate?
 
+    var storedMarkedText: String?
+    var storedMarkedSelectedRange: NSRange = NSRange(location: NSNotFound, length: 0)
+
     init(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver) {
         self.trackpadDriver = trackpadDriver
         super.init(frame: .zero)
@@ -186,6 +189,12 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     }
 
     func insertText(_ text: String) {
+        if storedMarkedText != nil {
+            inputDelegate?.textWillChange(self)
+            storedMarkedText = nil
+            storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+            inputDelegate?.textDidChange(self)
+        }
         submitTextInput(text, source: "insertText")
     }
 
@@ -335,6 +344,13 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
     func deleteBackward() {
         guard isInputEnabled else { return }
+        if storedMarkedText != nil {
+            inputDelegate?.textWillChange(self)
+            storedMarkedText = nil
+            storedMarkedSelectedRange = NSRange(location: NSNotFound, length: 0)
+            inputDelegate?.textDidChange(self)
+            return
+        }
         GhosttyRuntimeTrace.diagnostics(
             "responder.deleteBackward firstResponder=\(isFirstResponder) token=\(activationToken)"
         )

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -924,4 +924,211 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         driver.repeatTick(at: .greatestFiniteMagnitude)
         XCTAssertEqual(receivedEvents.count, eventCountAfterDisable)
     }
+
+    // MARK: - Marked text (IME composing)
+
+    @MainActor
+    func testSetMarkedTextStoresComposingRegionAndExposesMarkedTextRange() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        view.setMarkedText("pin", selectedRange: NSRange(location: 3, length: 0))
+
+        XCTAssertNotNil(view.markedTextRange)
+        XCTAssertEqual(view.text(in: view.markedTextRange!), "pin")
+    }
+
+    @MainActor
+    func testSetMarkedTextWithNilClearsComposingRegion() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        view.setMarkedText("zh", selectedRange: NSRange(location: 2, length: 0))
+        XCTAssertNotNil(view.markedTextRange)
+
+        view.setMarkedText(nil, selectedRange: NSRange(location: NSNotFound, length: 0))
+        XCTAssertNil(view.markedTextRange)
+    }
+
+    @MainActor
+    func testUnmarkTextCommitsStoredMarkedTextToTerminal() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedText: [String] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: {
+                receivedText.append($0)
+                return true
+            },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        // Simulate CJK IME: setMarkedText with the selected character, then unmarkText.
+        view.setMarkedText("\u{4e2d}", selectedRange: NSRange(location: 1, length: 0))
+        view.unmarkText()
+
+        XCTAssertEqual(receivedText, ["\u{4e2d}"])
+        XCTAssertNil(view.markedTextRange)
+    }
+
+    @MainActor
+    func testUnmarkTextWithNoMarkedTextDoesNotSendToTerminal() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedText: [String] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: {
+                receivedText.append($0)
+                return true
+            },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        view.unmarkText()
+
+        XCTAssertTrue(receivedText.isEmpty)
+    }
+
+    @MainActor
+    func testInsertTextClearsActiveMarkedTextAndSendsCommittedCharacter() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedText: [String] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: {
+                receivedText.append($0)
+                return true
+            },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        // Simulate IME path where insertText arrives while composing.
+        view.setMarkedText("pin", selectedRange: NSRange(location: 3, length: 0))
+        view.insertText("\u{62fc}")
+
+        XCTAssertEqual(receivedText, ["\u{62fc}"])
+        XCTAssertNil(view.markedTextRange)
+    }
+
+    @MainActor
+    func testDeleteBackwardDuringComposingClearsMarkedTextWithoutSendingBackspace() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedText: [String] = []
+        var receivedEvent: GhosttySurfaceKeyEvent?
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: {
+                receivedText.append($0)
+                return true
+            },
+            sendPaste: { _ in true },
+            sendKeyEvent: {
+                receivedEvent = $0
+                return true
+            },
+            onTrackpadStateChange: { _ in }
+        )
+
+        view.setMarkedText("zh", selectedRange: NSRange(location: 2, length: 0))
+        view.deleteBackward()
+
+        XCTAssertNil(view.markedTextRange)
+        XCTAssertTrue(receivedText.isEmpty)
+        XCTAssertNil(receivedEvent)
+    }
+
+    @MainActor
+    func testReplaceTextDuringComposingClearsMarkedTextAndSendsReplacement() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedText: [String] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: {
+                receivedText.append($0)
+                return true
+            },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        view.setMarkedText("wen", selectedRange: NSRange(location: 3, length: 0))
+        view.replace(view.markedTextRange!, withText: "\u{6587}")
+
+        XCTAssertEqual(receivedText, ["\u{6587}"])
+        XCTAssertNil(view.markedTextRange)
+    }
+
+    @MainActor
+    func testMarkedTextRangeIsNilWithNoComposingText() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        XCTAssertNil(view.markedTextRange)
+    }
+
+    @MainActor
+    func testEndOfDocumentReflectsMarkedTextLength() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onTrackpadStateChange: { _ in }
+        )
+
+        let endBefore = view.endOfDocument as! GhosttyVirtualTextPosition
+        XCTAssertEqual(endBefore.offset, 0)
+
+        view.setMarkedText("zhong", selectedRange: NSRange(location: 5, length: 0))
+
+        let endDuring = view.endOfDocument as! GhosttyVirtualTextPosition
+        XCTAssertEqual(endDuring.offset, 5)
+
+        view.unmarkText()
+
+        let endAfter = view.endOfDocument as! GhosttyVirtualTextPosition
+        XCTAssertEqual(endAfter.offset, 0)
+    }
 }


### PR DESCRIPTION
## Summary

- Implement `UITextInput` marked text (composing) support so CJK input methods
  (Pinyin, Wubi, etc.) can establish a composing region, display candidates,
  and commit selected characters to the terminal.
- Previously all marked-text methods were stubbed as no-ops, which caused the
  system IME to silently discard composing state — no candidate bar appeared
  and no CJK text could be entered via the software keyboard.

## What changed

**`GhosttyTerminalResponderView.swift`**
- Added `storedMarkedText` and `storedMarkedSelectedRange` properties to track
  the active composing state across the `UITextInput` extension in the shim.
- `insertText` now clears any active composing state before forwarding the
  committed text to the terminal.
- `deleteBackward` clears composing state (instead of sending a backspace key
  event) when an IME composing region is active.

**`GhosttyTerminalResponderTextInputShim.swift`**
- `setMarkedText` stores the composing string and notifies `inputDelegate`,
  enabling the system candidate bar.
- `unmarkText` commits the stored composing text to the terminal via
  `submitTextInput`, then clears the composing state. This covers the
  `setMarkedText → unmarkText` commit path used by the system Pinyin keyboard.
- `markedTextRange` returns the active composing region (previously always `nil`).
- `text(in:)` returns the composing string content for the marked range.
- `selectedTextRange` and `endOfDocument` reflect the dynamic virtual document
  length while composing.
- `replace(_:withText:)` clears composing state before forwarding replacement
  text.
- `firstRect(for:)` and `caretRect(for:)` return a small rect at the bottom of
  the view so the system can anchor the candidate window on screen (previously
  returned `.zero`).

**`GhosttyTerminalResponderViewTests.swift`**
- Added 8 unit tests covering all marked text paths: set/clear composing,
  unmark-commits-to-terminal, insert-clears-composing, delete-during-composing,
  replace-during-composing, nil-marked-range baseline, and dynamic document
  length.

## Test plan

- [x] All 48 unit tests pass (40 existing + 8 new), zero regressions
- [x] Verified on device (iPhone 12 Pro, iOS 18) with system Pinyin keyboard:
  candidate bar appears, selecting a candidate commits the character to the
  terminal
- [x] English keyboard input continues to work unchanged
- [x] Spacebar long-press floating cursor gesture continues to work unchanged