### PR TITLE
Make terminal trackpad navigation easier to control

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardCursorTrackpad.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardCursorTrackpad.swift
@@ -2,32 +2,29 @@ import CoreGraphics
 import Foundation
 import QuartzCore
 
-/// Translates the iOS spacebar long-press / floating-cursor drag into
-/// terminal arrow-key emissions. The further the user has pushed past the
-/// initial axis lock, the denser the emissions become — distance-based
-/// cursor acceleration along the locked axis, modeled as a continuous ramp
-/// rather than discrete slow/fast modes, so the gesture reads as continuous
-/// analog cursor steering instead of a stepped gear shifter.
-struct GhosttyKeyboardCursorTrackpad: Equatable {
-    struct Configuration: Equatable {
-        var horizontalStep: CGFloat
-        var verticalStep: CGFloat
-        var lockDeadband: CGFloat
-        var lateSwitchRatio: CGFloat
-        var rampStartDisplacement: CGFloat
-        var rampEndDisplacement: CGFloat
-        var maxAccelMultiplier: CGFloat
-        var maxStepsPerUpdate: Int
+/// Maps radial travel from a fixed long-press origin to one cardinal direction
+/// and three repeat-rate tiers. Each committed tier has a stable plateau before
+/// travel begins arming the next tier.
+struct GhosttyKeyboardCursorTrackpad {
+    struct Configuration {
+        var neutralRadius: CGFloat
+        var armingDistance: CGFloat
+        var tierPlateauDistance: CGFloat
+        var oneXRepeatInterval: TimeInterval
+        var twoXRepeatInterval: TimeInterval
+        var threeXRepeatInterval: TimeInterval
+        var directionSwitchRatio: CGFloat
+        var tierReleaseHysteresis: CGFloat
 
         static let `default` = Configuration(
-            horizontalStep: 10,
-            verticalStep: 18,
-            lockDeadband: 12,
-            lateSwitchRatio: 3,
-            rampStartDisplacement: 30,
-            rampEndDisplacement: 100,
-            maxAccelMultiplier: 3,
-            maxStepsPerUpdate: 6
+            neutralRadius: 8,
+            armingDistance: 28,
+            tierPlateauDistance: 14,
+            oneXRepeatInterval: 0.45,
+            twoXRepeatInterval: 0.225,
+            threeXRepeatInterval: 0.12,
+            directionSwitchRatio: 1.25,
+            tierReleaseHysteresis: 4
         )
     }
 
@@ -36,280 +33,298 @@ struct GhosttyKeyboardCursorTrackpad: Equatable {
         case right
         case up
         case down
+
+        var isHorizontal: Bool {
+            self == .left || self == .right
+        }
     }
 
-    enum Axis: Equatable {
-        case horizontal
-        case vertical
+    enum SpeedTier: Int, Equatable {
+        case neutral = 0
+        case one = 1
+        case two = 2
+        case three = 3
     }
 
-    struct Step: Equatable {
-        let direction: Direction
-        let intensity: CGFloat
-    }
-
-    struct HUDState: Equatable {
-        var activeDirection: Direction?
-        var intensity: CGFloat
+    struct FeedbackState: Equatable {
         var isVisible: Bool
+        var direction: Direction?
+        var committedTier: SpeedTier
+        var armingTier: SpeedTier?
+        var armingProgress: CGFloat
 
-        static let hidden = HUDState(activeDirection: nil, intensity: 0, isVisible: false)
-    }
+        static let hidden = FeedbackState(
+            isVisible: false,
+            direction: nil,
+            committedTier: .neutral,
+            armingTier: nil,
+            armingProgress: 0
+        )
 
-    struct UpdateOutcome: Equatable {
-        var steps: [Step]
-        var hud: HUDState
-        var didLockAxis: Bool
+        static let active = FeedbackState(
+            isVisible: true,
+            direction: nil,
+            committedTier: .neutral,
+            armingTier: nil,
+            armingProgress: 0
+        )
     }
 
     let configuration: Configuration
 
-    private var previousPoint: CGPoint?
-    private var lockedAxis: Axis?
-    private var preLockAccX: CGFloat = 0
-    private var preLockAccY: CGFloat = 0
-    private var stepAcc: CGFloat = 0
-    private var rawSinceLockLocked: CGFloat = 0
-    private var rawSinceLockOrtho: CGFloat = 0
-    private var axisDisplacement: CGFloat = 0
+    private var origin: CGPoint?
+    private var direction: Direction?
+    private var committedTier: SpeedTier = .neutral
 
     init(configuration: Configuration = .default) {
-        precondition(configuration.horizontalStep > 0, "horizontalStep must be positive")
-        precondition(configuration.verticalStep > 0, "verticalStep must be positive")
-        precondition(configuration.lockDeadband > 0, "lockDeadband must be positive")
-        precondition(configuration.lateSwitchRatio > 0, "lateSwitchRatio must be positive")
-        precondition(configuration.maxAccelMultiplier >= 1, "maxAccelMultiplier must be >= 1 (1x = no acceleration)")
-        precondition(configuration.maxStepsPerUpdate > 0, "maxStepsPerUpdate must be positive")
+        precondition(configuration.neutralRadius >= 0, "neutralRadius must be non-negative")
+        precondition(configuration.armingDistance > 0, "armingDistance must be positive")
+        precondition(configuration.tierPlateauDistance >= 0, "tierPlateauDistance must be non-negative")
+        precondition(configuration.oneXRepeatInterval > 0, "oneXRepeatInterval must be positive")
+        precondition(configuration.twoXRepeatInterval > 0, "twoXRepeatInterval must be positive")
+        precondition(configuration.threeXRepeatInterval > 0, "threeXRepeatInterval must be positive")
+        precondition(configuration.directionSwitchRatio >= 1, "directionSwitchRatio must be at least 1")
+        precondition(configuration.tierReleaseHysteresis >= 0, "tierReleaseHysteresis must be non-negative")
         precondition(
-            configuration.rampStartDisplacement >= 0,
-            "rampStartDisplacement must be non-negative"
-        )
-        precondition(
-            configuration.rampEndDisplacement > configuration.rampStartDisplacement,
-            "rampEndDisplacement must exceed rampStartDisplacement so the intensity ramp has positive width"
+            configuration.tierReleaseHysteresis < configuration.armingDistance,
+            "tierReleaseHysteresis must be shorter than armingDistance"
         )
         self.configuration = configuration
     }
 
-    mutating func begin(at point: CGPoint) -> HUDState {
-        previousPoint = point
-        lockedAxis = nil
-        preLockAccX = 0
-        preLockAccY = 0
-        stepAcc = 0
-        rawSinceLockLocked = 0
-        rawSinceLockOrtho = 0
-        axisDisplacement = 0
-        return HUDState(activeDirection: nil, intensity: 0, isVisible: true)
+    mutating func begin(at point: CGPoint) -> FeedbackState {
+        origin = point
+        direction = nil
+        committedTier = .neutral
+        return .active
     }
 
-    mutating func end() -> HUDState {
-        previousPoint = nil
-        lockedAxis = nil
-        preLockAccX = 0
-        preLockAccY = 0
-        stepAcc = 0
-        rawSinceLockLocked = 0
-        rawSinceLockOrtho = 0
-        axisDisplacement = 0
-        return .hidden
-    }
-
-    mutating func update(at point: CGPoint) -> UpdateOutcome {
-        guard let previous = previousPoint else {
-            previousPoint = point
-            return UpdateOutcome(
-                steps: [],
-                hud: HUDState(activeDirection: nil, intensity: 0, isVisible: true),
-                didLockAxis: false
-            )
+    mutating func update(at point: CGPoint) -> FeedbackState {
+        guard let origin else {
+            return begin(at: point)
         }
 
-        let dx = point.x - previous.x
-        let dy = point.y - previous.y
-        previousPoint = point
-
-        if lockedAxis == nil {
-            preLockAccX += dx
-            preLockAccY += dy
-            guard max(abs(preLockAccX), abs(preLockAccY)) > configuration.lockDeadband else {
-                return UpdateOutcome(
-                    steps: [],
-                    hud: HUDState(activeDirection: nil, intensity: 0, isVisible: true),
-                    didLockAxis: false
-                )
-            }
-
-            lockedAxis = abs(preLockAccX) >= abs(preLockAccY) ? .horizontal : .vertical
-            stepAcc = 0
-            rawSinceLockLocked = 0
-            rawSinceLockOrtho = 0
-            axisDisplacement = 0
-            preLockAccX = 0
-            preLockAccY = 0
-            return UpdateOutcome(
-                steps: [],
-                hud: HUDState(activeDirection: nil, intensity: 0, isVisible: true),
-                didLockAxis: true
-            )
+        let displacement = CGPoint(
+            x: point.x - origin.x,
+            y: point.y - origin.y
+        )
+        let radius = sqrt(
+            displacement.x * displacement.x
+                + displacement.y * displacement.y
+        )
+        guard radius > 0, radius >= configuration.neutralRadius else {
+            direction = nil
+            committedTier = .neutral
+            return .active
         }
 
-        var axis = lockedAxis ?? .horizontal
-        var lockedDelta = (axis == .horizontal) ? dx : dy
-        var orthDelta = (axis == .horizontal) ? dy : dx
-        rawSinceLockLocked += lockedDelta
-        rawSinceLockOrtho += orthDelta
+        direction = resolveDirection(for: displacement)
+        guard let direction else { return .active }
 
-        var didLockAxis = false
-        // Require *both* a meaningful absolute orthogonal commitment (at least
-        // the lock deadband, same threshold the user crossed to lock the axis
-        // in the first place) AND the ratio dominance check. Without the
-        // absolute floor a 1pt orthogonal wobble immediately after lock satisfies
-        // the ratio against an effectively-zero locked travel and flips axes
-        // on a single pixel of jitter.
-        let orthogonalCommitted = abs(rawSinceLockOrtho) >= configuration.lockDeadband
-        let orthogonalDominant = abs(rawSinceLockOrtho) > configuration.lateSwitchRatio * abs(rawSinceLockLocked)
-        if orthogonalCommitted && orthogonalDominant {
-            axis = (axis == .horizontal) ? .vertical : .horizontal
-            lockedAxis = axis
-            stepAcc = 0
-            axisDisplacement = 0
-            rawSinceLockLocked = orthDelta
-            rawSinceLockOrtho = lockedDelta
-            lockedDelta = (axis == .horizontal) ? dx : dy
-            orthDelta = (axis == .horizontal) ? dy : dx
-            didLockAxis = true
-        }
+        let speed = speedState(at: radius)
 
-        axisDisplacement += lockedDelta
-        stepAcc += lockedDelta
-
-        let intensity = computeIntensity(displacement: axisDisplacement)
-        let multiplier = 1.0 + intensity * (configuration.maxAccelMultiplier - 1.0)
-        let baseStep = (axis == .horizontal) ? configuration.horizontalStep : configuration.verticalStep
-        let effectiveStep = baseStep / multiplier
-        let heldDirection = abs(axisDisplacement) >= baseStep
-            ? directionFor(axis: axis, signedAccumulator: axisDisplacement)
-            : nil
-
-        var steps: [Step] = []
-        let count = Int(abs(stepAcc) / effectiveStep)
-        if count > 0 {
-            let direction: Direction = directionFor(axis: axis, signedAccumulator: stepAcc)
-            let bounded = min(count, configuration.maxStepsPerUpdate)
-            for _ in 0..<bounded {
-                steps.append(Step(direction: direction, intensity: intensity))
-            }
-            // Consume only what we emitted. Any backlog from a coalesced UIKit
-            // update rolls into the next callback rather than being silently
-            // dropped; cursor density per pt of finger travel stays consistent
-            // regardless of how UIKit chunks the floating-cursor stream.
-            let consumed = CGFloat(bounded) * effectiveStep
-            stepAcc = stepAcc > 0 ? stepAcc - consumed : stepAcc + consumed
-        }
-
-        return UpdateOutcome(
-            steps: steps,
-            hud: HUDState(
-                activeDirection: heldDirection,
-                intensity: intensity,
-                isVisible: true
-            ),
-            didLockAxis: didLockAxis
+        return FeedbackState(
+            isVisible: true,
+            direction: direction,
+            committedTier: speed.committedTier,
+            armingTier: speed.armingTier,
+            armingProgress: speed.armingProgress
         )
     }
 
-    private func computeIntensity(displacement: CGFloat) -> CGFloat {
-        let span = configuration.rampEndDisplacement - configuration.rampStartDisplacement
-        let raw = (abs(displacement) - configuration.rampStartDisplacement) / span
-        return max(0, min(1, raw))
+    func repeatInterval(for tier: SpeedTier) -> TimeInterval? {
+        switch tier {
+        case .neutral: nil
+        case .one: configuration.oneXRepeatInterval
+        case .two: configuration.twoXRepeatInterval
+        case .three: configuration.threeXRepeatInterval
+        }
     }
 
-    private func directionFor(axis: Axis, signedAccumulator: CGFloat) -> Direction {
-        switch axis {
-        case .horizontal:
-            return signedAccumulator >= 0 ? .right : .left
-        case .vertical:
-            return signedAccumulator >= 0 ? .down : .up
+    private mutating func speedState(
+        at radius: CGFloat
+    ) -> (committedTier: SpeedTier, armingTier: SpeedTier?, armingProgress: CGFloat) {
+        let rawState = rawSpeedState(at: radius)
+
+        if rawState.committedTier.rawValue > committedTier.rawValue {
+            committedTier = rawState.committedTier
+            return rawState
         }
+
+        if rawState.committedTier.rawValue < committedTier.rawValue {
+            let releaseRadius = activationRadius(for: committedTier)
+                - configuration.tierReleaseHysteresis
+            guard radius < releaseRadius else {
+                return (committedTier, nil, 0)
+            }
+            committedTier = rawState.committedTier
+        }
+
+        return rawState
+    }
+
+    private func rawSpeedState(
+        at radius: CGFloat
+    ) -> (committedTier: SpeedTier, armingTier: SpeedTier?, armingProgress: CGFloat) {
+        var remaining = radius - configuration.neutralRadius
+        guard remaining >= 0 else { return (.neutral, nil, 0) }
+
+        if remaining < configuration.armingDistance {
+            return (.neutral, .one, remaining / configuration.armingDistance)
+        }
+        remaining -= configuration.armingDistance
+
+        if remaining < configuration.tierPlateauDistance {
+            return (.one, nil, 0)
+        }
+        remaining -= configuration.tierPlateauDistance
+
+        if remaining < configuration.armingDistance {
+            return (.one, .two, remaining / configuration.armingDistance)
+        }
+        remaining -= configuration.armingDistance
+
+        if remaining < configuration.tierPlateauDistance {
+            return (.two, nil, 0)
+        }
+        remaining -= configuration.tierPlateauDistance
+
+        if remaining < configuration.armingDistance {
+            return (.two, .three, remaining / configuration.armingDistance)
+        }
+        return (.three, nil, 0)
+    }
+
+    private func activationRadius(for tier: SpeedTier) -> CGFloat {
+        guard tier != .neutral else { return configuration.neutralRadius }
+        return configuration.neutralRadius
+            + CGFloat(tier.rawValue) * configuration.armingDistance
+            + CGFloat(tier.rawValue - 1) * configuration.tierPlateauDistance
+    }
+
+    private mutating func resolveDirection(for displacement: CGPoint) -> Direction {
+        let proposed: Direction
+        if abs(displacement.x) >= abs(displacement.y) {
+            proposed = displacement.x >= 0 ? .right : .left
+        } else {
+            proposed = displacement.y >= 0 ? .down : .up
+        }
+
+        guard let direction else { return proposed }
+        guard direction.isHorizontal != proposed.isHorizontal else { return proposed }
+
+        let currentAxisDistance = direction.isHorizontal
+            ? abs(displacement.x)
+            : abs(displacement.y)
+        let proposedAxisDistance = proposed.isHorizontal
+            ? abs(displacement.x)
+            : abs(displacement.y)
+        guard proposedAxisDistance >= currentAxisDistance * configuration.directionSwitchRatio else {
+            if direction.isHorizontal {
+                return displacement.x >= 0 ? .right : .left
+            }
+            return displacement.y >= 0 ? .down : .up
+        }
+        return proposed
     }
 }
 
-/// Owns the one clock used by held cursor-steering gestures. Movement remains
-/// synchronous: the trackpad's immediate steps are sent from `update`. The
-/// repeating timer exists only while a direction is held, and adds one repeated
-/// arrow at a time after the initial delay.
+/// Owns one anchored cursor-steering gesture and its single repeat scheduler.
 @MainActor
 final class GhosttyKeyboardCursorTrackpadDriver {
-    static let initialRepeatDelay: TimeInterval = 0.30
-    static let slowRepeatInterval: TimeInterval = 0.18
-    static let mediumRepeatInterval: TimeInterval = 0.10
-    static let fastRepeatInterval: TimeInterval = 0.06
+    enum HapticCue: Equatable {
+        case tierChanged
+        case neutralEntered
+    }
 
     private struct RepeatState {
         var direction: GhosttyKeyboardCursorTrackpad.Direction
-        var interval: TimeInterval
+        var tier: GhosttyKeyboardCursorTrackpad.SpeedTier
         var nextFireAt: TimeInterval
     }
 
+    private let configuration: GhosttyKeyboardCursorTrackpad.Configuration
+    private let playHaptic: (HapticCue) -> Void
     private weak var owner: AnyObject?
     private var trackpad: GhosttyKeyboardCursorTrackpad?
     private var sendKeyEvent: ((GhosttySurfaceKeyEvent) -> Bool)?
-    private var publishHUD: ((GhosttyKeyboardCursorTrackpad.HUDState) -> Void)?
+    private var publishFeedback: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var repeatState: RepeatState?
     private var repeatTimer: Timer?
     private var didSteer = false
 
-    var isRepeatScheduled: Bool { repeatTimer != nil }
+    init(
+        configuration: GhosttyKeyboardCursorTrackpad.Configuration = .default,
+        playHaptic: @escaping (HapticCue) -> Void = { cue in
+            switch cue {
+            case .tierChanged:
+                Haptic.selection()
+            case .neutralEntered:
+                Haptic.tap(.soft)
+            }
+        }
+    ) {
+        self.configuration = configuration
+        self.playHaptic = playHaptic
+    }
 
     func begin(
         owner: AnyObject,
         at point: CGPoint,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
-        onHUDStateChange: @escaping (GhosttyKeyboardCursorTrackpad.HUDState) -> Void
+        onFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     ) {
         cancelCurrentGesture()
 
-        var trackpad = GhosttyKeyboardCursorTrackpad()
-        let hud = trackpad.begin(at: point)
+        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
+        let feedback = trackpad.begin(at: point)
         self.owner = owner
         self.trackpad = trackpad
         self.sendKeyEvent = sendKeyEvent
-        publishHUD = onHUDStateChange
+        publishFeedback = onFeedbackChange
         didSteer = false
-        onHUDStateChange(hud)
+        onFeedbackChange(feedback)
         Haptic.tap(.soft)
     }
 
+    @discardableResult
     func update(
         owner: AnyObject,
         at point: CGPoint,
         now: TimeInterval = CACurrentMediaTime()
-    ) -> GhosttyKeyboardCursorTrackpad.UpdateOutcome? {
+    ) -> GhosttyKeyboardCursorTrackpad.FeedbackState? {
         guard self.owner === owner, var trackpad else { return nil }
 
-        let outcome = trackpad.update(at: point)
+        let feedback = trackpad.update(at: point)
         self.trackpad = trackpad
+        guard apply(feedback: feedback, now: now) else { return feedback }
+        publishFeedback?(feedback)
+        return feedback
+    }
 
-        for step in outcome.steps {
-            didSteer = true
-            guard send(direction: step.direction) else {
-                rejectCurrentGesture()
-                return outcome
-            }
+    /// Deterministic time injection for repeat behavior tests. Delayed ticks
+    /// emit at most one key and never catch up a backlog.
+    func repeatTick(at now: TimeInterval) {
+        guard let state = repeatState, now >= state.nextFireAt else { return }
+        repeatTimer?.invalidate()
+        repeatTimer = nil
+
+        guard emit(direction: state.direction) else {
+            cancelCurrentGesture()
+            return
         }
 
-        if outcome.didLockAxis {
-            Haptic.selection()
+        guard let interval = trackpad?.repeatInterval(for: state.tier) else {
+            stopRepeating()
+            return
         }
-        publishHUD?(outcome.hud)
-        updateRepeat(for: outcome.hud, now: now)
-        return outcome
+        repeatState?.nextFireAt = now + interval
+        scheduleRepeat(after: interval)
     }
 
     /// Returns whether this gesture sent or attempted any steering key. A
-    /// non-owner gets `nil`, allowing another gesture entry point to decide
-    /// whether a stationary release should begin text selection.
+    /// non-owner gets `nil`, allowing a stationary terminal long press to
+    /// continue into text selection.
     @discardableResult
     func end(owner: AnyObject) -> Bool? {
         guard self.owner === owner else { return nil }
@@ -325,96 +340,84 @@ final class GhosttyKeyboardCursorTrackpadDriver {
         return true
     }
 
-    /// Internal time injection keeps repeat timing deterministic in tests.
-    func repeatTick(at now: TimeInterval) {
-        guard let nextFireAt = repeatState?.nextFireAt, now >= nextFireAt else { return }
-        emitRepeat(at: now)
-    }
-
-    private func emitRepeat(at now: TimeInterval) {
-        guard owner != nil else {
-            cancelCurrentGesture()
-            return
-        }
-        guard var state = repeatState else { return }
-
-        didSteer = true
-        guard send(direction: state.direction) else {
-            rejectCurrentGesture()
-            return
-        }
-
-        // Never catch up after a delayed frame. One tick sends at most one key
-        // and the next deadline is measured from the actual send time.
-        state.nextFireAt = now + state.interval
-        repeatState = state
-    }
-
-    private func updateRepeat(
-        for hud: GhosttyKeyboardCursorTrackpad.HUDState,
+    private func apply(
+        feedback: GhosttyKeyboardCursorTrackpad.FeedbackState,
         now: TimeInterval
-    ) {
-        guard let direction = hud.activeDirection else {
+    ) -> Bool {
+        guard let direction = feedback.direction,
+              feedback.committedTier != .neutral,
+              let interval = trackpad?.repeatInterval(for: feedback.committedTier)
+        else {
+            let enteredNeutral = repeatState != nil
             stopRepeating()
-            return
+            if enteredNeutral {
+                playHaptic(.neutralEntered)
+            }
+            return true
         }
 
-        let interval = repeatInterval(for: hud.intensity)
-        if var state = repeatState, state.direction == direction {
-            if state.interval != interval {
-                state.interval = interval
-                state.nextFireAt = now + interval
-                repeatState = state
-                scheduleRepeat(every: interval, firstFireAfter: interval)
+        guard let current = repeatState else {
+            guard emit(direction: direction) else {
+                cancelCurrentGesture()
+                return false
             }
-        } else {
+            playHaptic(.tierChanged)
             repeatState = RepeatState(
                 direction: direction,
-                interval: interval,
-                nextFireAt: now + Self.initialRepeatDelay
+                tier: feedback.committedTier,
+                nextFireAt: now + interval
             )
-            scheduleRepeat(every: interval, firstFireAfter: Self.initialRepeatDelay)
+            scheduleRepeat(after: interval)
+            return true
         }
-    }
 
-    private func send(direction: GhosttyKeyboardCursorTrackpad.Direction) -> Bool {
-        sendKeyEvent?(GhosttySurfaceKeyEvent(keyCode: direction.keyCode)) == true
-    }
-
-    private func rejectCurrentGesture() {
-        trackpad = nil
-        stopRepeating()
-        publishHUD?(.hidden)
-    }
-
-    private func cancelCurrentGesture() {
-        trackpad = nil
-        stopRepeating()
-        if owner != nil {
-            publishHUD?(.hidden)
+        guard current.direction == direction else {
+            stopRepeating()
+            guard emit(direction: direction) else {
+                cancelCurrentGesture()
+                return false
+            }
+            playHaptic(.tierChanged)
+            repeatState = RepeatState(
+                direction: direction,
+                tier: feedback.committedTier,
+                nextFireAt: now + interval
+            )
+            scheduleRepeat(after: interval)
+            return true
         }
-        owner = nil
-        sendKeyEvent = nil
-        publishHUD = nil
-        didSteer = false
+
+        guard current.tier != feedback.committedTier else { return true }
+        if feedback.committedTier.rawValue > current.tier.rawValue {
+            guard emit(direction: direction) else {
+                cancelCurrentGesture()
+                return false
+            }
+        }
+        playHaptic(.tierChanged)
+        repeatState = RepeatState(
+            direction: direction,
+            tier: feedback.committedTier,
+            nextFireAt: now + interval
+        )
+        scheduleRepeat(after: interval)
+        return true
     }
 
-    private func repeatInterval(for intensity: CGFloat) -> TimeInterval {
-        if intensity >= 1 { return Self.fastRepeatInterval }
-        if intensity > 0 { return Self.mediumRepeatInterval }
-        return Self.slowRepeatInterval
+    private func emit(direction: GhosttyKeyboardCursorTrackpad.Direction) -> Bool {
+        didSteer = true
+        return sendKeyEvent?(GhosttySurfaceKeyEvent(keyCode: direction.keyCode)) == true
     }
 
-    private func scheduleRepeat(every interval: TimeInterval, firstFireAfter delay: TimeInterval) {
+    private func scheduleRepeat(after delay: TimeInterval) {
         repeatTimer?.invalidate()
         let timer = Timer(
-            timeInterval: interval,
+            timeInterval: max(delay, 0.001),
             target: self,
             selector: #selector(repeatTimerFired),
             userInfo: nil,
-            repeats: true
+            repeats: false
         )
-        timer.fireDate = Date(timeIntervalSinceNow: delay)
         RunLoop.main.add(timer, forMode: .common)
         repeatTimer = timer
     }
@@ -425,11 +428,21 @@ final class GhosttyKeyboardCursorTrackpadDriver {
         repeatTimer = nil
     }
 
-    @objc private func repeatTimerFired() {
-        emitRepeat(at: CACurrentMediaTime())
-        if let interval = repeatState?.interval {
-            repeatTimer?.fireDate = Date(timeIntervalSinceNow: interval)
+    private func cancelCurrentGesture() {
+        let hadOwner = owner != nil
+        trackpad = nil
+        stopRepeating()
+        if hadOwner {
+            publishFeedback?(.hidden)
         }
+        owner = nil
+        sendKeyEvent = nil
+        publishFeedback = nil
+        didSteer = false
+    }
+
+    @objc private func repeatTimerFired() {
+        repeatTick(at: CACurrentMediaTime())
     }
 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardCursorTrackpadHUD.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardCursorTrackpadHUD.swift
@@ -1,29 +1,32 @@
 import SwiftUI
 
-/// Floating compass overlay shown while the spacebar long-press cursor
-/// trackpad gesture is active. The active arrow saturates from a soft accent
-/// to a vivid one as the user pushes further from the lock point — matching
-/// the analog acceleration model so users see directly how committed their
-/// finger is. A perimeter ring fills with the same intensity as a secondary
-/// signal.
+/// Displays either the stable committed rate or the complete shape currently
+/// being armed. The repeat scheduler remains driven only by `committedTier`.
 struct GhosttyKeyboardCursorTrackpadHUD: View {
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
 
-    let state: GhosttyKeyboardCursorTrackpad.HUDState
+    let state: GhosttyKeyboardCursorTrackpad.FeedbackState
 
     private let cornerRadius: CGFloat = 14
     private let dimensions: CGFloat = 64
+    private let maximumArmingFill: CGFloat = 0.82
 
     var body: some View {
         ZStack {
-            arrow(for: .up)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            arrow(for: .down)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
-            arrow(for: .left)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-            arrow(for: .right)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+            ForEach(DirectionPlacement.allCases, id: \.self) { placement in
+                Group {
+                    if state.direction == placement.direction {
+                        tierIndicator(for: placement.direction)
+                    } else {
+                        baseArrow(for: placement.direction)
+                    }
+                }
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity,
+                    alignment: placement.alignment
+                )
+            }
         }
         .padding(8)
         .frame(width: dimensions, height: dimensions)
@@ -33,50 +36,174 @@ struct GhosttyKeyboardCursorTrackpadHUD: View {
             RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                 .stroke(Color.white.opacity(0.10), lineWidth: 1)
         )
-        .overlay(
-            intensityRing
-        )
         .shadow(color: Color.black.opacity(0.28), radius: 6, y: 2)
         .opacity(state.isVisible ? 1 : 0)
         .scaleEffect(state.isVisible ? 1 : 0.94)
         .animation(.spring(response: 0.22, dampingFraction: 0.78), value: state.isVisible)
-        .animation(.easeOut(duration: 0.10), value: state.activeDirection)
-        .animation(.easeOut(duration: 0.08), value: state.intensity)
         .accessibilityHidden(true)
         .allowsHitTesting(false)
     }
 
-    private var intensityRing: some View {
-        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .trim(from: 0, to: max(0.001, state.intensity))
-            .stroke(
-                chromeStyle.accent.opacity(0.45 + 0.55 * state.intensity),
-                style: StrokeStyle(lineWidth: 2, lineCap: .round)
-            )
-            .opacity(state.intensity > 0 ? 1 : 0)
+    private func baseArrow(for direction: GhosttyKeyboardCursorTrackpad.Direction) -> some View {
+        Image(systemName: arrowSymbol(for: direction))
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(Color.white.opacity(0.42))
     }
 
     @ViewBuilder
-    private func arrow(for direction: GhosttyKeyboardCursorTrackpad.Direction) -> some View {
-        let active = state.activeDirection == direction
-        Image(systemName: symbolName(for: direction))
-            .font(.system(size: active ? 13 + 2 * state.intensity : 11, weight: .bold))
-            .foregroundStyle(arrowColor(active: active))
-            .scaleEffect(active ? 1 + 0.08 * state.intensity : 1)
+    private func tierIndicator(
+        for direction: GhosttyKeyboardCursorTrackpad.Direction
+    ) -> some View {
+        let displayedTier = state.armingTier ?? state.committedTier
+        let progress: CGFloat = state.armingTier == nil
+            ? 1
+            : state.armingProgress * maximumArmingFill
+
+        switch displayedTier {
+        case .neutral:
+            baseArrow(for: direction)
+        case .one:
+            progressivelyFilledSymbol(
+                arrowSymbol(for: direction),
+                direction: direction,
+                progress: progress,
+                size: 13
+            )
+        case .two, .three:
+            chevronGroup(
+                direction: direction,
+                count: displayedTier.rawValue,
+                progress: progress
+            )
+        }
     }
 
-    private func arrowColor(active: Bool) -> Color {
-        guard active else { return Color.white.opacity(0.45) }
-        let baseAlpha: CGFloat = 0.55
-        return chromeStyle.accent.opacity(baseAlpha + (1 - baseAlpha) * state.intensity)
+    @ViewBuilder
+    private func chevronGroup(
+        direction: GhosttyKeyboardCursorTrackpad.Direction,
+        count: Int,
+        progress: CGFloat
+    ) -> some View {
+        if direction.isHorizontal {
+            HStack(spacing: -2) {
+                chevrons(direction: direction, count: count, progress: progress)
+            }
+        } else {
+            VStack(spacing: -2) {
+                chevrons(direction: direction, count: count, progress: progress)
+            }
+        }
     }
 
-    private func symbolName(for direction: GhosttyKeyboardCursorTrackpad.Direction) -> String {
+    @ViewBuilder
+    private func chevrons(
+        direction: GhosttyKeyboardCursorTrackpad.Direction,
+        count: Int,
+        progress: CGFloat
+    ) -> some View {
+        ForEach(0..<count, id: \.self) { index in
+            let fillIndex = fillsFromTrailingEdge(direction)
+                ? count - index - 1
+                : index
+            progressivelyFilledSymbol(
+                chevronSymbol(for: direction),
+                direction: direction,
+                progress: max(0, min(1, progress * CGFloat(count) - CGFloat(fillIndex))),
+                size: 12
+            )
+        }
+    }
+
+    private func fillsFromTrailingEdge(
+        _ direction: GhosttyKeyboardCursorTrackpad.Direction
+    ) -> Bool {
+        direction == .left || direction == .up
+    }
+
+    private func progressivelyFilledSymbol(
+        _ symbol: String,
+        direction: GhosttyKeyboardCursorTrackpad.Direction,
+        progress: CGFloat,
+        size: CGFloat
+    ) -> some View {
+        ZStack {
+            Image(systemName: symbol)
+                .foregroundStyle(Color.white.opacity(0.42))
+            Image(systemName: symbol)
+                .foregroundStyle(chromeStyle.accent)
+                .mask {
+                    GeometryReader { proxy in
+                        Rectangle()
+                            .frame(
+                                width: direction.isHorizontal
+                                    ? proxy.size.width * progress
+                                    : proxy.size.width,
+                                height: direction.isHorizontal
+                                    ? proxy.size.height
+                                    : proxy.size.height * progress
+                            )
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity,
+                                alignment: fillAlignment(for: direction)
+                            )
+                    }
+                }
+        }
+        .font(.system(size: size, weight: .bold))
+    }
+
+    private func fillAlignment(
+        for direction: GhosttyKeyboardCursorTrackpad.Direction
+    ) -> Alignment {
         switch direction {
-        case .up: return "arrow.up"
-        case .down: return "arrow.down"
-        case .left: return "arrow.left"
-        case .right: return "arrow.right"
+        case .right: .leading
+        case .left: .trailing
+        case .down: .top
+        case .up: .bottom
+        }
+    }
+
+    private func arrowSymbol(for direction: GhosttyKeyboardCursorTrackpad.Direction) -> String {
+        switch direction {
+        case .up: "arrow.up"
+        case .down: "arrow.down"
+        case .left: "arrow.left"
+        case .right: "arrow.right"
+        }
+    }
+
+    private func chevronSymbol(for direction: GhosttyKeyboardCursorTrackpad.Direction) -> String {
+        switch direction {
+        case .up: "chevron.up"
+        case .down: "chevron.down"
+        case .left: "chevron.left"
+        case .right: "chevron.right"
+        }
+    }
+
+    private enum DirectionPlacement: CaseIterable, Hashable {
+        case up
+        case down
+        case left
+        case right
+
+        var direction: GhosttyKeyboardCursorTrackpad.Direction {
+            switch self {
+            case .up: .up
+            case .down: .down
+            case .left: .left
+            case .right: .right
+            }
+        }
+
+        var alignment: Alignment {
+            switch self {
+            case .up: .top
+            case .down: .bottom
+            case .left: .leading
+            case .right: .trailing
+            }
         }
     }
 }

--- a/RemuxApp/Sources/Ghostty/GhosttySingleViewportView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySingleViewportView.swift
@@ -13,7 +13,7 @@ struct GhosttySingleViewportView: View {
     let onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)?
     let onWindowSwipe: ((GhosttyRuntimeSelectionDirection) -> Void)?
     let sendKeyEvent: (GhosttySurfaceKeyEvent) -> Bool
-    let onTrackpadStateChange: (GhosttyKeyboardCursorTrackpad.HUDState) -> Void
+    let onTrackpadFeedbackChange: (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     let isMouseCaptured: (UUID) -> Bool
     let submitMouseButton: ((UUID, GhosttySurfaceMouseButtonEvent) -> GhosttyMouseInputSubmissionOutcome)?
     let submitMousePosition: ((UUID, CGPoint, GhosttySurfaceKeyEvent.Mods) -> GhosttyMouseInputSubmissionOutcome)?
@@ -29,7 +29,7 @@ struct GhosttySingleViewportView: View {
             onPreviewSelection: onPreviewSelection,
             onWindowSwipe: onWindowSwipe,
             sendKeyEvent: sendKeyEvent,
-            onTrackpadStateChange: onTrackpadStateChange,
+            onTrackpadFeedbackChange: onTrackpadFeedbackChange,
             isMouseCaptured: isMouseCaptured,
             submitMouseButton: submitMouseButton,
             submitMousePosition: submitMousePosition,
@@ -48,7 +48,7 @@ private struct GhosttySingleViewportRepresentable: UIViewRepresentable {
     let onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)?
     let onWindowSwipe: ((GhosttyRuntimeSelectionDirection) -> Void)?
     let sendKeyEvent: (GhosttySurfaceKeyEvent) -> Bool
-    let onTrackpadStateChange: (GhosttyKeyboardCursorTrackpad.HUDState) -> Void
+    let onTrackpadFeedbackChange: (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     let isMouseCaptured: (UUID) -> Bool
     let submitMouseButton: ((UUID, GhosttySurfaceMouseButtonEvent) -> GhosttyMouseInputSubmissionOutcome)?
     let submitMousePosition: ((UUID, CGPoint, GhosttySurfaceKeyEvent.Mods) -> GhosttyMouseInputSubmissionOutcome)?
@@ -72,7 +72,7 @@ private struct GhosttySingleViewportRepresentable: UIViewRepresentable {
             onPreviewSelection: onPreviewSelection,
             onWindowSwipe: onWindowSwipe,
             sendKeyEvent: sendKeyEvent,
-            onTrackpadStateChange: onTrackpadStateChange,
+            onTrackpadFeedbackChange: onTrackpadFeedbackChange,
             isMouseCaptured: isMouseCaptured,
             submitMouseButton: submitMouseButton,
             submitMousePosition: submitMousePosition,
@@ -102,7 +102,7 @@ private final class GhosttySingleViewportContainerView: UIView,
     private var onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)?
     private var onWindowSwipe: ((GhosttyRuntimeSelectionDirection) -> Void)?
     private var sendKeyEvent: ((GhosttySurfaceKeyEvent) -> Bool)?
-    private var onTrackpadStateChange: ((GhosttyKeyboardCursorTrackpad.HUDState) -> Void)?
+    private var onTrackpadFeedbackChange: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var isMouseCaptured: (UUID) -> Bool = { _ in false }
     private var submitMouseButton: ((UUID, GhosttySurfaceMouseButtonEvent) -> GhosttyMouseInputSubmissionOutcome)?
     private var submitMousePosition: ((UUID, CGPoint, GhosttySurfaceKeyEvent.Mods) -> GhosttyMouseInputSubmissionOutcome)?
@@ -207,7 +207,7 @@ private final class GhosttySingleViewportContainerView: UIView,
         onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)?,
         onWindowSwipe: ((GhosttyRuntimeSelectionDirection) -> Void)?,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
-        onTrackpadStateChange: @escaping (GhosttyKeyboardCursorTrackpad.HUDState) -> Void,
+        onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void,
         isMouseCaptured: @escaping (UUID) -> Bool,
         submitMouseButton: ((UUID, GhosttySurfaceMouseButtonEvent) -> GhosttyMouseInputSubmissionOutcome)?,
         submitMousePosition: ((UUID, CGPoint, GhosttySurfaceKeyEvent.Mods) -> GhosttyMouseInputSubmissionOutcome)?,
@@ -220,7 +220,7 @@ private final class GhosttySingleViewportContainerView: UIView,
         self.onPreviewSelection = onPreviewSelection
         self.onWindowSwipe = onWindowSwipe
         self.sendKeyEvent = sendKeyEvent
-        self.onTrackpadStateChange = onTrackpadStateChange
+        self.onTrackpadFeedbackChange = onTrackpadFeedbackChange
         self.isMouseCaptured = isMouseCaptured
         self.submitMouseButton = submitMouseButton
         self.submitMousePosition = submitMousePosition
@@ -265,7 +265,7 @@ private final class GhosttySingleViewportContainerView: UIView,
         onPreviewSelection = nil
         onWindowSwipe = nil
         sendKeyEvent = nil
-        onTrackpadStateChange = nil
+        onTrackpadFeedbackChange = nil
         isMouseCaptured = { _ in false }
         submitMouseButton = nil
         submitMousePosition = nil
@@ -429,8 +429,8 @@ private final class GhosttySingleViewportContainerView: UIView,
                 guard self?.exactLocalSelectionSurface() != nil else { return false }
                 return self?.sendKeyEvent?(event) == true
             },
-            onHUDStateChange: { [weak self] state in
-                self?.onTrackpadStateChange?(state)
+            onFeedbackChange: { [weak self] state in
+                self?.onTrackpadFeedbackChange?(state)
             }
         )
     }

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -70,7 +70,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     @State private var keyboardViewportTransitionCoordinator = GhosttyKeyboardViewportTransitionCoordinator()
     @State private var topologyActionInputRefocusCoordinator = GhosttyTopologyActionInputRefocusCoordinator()
     @State private var trackpadDriver = GhosttyKeyboardCursorTrackpadDriver()
-    @State private var trackpadHUDState = GhosttyKeyboardCursorTrackpad.HUDState.hidden
+    @State private var trackpadFeedback = GhosttyKeyboardCursorTrackpad.FeedbackState.hidden
     @State private var isShortcutPalettePresented = false
     @State private var isShortcutsSettingsPresented = false
     @State private var shortcutEditorRequest: ShortcutEditorRequest?
@@ -188,7 +188,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             onPreviewSelection: onPreviewSelection,
                             onWindowSwipe: handleWindowSwipe,
                             sendKeyEvent: sendTerminalKeyEvent,
-                            onTrackpadStateChange: { trackpadHUDState = $0 },
+                            onTrackpadFeedbackChange: { trackpadFeedback = $0 },
                             isMouseCaptured: { surfaceID in
                                 model.isMouseCaptured(for: surfaceID)
                             },
@@ -218,7 +218,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             sendText: sendTerminalText,
                             sendPaste: sendTerminalPaste,
                             sendKeyEvent: sendTerminalKeyEvent,
-                            onTrackpadStateChange: { trackpadHUDState = $0 },
+                            onTrackpadFeedbackChange: { trackpadFeedback = $0 },
                             onFirstResponderChange: { isTerminalResponderFirstResponder = $0 }
                         )
                         .frame(
@@ -256,7 +256,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                         )
                     }
                     .overlay(alignment: .topTrailing) {
-                        GhosttyKeyboardCursorTrackpadHUD(state: trackpadHUDState)
+                        GhosttyKeyboardCursorTrackpadHUD(state: trackpadFeedback)
                             .padding(.top, 12)
                             .padding(.trailing, 12)
                     }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -10,7 +10,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     let sendText: (String) -> Bool
     let sendPaste: (String) -> Bool
     let sendKeyEvent: (GhosttySurfaceKeyEvent) -> Bool
-    let onTrackpadStateChange: (GhosttyKeyboardCursorTrackpad.HUDState) -> Void
+    let onTrackpadFeedbackChange: (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     let onFirstResponderChange: (Bool) -> Void
 
     init(
@@ -22,7 +22,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
         sendText: @escaping (String) -> Bool,
         sendPaste: @escaping (String) -> Bool,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
-        onTrackpadStateChange: @escaping (GhosttyKeyboardCursorTrackpad.HUDState) -> Void,
+        onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void,
         onFirstResponderChange: @escaping (Bool) -> Void = { _ in }
     ) {
         self.isEnabled = isEnabled
@@ -33,7 +33,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
         self.sendText = sendText
         self.sendPaste = sendPaste
         self.sendKeyEvent = sendKeyEvent
-        self.onTrackpadStateChange = onTrackpadStateChange
+        self.onTrackpadFeedbackChange = onTrackpadFeedbackChange
         self.onFirstResponderChange = onFirstResponderChange
     }
 
@@ -53,7 +53,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
             sendText: { sendText(GhosttyTerminalInputNormalizer.normalize($0)) },
             sendPaste: sendPaste,
             sendKeyEvent: sendKeyEvent,
-            onTrackpadStateChange: onTrackpadStateChange,
+            onTrackpadFeedbackChange: onTrackpadFeedbackChange,
             onFirstResponderChange: onFirstResponderChange
         )
     }
@@ -61,8 +61,6 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     static func dismantleUIView(_ uiView: GhosttyTerminalResponderUIView, coordinator: ()) {
         // SwiftUI is dropping this representable while a trackpad gesture may
         // still be live (surface revision, screen transition, disconnect).
-        // Make sure the floating-cursor HUD state observer downstream goes
-        // hidden so it doesn't strand on a parent view.
         uiView.cancelTrackpadGestureIfActive(reason: "dismantle")
     }
 }
@@ -97,9 +95,9 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     private var sendTextHandler: ((String) -> Bool)?
     private var sendPasteHandler: ((String) -> Bool)?
     private var sendKeyEventHandler: ((GhosttySurfaceKeyEvent) -> Bool)?
+    private var trackpadFeedbackHandler: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var firstResponderStateHandler: ((Bool) -> Void)?
     private var lastReportedFirstResponderState: Bool?
-    var trackpadStateHandler: ((GhosttyKeyboardCursorTrackpad.HUDState) -> Void)?
     private let trackpadDriver: GhosttyKeyboardCursorTrackpadDriver
     lazy var floatingCursorTokenizer: UITextInputTokenizer =
         UITextInputStringTokenizer(textInput: self)
@@ -123,7 +121,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         sendText: @escaping (String) -> Bool,
         sendPaste: @escaping (String) -> Bool,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
-        onTrackpadStateChange: @escaping (GhosttyKeyboardCursorTrackpad.HUDState) -> Void,
+        onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void = { _ in },
         onFirstResponderChange: @escaping (Bool) -> Void = { _ in }
     ) {
         let wasInputEnabled = self.isInputEnabled
@@ -152,7 +150,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         self.sendTextHandler = sendText
         self.sendPasteHandler = sendPaste
         self.sendKeyEventHandler = sendKeyEvent
-        self.trackpadStateHandler = onTrackpadStateChange
+        self.trackpadFeedbackHandler = onTrackpadFeedbackChange
         self.firstResponderStateHandler = onFirstResponderChange
 
         if isFirstResponder, previousKeyboardAppearance != keyboardAppearance {
@@ -283,8 +281,8 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             sendKeyEvent: { [weak self] event in
                 self?.sendKeyEventHandler?(event) == true
             },
-            onHUDStateChange: { [weak self] state in
-                self?.trackpadStateHandler?(state)
+            onFeedbackChange: { [weak self] state in
+                self?.trackpadFeedbackHandler?(state)
             }
         )
         GhosttyRuntimeTrace.flowEventIfActive(
@@ -299,14 +297,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
     func updateFloatingCursor(at point: CGPoint) {
         guard isInputEnabled else { return }
-        let traceStart = GhosttyRuntimeTrace.nowNanos()
-        guard let outcome = trackpadDriver.update(owner: self, at: point) else { return }
-
-        if !outcome.steps.isEmpty || outcome.didLockAxis {
-            GhosttyRuntimeTrace.perf(
-                "input.trackpad.steps count=\(outcome.steps.count) intensity=\(String(format: "%.2f", Double(outcome.hud.intensity))) lockedAxis=\(outcome.didLockAxis) elapsed_ms=\(GhosttyRuntimeTrace.elapsedMilliseconds(from: traceStart))"
-            )
-        }
+        _ = trackpadDriver.update(owner: self, at: point)
     }
 
     func endFloatingCursor() {

--- a/RemuxAppTests/GhosttyKeyboardCursorTrackpadTests.swift
+++ b/RemuxAppTests/GhosttyKeyboardCursorTrackpadTests.swift
@@ -3,391 +3,390 @@ import XCTest
 @testable import Remux
 
 final class GhosttyKeyboardCursorTrackpadTests: XCTestCase {
-    private final class GestureOwner {}
-
     private let configuration = GhosttyKeyboardCursorTrackpad.Configuration(
-        horizontalStep: 10,
-        verticalStep: 18,
-        lockDeadband: 12,
-        lateSwitchRatio: 3,
-        rampStartDisplacement: 30,
-        rampEndDisplacement: 100,
-        maxAccelMultiplier: 3,
-        maxStepsPerUpdate: 6
+        neutralRadius: 2,
+        armingDistance: 8,
+        tierPlateauDistance: 4,
+        oneXRepeatInterval: 0.2,
+        twoXRepeatInterval: 0.1,
+        threeXRepeatInterval: 0.05,
+        directionSwitchRatio: 1.25,
+        tierReleaseHysteresis: 2
     )
 
-    func testBeginReturnsVisibleZeroIntensityHUD() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        let hud = trackpad.begin(at: .init(x: 50, y: 50))
-        XCTAssertEqual(hud.intensity, 0)
-        XCTAssertEqual(hud.activeDirection, nil)
-        XCTAssertTrue(hud.isVisible)
+    func testRadialZonesSeparateArmingFromStableCommittedTiers() {
+        var trackpad = makeTrackpad()
+
+        XCTAssertEqual(trackpad.update(at: .init(x: 1, y: 0)), .active)
+        assertFeedback(
+            trackpad.update(at: .init(x: 6, y: 0)),
+            direction: .right,
+            committedTier: .neutral,
+            armingTier: .one,
+            armingProgress: 0.5
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 10, y: 0)),
+            direction: .right,
+            committedTier: .one
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 12, y: 0)),
+            direction: .right,
+            committedTier: .one
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 18, y: 0)),
+            direction: .right,
+            committedTier: .one,
+            armingTier: .two,
+            armingProgress: 0.5
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 22, y: 0)),
+            direction: .right,
+            committedTier: .two
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 24, y: 0)),
+            direction: .right,
+            committedTier: .two
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 30, y: 0)),
+            direction: .right,
+            committedTier: .two,
+            armingTier: .three,
+            armingProgress: 0.5
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 34, y: 0)),
+            direction: .right,
+            committedTier: .three
+        )
     }
 
-    func testFirstUpdateAfterBeginEmitsNothing() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 50, y: 50))
-        let outcome = trackpad.update(at: .init(x: 50, y: 50))
-        XCTAssertEqual(outcome.steps, [])
-        XCTAssertFalse(outcome.didLockAxis)
+    func testTierProgressUsesRadiusFromOrigin() {
+        var trackpad = makeTrackpad()
+
+        assertFeedback(
+            trackpad.update(at: .init(x: 6, y: 8)),
+            direction: .down,
+            committedTier: .one
+        )
     }
 
-    func testHorizontalDragBelowDeadbandEmitsNothing() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        let outcome = trackpad.update(at: .init(x: 6, y: 0))
-        XCTAssertEqual(outcome.steps, [])
-        XCTAssertFalse(outcome.didLockAxis)
-        XCTAssertEqual(outcome.hud.intensity, 0)
+    func testMovingInwardPastReleaseHysteresisLowersCommittedTier() {
+        var trackpad = makeTrackpad()
+        XCTAssertEqual(trackpad.update(at: .init(x: 24, y: 0)).committedTier, .two)
+
+        assertFeedback(
+            trackpad.update(at: .init(x: 19, y: 0)),
+            direction: .right,
+            committedTier: .one,
+            armingTier: .two,
+            armingProgress: 0.625
+        )
     }
 
-    func testCrossingDeadbandLocksAxisWithoutEmission() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        let outcome = trackpad.update(at: .init(x: 15, y: 0))
-        XCTAssertEqual(outcome.steps, [])
-        XCTAssertTrue(outcome.didLockAxis)
-        XCTAssertEqual(outcome.hud.activeDirection, nil)
-        XCTAssertEqual(outcome.hud.intensity, 0)
+    func testCommittedTierDoesNotChatterAtReleaseBoundary() {
+        var trackpad = makeTrackpad()
+        XCTAssertEqual(trackpad.update(at: .init(x: 22, y: 0)).committedTier, .two)
+
+        assertFeedback(
+            trackpad.update(at: .init(x: 21, y: 0)),
+            direction: .right,
+            committedTier: .two
+        )
+        assertFeedback(
+            trackpad.update(at: .init(x: 19, y: 0)),
+            direction: .right,
+            committedTier: .one,
+            armingTier: .two,
+            armingProgress: 0.625
+        )
     }
 
-    func testHorizontalLockEmitsRightStepsAtBaseStepSize() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        // Displacement after this update is 10pt, well below rampStart (30) so
-        // the multiplier is 1x and one 10pt step crossing emits exactly one
-        // .right key event.
-        let outcome = trackpad.update(at: .init(x: 25, y: 0))
-        XCTAssertEqual(outcome.steps.count, 1)
-        XCTAssertEqual(outcome.steps.first?.direction, .right)
-        XCTAssertEqual(outcome.steps.first?.intensity, 0)
+    func testReturningInsideNeutralCircleClearsDirectionAndStopsSteering() {
+        var trackpad = makeTrackpad()
+        _ = trackpad.update(at: .init(x: 22, y: 0))
+
+        XCTAssertEqual(trackpad.update(at: .init(x: 1, y: 0)), .active)
     }
 
-    func testIntensityIsZeroBelowRampStart() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        let outcome = trackpad.update(at: .init(x: 35, y: 0))
-        XCTAssertEqual(outcome.hud.intensity, 0)
+    func testFixedOriginMapsAllCardinalDirections() {
+        let samples: [(CGPoint, GhosttyKeyboardCursorTrackpad.Direction)] = [
+            (.init(x: 10, y: 0), .right),
+            (.init(x: -10, y: 0), .left),
+            (.init(x: 0, y: -10), .up),
+            (.init(x: 0, y: 10), .down),
+        ]
+
+        for (point, direction) in samples {
+            var trackpad = makeTrackpad()
+            assertFeedback(
+                trackpad.update(at: point),
+                direction: direction,
+                committedTier: .one
+            )
+        }
     }
 
-    func testIntensityRampsLinearlyBetweenStartAndEnd() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        // Displacement of 65pt past the lock point sits halfway between
-        // rampStart (30) and rampEnd (100), so intensity = 0.5.
-        let outcome = trackpad.update(at: .init(x: 80, y: 0))
-        XCTAssertEqual(outcome.hud.intensity, 0.5, accuracy: 0.01)
+    func testAxisHysteresisPreventsDirectionFlickerNearDiagonal() {
+        var trackpad = makeTrackpad()
+        XCTAssertEqual(trackpad.update(at: .init(x: 20, y: 10)).direction, .right)
+
+        XCTAssertEqual(trackpad.update(at: .init(x: 20, y: 24)).direction, .right)
+        XCTAssertEqual(trackpad.update(at: .init(x: 20, y: 25)).direction, .down)
     }
 
-    func testIntensityClampsToOneAboveRampEnd() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        let outcome = trackpad.update(at: .init(x: 250, y: 0))
-        XCTAssertEqual(outcome.hud.intensity, 1)
+    func testCrossingOriginReversesImmediatelyOnSameAxis() {
+        var trackpad = makeTrackpad()
+        XCTAssertEqual(trackpad.update(at: .init(x: 10, y: 0)).direction, .right)
+
+        XCTAssertEqual(trackpad.update(at: .init(x: -10, y: 0)).direction, .left)
     }
 
-    func testFullIntensityHitsMaxStepsPerUpdateCap() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        // 135pt of locked-axis travel past the lock at maxAccelMultiplier=3
-        // yields effective step ≈ 3.33pt, ≈40 raw crossings, capped at
-        // maxStepsPerUpdate (6).
-        let outcome = trackpad.update(at: .init(x: 150, y: 0))
-        XCTAssertEqual(outcome.steps.count, configuration.maxStepsPerUpdate)
-        XCTAssertEqual(outcome.steps.first?.intensity, 1)
+    func testStationaryPointKeepsSameCommittedState() {
+        var trackpad = makeTrackpad()
+        let point = CGPoint(x: 18, y: 0)
+        let first = trackpad.update(at: point)
+
+        XCTAssertEqual(trackpad.update(at: point), first)
     }
 
-    func testEmissionDensityScalesWithIntensity() {
-        // Two parallel runs: one at intensity 0 (low displacement), one near
-        // intensity 1 (large displacement). Same incremental movement, expect
-        // the high-intensity run to emit more steps per pt of finger travel.
-        var slow = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = slow.begin(at: .init(x: 0, y: 0))
-        _ = slow.update(at: .init(x: 15, y: 0))
-        let slowOutcome = slow.update(at: .init(x: 35, y: 0))
+    func testRepeatIntervalsAreExplicitForEachTier() {
+        let trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
 
-        var fast = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = fast.begin(at: .init(x: 0, y: 0))
-        _ = fast.update(at: .init(x: 15, y: 0))
-        _ = fast.update(at: .init(x: 200, y: 0))
-        let fastOutcome = fast.update(at: .init(x: 220, y: 0))
-
-        XCTAssertGreaterThan(fastOutcome.steps.count, slowOutcome.steps.count)
+        XCTAssertNil(trackpad.repeatInterval(for: .neutral))
+        XCTAssertEqual(trackpad.repeatInterval(for: .one)!, 0.2, accuracy: 0.000_001)
+        XCTAssertEqual(trackpad.repeatInterval(for: .two)!, 0.1, accuracy: 0.000_001)
+        XCTAssertEqual(trackpad.repeatInterval(for: .three)!, 0.05, accuracy: 0.000_001)
     }
 
-    func testReversingDirectionUnwindsDisplacementAndDecreasesIntensity() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        let pushed = trackpad.update(at: .init(x: 130, y: 0))
-        XCTAssertEqual(pushed.hud.intensity, 1)
+    func testDefaultCadencesMatchPrecisionAndTraversalRoles() {
+        let trackpad = GhosttyKeyboardCursorTrackpad()
 
-        // Pull back 80pt. New displacement ≈ 35 -> intensity ≈ (35-30)/70 = 0.07.
-        let pulled = trackpad.update(at: .init(x: 50, y: 0))
-        XCTAssertLessThan(pulled.hud.intensity, 0.2)
+        XCTAssertEqual(trackpad.repeatInterval(for: .one)!, 0.45, accuracy: 0.000_001)
+        XCTAssertEqual(trackpad.repeatInterval(for: .two)!, 0.225, accuracy: 0.000_001)
+        XCTAssertEqual(trackpad.repeatInterval(for: .three)!, 0.12, accuracy: 0.000_001)
     }
 
-    func testReversalEmitsOppositeDirection() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 100, y: 0))
-        _ = trackpad.update(at: .init(x: 85, y: 0))
-        let outcome = trackpad.update(at: .init(x: 65, y: 0))
-        XCTAssertEqual(outcome.steps.count, 2)
-        XCTAssertTrue(outcome.steps.allSatisfy { $0.direction == .left })
-    }
+    func testDefaultGeometryKeepsAllTiersWithinOneHundredTwentyPoints() {
+        var trackpad = GhosttyKeyboardCursorTrackpad()
+        _ = trackpad.begin(at: .zero)
 
-    func testVerticalLockEmitsDownStepsAtVerticalThreshold() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 0, y: 15))
-        let outcome = trackpad.update(at: .init(x: 0, y: 38))
-        XCTAssertEqual(outcome.steps.count, 1)
-        XCTAssertEqual(outcome.steps.first?.direction, .down)
-    }
-
-    func testTinyOrthogonalJitterAfterLockDoesNotSwitchAxis() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-
-        // Real-finger noise: a few sub-deadband vertical wobbles. These must
-        // not flip the axis lock away from horizontal.
-        let firstJitter = trackpad.update(at: .init(x: 15, y: 3))
-        XCTAssertFalse(firstJitter.didLockAxis)
-        let secondJitter = trackpad.update(at: .init(x: 15, y: 6))
-        XCTAssertFalse(secondJitter.didLockAxis)
-        let thirdJitter = trackpad.update(at: .init(x: 15, y: 4))
-        XCTAssertFalse(thirdJitter.didLockAxis)
-
-        // A subsequent horizontal commit should still emit a right arrow,
-        // proving the axis lock survived the jitter.
-        let horizontalCommit = trackpad.update(at: .init(x: 25, y: 4))
-        XCTAssertEqual(horizontalCommit.steps.first?.direction, .right)
-    }
-
-    func testLateAxisSwitchResetsDisplacement() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        // Build up horizontal displacement well above rampStart.
-        let pushed = trackpad.update(at: .init(x: 90, y: 0))
-        XCTAssertGreaterThan(pushed.hud.intensity, 0.5)
-
-        // Sharp downward sweep flips lock to vertical and resets the
-        // displacement counter.
-        let switchOutcome = trackpad.update(at: .init(x: 90, y: 250))
-        XCTAssertTrue(switchOutcome.didLockAxis)
-        // The 250pt downward update on the new vertical axis with displacement
-        // counter starting fresh from 0 puts displacement at 250 -> intensity 1.
-        XCTAssertEqual(switchOutcome.hud.intensity, 1)
-        XCTAssertTrue(switchOutcome.steps.allSatisfy { $0.direction == .down })
-    }
-
-    func testCappedUpdatePreservesBacklogForNextCallback() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-
-        // Coalesced 200pt update at clamped intensity emits the cap and leaves
-        // a substantial residual in the accumulator.
-        let big = trackpad.update(at: .init(x: 215, y: 0))
-        XCTAssertEqual(big.steps.count, configuration.maxStepsPerUpdate)
-
-        // No new finger movement on the next callback. The residual still has
-        // enough travel to fire more arrows. With the previous (uncapped)
-        // consumption policy this would be empty.
-        let drain = trackpad.update(at: .init(x: 215, y: 0))
-        XCTAssertGreaterThan(drain.steps.count, 0)
-        XCTAssertTrue(drain.steps.allSatisfy { $0.direction == .right })
-    }
-
-    func testEndReturnsHiddenHUDState() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 25, y: 0))
-        let hud = trackpad.end()
-        XCTAssertEqual(hud, .hidden)
-    }
-
-    func testResidualTravelAccumulatesAcrossUpdates() {
-        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
-        _ = trackpad.begin(at: .init(x: 0, y: 0))
-        _ = trackpad.update(at: .init(x: 15, y: 0))
-        // Two below-threshold updates of 6pt each accumulate to one step.
-        let first = trackpad.update(at: .init(x: 21, y: 0))
-        XCTAssertEqual(first.steps, [])
-        let second = trackpad.update(at: .init(x: 27, y: 0))
-        XCTAssertEqual(second.steps.count, 1)
-        XCTAssertEqual(second.steps.first?.direction, .right)
+        XCTAssertEqual(trackpad.update(at: .init(x: 7, y: 0)), .active)
+        assertFeedback(
+            trackpad.update(at: .init(x: 22, y: 0)),
+            direction: .right,
+            committedTier: .neutral,
+            armingTier: .one,
+            armingProgress: 0.5
+        )
+        XCTAssertEqual(trackpad.update(at: .init(x: 36, y: 0)).committedTier, .one)
+        XCTAssertEqual(trackpad.update(at: .init(x: 78, y: 0)).committedTier, .two)
+        XCTAssertEqual(trackpad.update(at: .init(x: 120, y: 0)).committedTier, .three)
     }
 
     @MainActor
-    func testDriverStartsClockOnlyAfterImmediateMovementAndHonorsInitialDelay() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let owner = GestureOwner()
-        var events: [GhosttySurfaceKeyEvent.KeyCode] = []
+    func testDriverDoesNotEmitDuringInitialArming() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
 
-        driver.begin(
-            owner: owner,
-            at: .zero,
-            sendKeyEvent: {
-                events.append($0.keyCode)
-                return true
-            },
-            onHUDStateChange: { _ in }
+        let feedback = harness.driver.update(owner: harness.owner, at: .init(x: 6, y: 0), now: 0)
+
+        XCTAssertTrue(harness.keyCodes.isEmpty)
+        assertFeedback(
+            feedback!,
+            direction: .right,
+            committedTier: .neutral,
+            armingTier: .one,
+            armingProgress: 0.5
         )
-        XCTAssertFalse(driver.isRepeatScheduled)
-
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0)
-        XCTAssertFalse(driver.isRepeatScheduled)
-        XCTAssertTrue(events.isEmpty)
-
-        _ = driver.update(owner: owner, at: .init(x: 25, y: 0), now: 0)
-        XCTAssertEqual(events, [.arrowRight])
-        XCTAssertTrue(driver.isRepeatScheduled)
-
-        driver.repeatTick(at: GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay - 0.001)
-        XCTAssertEqual(events.count, 1)
-        driver.repeatTick(at: GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay)
-        XCTAssertEqual(events, [.arrowRight, .arrowRight])
     }
 
     @MainActor
-    func testDriverUsesThreeRepeatGearsWithoutCatchUp() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let owner = GestureOwner()
-        var events: [GhosttySurfaceKeyEvent.KeyCode] = []
-        driver.begin(
-            owner: owner,
-            at: .zero,
-            sendKeyEvent: {
-                events.append($0.keyCode)
-                return true
-            },
-            onHUDStateChange: { _ in }
-        )
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0)
-        _ = driver.update(owner: owner, at: .init(x: 25, y: 0), now: 0)
+    func testDriverRepeatsCommittedDirectionWhileFingerIsStill() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 10, y: 0), now: 0)
 
-        driver.repeatTick(at: GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay)
-        let afterFirstSlowRepeat = events.count
-        driver.repeatTick(
-            at: GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay +
-                GhosttyKeyboardCursorTrackpadDriver.slowRepeatInterval - 0.001
-        )
-        XCTAssertEqual(events.count, afterFirstSlowRepeat)
-        let slowDeadline = GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay +
-            GhosttyKeyboardCursorTrackpadDriver.slowRepeatInterval
-        driver.repeatTick(at: slowDeadline)
-        XCTAssertEqual(events.count, afterFirstSlowRepeat + 1)
+        XCTAssertEqual(harness.keyCodes, [.arrowRight])
+        harness.driver.repeatTick(at: 0.19)
+        XCTAssertEqual(harness.keyCodes, [.arrowRight])
+        harness.driver.repeatTick(at: 0.20)
+        harness.driver.repeatTick(at: 0.39)
+        harness.driver.repeatTick(at: 0.40)
 
-        _ = driver.update(owner: owner, at: .init(x: 80, y: 0), now: slowDeadline)
-        driver.repeatTick(at: slowDeadline + GhosttyKeyboardCursorTrackpadDriver.slowRepeatInterval)
-        let afterFirstMediumRepeat = events.count
-        driver.repeatTick(
-            at: slowDeadline + GhosttyKeyboardCursorTrackpadDriver.slowRepeatInterval +
-                GhosttyKeyboardCursorTrackpadDriver.mediumRepeatInterval
-        )
-        XCTAssertEqual(events.count, afterFirstMediumRepeat + 1)
-
-        let mediumDeadline = slowDeadline + GhosttyKeyboardCursorTrackpadDriver.slowRepeatInterval +
-            GhosttyKeyboardCursorTrackpadDriver.mediumRepeatInterval
-        _ = driver.update(owner: owner, at: .init(x: 130, y: 0), now: mediumDeadline)
-        driver.repeatTick(at: mediumDeadline + GhosttyKeyboardCursorTrackpadDriver.mediumRepeatInterval)
-        let afterFirstFastRepeat = events.count
-        driver.repeatTick(
-            at: mediumDeadline + GhosttyKeyboardCursorTrackpadDriver.mediumRepeatInterval +
-                GhosttyKeyboardCursorTrackpadDriver.fastRepeatInterval
-        )
-        XCTAssertEqual(events.count, afterFirstFastRepeat + 1)
-
-        driver.repeatTick(at: 100)
-        XCTAssertEqual(events.count, afterFirstFastRepeat + 2, "a delayed frame emits only one repeat")
+        XCTAssertEqual(harness.keyCodes, [.arrowRight, .arrowRight, .arrowRight])
+        XCTAssertEqual(harness.driver.end(owner: harness.owner), true)
     }
 
     @MainActor
-    func testDriverNeutralAndDirectionChangesResetRepeatDelay() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let owner = GestureOwner()
-        var events: [GhosttySurfaceKeyEvent.KeyCode] = []
-        driver.begin(
-            owner: owner,
-            at: .zero,
-            sendKeyEvent: {
-                events.append($0.keyCode)
-                return true
-            },
-            onHUDStateChange: { _ in }
+    func testDriverKeepsCurrentRateWhileNextTierIsArming() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 10, y: 0), now: 0)
+
+        let feedback = harness.driver.update(owner: harness.owner, at: .init(x: 18, y: 0), now: 0.1)
+        harness.driver.repeatTick(at: 0.20)
+
+        assertFeedback(
+            feedback!,
+            direction: .right,
+            committedTier: .one,
+            armingTier: .two,
+            armingProgress: 0.5
         )
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0)
-        _ = driver.update(owner: owner, at: .init(x: 25, y: 0), now: 0)
-        XCTAssertTrue(driver.isRepeatScheduled)
-
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0.1)
-        XCTAssertFalse(driver.isRepeatScheduled)
-        let neutralEventCount = events.count
-        driver.repeatTick(at: 1)
-        XCTAssertEqual(events.count, neutralEventCount)
-
-        _ = driver.update(owner: owner, at: .init(x: 5, y: 0), now: 1)
-        XCTAssertTrue(driver.isRepeatScheduled)
-        let leftMovementEventCount = events.count
-        driver.repeatTick(at: 1 + GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay - 0.001)
-        XCTAssertEqual(events.count, leftMovementEventCount)
-        driver.repeatTick(at: 1 + GhosttyKeyboardCursorTrackpadDriver.initialRepeatDelay)
-        XCTAssertEqual(events.last, .arrowLeft)
-        XCTAssertEqual(events.count, leftMovementEventCount + 1)
+        XCTAssertEqual(harness.keyCodes, [.arrowRight, .arrowRight])
     }
 
     @MainActor
-    func testDriverInputRejectionStopsClockAndPreservesSteeredResult() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let owner = GestureOwner()
-        var sendAttempts = 0
-        var hudStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
+    func testDriverUsesFasterCadenceOnlyAfterTierCommits() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 10, y: 0), now: 0)
+
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 22, y: 0), now: 0.1)
+        harness.driver.repeatTick(at: 0.19)
+        XCTAssertEqual(harness.keyCodes, [.arrowRight, .arrowRight])
+        harness.driver.repeatTick(at: 0.20)
+
+        XCTAssertEqual(harness.keyCodes, [.arrowRight, .arrowRight, .arrowRight])
+        XCTAssertEqual(harness.hapticCues, [.tierChanged, .tierChanged])
+    }
+
+    @MainActor
+    func testDriverDoesNotEmitExtraCommandWhenMovingToSlowerTier() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 22, y: 0), now: 0)
+        XCTAssertEqual(harness.keyCodes, [.arrowRight])
+
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 19, y: 0), now: 0.1)
+
+        XCTAssertEqual(harness.keyCodes, [.arrowRight])
+        XCTAssertEqual(harness.hapticCues, [.tierChanged, .tierChanged])
+    }
+
+    @MainActor
+    func testDriverStopsImmediatelyInsideNeutralZone() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 10, y: 0), now: 0)
+
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 1, y: 0), now: 0.1)
+        harness.driver.repeatTick(at: 1)
+
+        XCTAssertEqual(harness.keyCodes, [.arrowRight])
+        XCTAssertEqual(harness.hapticCues, [.tierChanged, .neutralEntered])
+    }
+
+    @MainActor
+    func testDriverDirectionChangeEmitsNewDirectionAndCancelsOldRepeat() {
+        let harness = DriverHarness(configuration: configuration)
+        defer { harness.driver.cancel(owner: harness.owner) }
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: 10, y: 0), now: 0)
+
+        _ = harness.driver.update(owner: harness.owner, at: .init(x: -10, y: 0), now: 0.1)
+        harness.driver.repeatTick(at: 0.299)
+        harness.driver.repeatTick(at: 0.301)
+
+        XCTAssertEqual(harness.keyCodes, [.arrowRight, .arrowLeft, .arrowLeft])
+    }
+
+    @MainActor
+    func testDriverRejectsUpdatesFromAnotherOwner() {
+        let harness = DriverHarness(configuration: configuration)
+        let otherOwner = NSObject()
+        defer { harness.driver.cancel(owner: harness.owner) }
+
+        XCTAssertNil(harness.driver.update(owner: otherOwner, at: .init(x: 10, y: 0)))
+        XCTAssertNil(harness.driver.end(owner: otherOwner))
+        XCTAssertEqual(harness.driver.end(owner: harness.owner), false)
+    }
+
+    @MainActor
+    func testDriverCancelsGestureWhenKeyPathRejectsInput() {
+        let driver = GhosttyKeyboardCursorTrackpadDriver(configuration: configuration)
+        let owner = NSObject()
+        var feedback: [GhosttyKeyboardCursorTrackpad.FeedbackState] = []
+        var attempts = 0
         driver.begin(
             owner: owner,
             at: .zero,
             sendKeyEvent: { _ in
-                sendAttempts += 1
+                attempts += 1
                 return false
             },
-            onHUDStateChange: { hudStates.append($0) }
+            onFeedbackChange: { feedback.append($0) }
         )
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0)
-        _ = driver.update(owner: owner, at: .init(x: 25, y: 0), now: 0)
 
-        XCTAssertEqual(sendAttempts, 1)
-        XCTAssertFalse(driver.isRepeatScheduled)
-        XCTAssertEqual(hudStates.last, .hidden)
-        driver.repeatTick(at: 10)
-        _ = driver.update(owner: owner, at: .init(x: 50, y: 0), now: 10)
-        XCTAssertEqual(sendAttempts, 1)
-        XCTAssertEqual(driver.end(owner: owner), true)
+        _ = driver.update(owner: owner, at: .init(x: 10, y: 0), now: 0)
+
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(feedback, [.active, .hidden])
+        XCTAssertNil(driver.update(owner: owner, at: .init(x: 22, y: 0)))
+        XCTAssertNil(driver.end(owner: owner))
     }
 
-    @MainActor
-    func testDriverEndCancelsClockAndHidesHUD() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let owner = GestureOwner()
-        var hudStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
+    private func makeTrackpad() -> GhosttyKeyboardCursorTrackpad {
+        var trackpad = GhosttyKeyboardCursorTrackpad(configuration: configuration)
+        trackpad.begin(at: .zero)
+        return trackpad
+    }
+
+    private func assertFeedback(
+        _ feedback: GhosttyKeyboardCursorTrackpad.FeedbackState,
+        direction: GhosttyKeyboardCursorTrackpad.Direction,
+        committedTier: GhosttyKeyboardCursorTrackpad.SpeedTier,
+        armingTier: GhosttyKeyboardCursorTrackpad.SpeedTier? = nil,
+        armingProgress: CGFloat = 0,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(feedback.isVisible, file: file, line: line)
+        XCTAssertEqual(feedback.direction, direction, file: file, line: line)
+        XCTAssertEqual(feedback.committedTier, committedTier, file: file, line: line)
+        XCTAssertEqual(feedback.armingTier, armingTier, file: file, line: line)
+        XCTAssertEqual(feedback.armingProgress, armingProgress, accuracy: 0.000_001, file: file, line: line)
+    }
+}
+
+@MainActor
+private final class DriverHarness {
+    let driver: GhosttyKeyboardCursorTrackpadDriver
+    let owner = NSObject()
+    let hapticRecorder: HapticRecorder
+    private(set) var keyCodes: [GhosttySurfaceKeyEvent.KeyCode] = []
+
+    var hapticCues: [GhosttyKeyboardCursorTrackpadDriver.HapticCue] {
+        hapticRecorder.cues
+    }
+
+    init(configuration: GhosttyKeyboardCursorTrackpad.Configuration) {
+        let hapticRecorder = HapticRecorder()
+        self.hapticRecorder = hapticRecorder
+        driver = GhosttyKeyboardCursorTrackpadDriver(
+            configuration: configuration,
+            playHaptic: { [hapticRecorder] cue in
+                hapticRecorder.cues.append(cue)
+            }
+        )
         driver.begin(
             owner: owner,
             at: .zero,
-            sendKeyEvent: { _ in true },
-            onHUDStateChange: { hudStates.append($0) }
+            sendKeyEvent: { [weak self] event in
+                self?.keyCodes.append(event.keyCode)
+                return true
+            },
+            onFeedbackChange: { _ in }
         )
-        _ = driver.update(owner: owner, at: .init(x: 15, y: 0), now: 0)
-        _ = driver.update(owner: owner, at: .init(x: 25, y: 0), now: 0)
-
-        XCTAssertEqual(driver.end(owner: owner), true)
-        XCTAssertFalse(driver.isRepeatScheduled)
-        XCTAssertEqual(hudStates.last, .hidden)
-        XCTAssertNil(driver.end(owner: owner))
     }
+}
+
+@MainActor
+private final class HapticRecorder {
+    var cues: [GhosttyKeyboardCursorTrackpadDriver.HapticCue] = []
 }

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -13,8 +13,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 1,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         XCTAssertTrue(view.hasText)
@@ -34,8 +33,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendKeyEvent: {
                 receivedEvents.append($0)
                 return true
-            },
-            onTrackpadStateChange: { _ in }
+            }
         )
 
         view.deleteBackward()
@@ -57,8 +55,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendKeyEvent: {
                 receivedEvents.append($0)
                 return true
-            },
-            onTrackpadStateChange: { _ in }
+            }
         )
 
         view.deleteBackward()
@@ -80,8 +77,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 return true
             },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         view.insertText("hello")
@@ -103,8 +99,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 return true
             },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         view.replace(view.selectedTextRange!, withText: "hello")
@@ -126,8 +121,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 return true
             },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         view.insertText("ignored")
@@ -149,8 +143,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 return true
             },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         view.replace(view.selectedTextRange!, withText: "ignored")
@@ -176,8 +169,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 pastedText.append($0)
                 return true
             },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         UIPasteboard.general.string = "first\nsecond"
@@ -201,8 +193,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 pastedText.append($0)
                 return true
             },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         UIPasteboard.general.string = ""
@@ -537,8 +528,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 7,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
         view.update(
             isEnabled: true,
@@ -546,8 +536,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 7,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         let becameFirstResponder = await waitUntil { view.isFirstResponder }
@@ -574,8 +563,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         XCTAssertTrue(view.canBecomeFirstResponder)
@@ -587,8 +575,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         XCTAssertFalse(view.isFirstResponder)
@@ -618,7 +605,6 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendText: { _ in true },
             sendPaste: { _ in true },
             sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in },
             onFirstResponderChange: { reportedStates.append($0) }
         )
 
@@ -652,8 +638,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
         let initiallyBecameFirstResponder = await waitUntil { view.isFirstResponder }
         XCTAssertTrue(initiallyBecameFirstResponder)
@@ -668,8 +653,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         let recoveredFirstResponder = await waitUntil { view.isFirstResponder }
@@ -696,8 +680,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
         let initiallyBecameFirstResponder = await waitUntil { view.isFirstResponder }
         XCTAssertTrue(initiallyBecameFirstResponder)
@@ -708,8 +691,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 3,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         XCTAssertTrue(view.isFirstResponder)
@@ -740,8 +722,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             activationToken: 1,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { _ in }
+            sendKeyEvent: { _ in true }
         )
 
         XCTAssertFalse(
@@ -787,144 +768,10 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
     }
 
     @MainActor
-    func testFloatingCursorSweepEmitsArrowRightKeyEvents() {
+    func testFloatingCursorCrossingFirstTierEmitsArrowAndPublishesTier() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
         var receivedEvents: [GhosttySurfaceKeyEvent] = []
-        var receivedHUDStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
-
-        view.update(
-            isEnabled: true,
-            wantsFirstResponder: true,
-            activationToken: 1,
-            sendText: { _ in true },
-            sendPaste: { _ in true },
-            sendKeyEvent: { event in
-                receivedEvents.append(event)
-                return true
-            },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
-        )
-
-        view.beginFloatingCursor(at: .init(x: 0, y: 0))
-        // Cross the lock deadband so the trackpad commits to the horizontal axis.
-        view.updateFloatingCursor(at: .init(x: 18, y: 0))
-        // After lock, the next horizontal travel above the per-step threshold
-        // should produce one or more arrow-right key events.
-        view.updateFloatingCursor(at: .init(x: 38, y: 0))
-        view.endFloatingCursor()
-
-        XCTAssertFalse(receivedEvents.isEmpty)
-        XCTAssertTrue(receivedEvents.allSatisfy { $0.keyCode == .arrowRight })
-        XCTAssertEqual(receivedHUDStates.first?.isVisible, true)
-        XCTAssertEqual(receivedHUDStates.last, .hidden)
-    }
-
-    @MainActor
-    func testResignFirstResponderClearsTrackpadHUDDuringActiveGesture() async {
-        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        window.rootViewController = UIViewController()
-        window.rootViewController?.view.addSubview(view)
-        window.makeKeyAndVisible()
-        defer {
-            view.removeFromSuperview()
-            window.isHidden = true
-            window.rootViewController = nil
-        }
-
-        var receivedHUDStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
-        view.update(
-            isEnabled: true,
-            wantsFirstResponder: true,
-            activationToken: 1,
-            sendText: { _ in true },
-            sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
-        )
-        _ = await waitUntil { view.isFirstResponder }
-
-        view.beginFloatingCursor(at: .init(x: 0, y: 0))
-        view.updateFloatingCursor(at: .init(x: 18, y: 0))
-        XCTAssertTrue(receivedHUDStates.contains { $0.isVisible })
-
-        _ = view.resignFirstResponder()
-
-        XCTAssertEqual(receivedHUDStates.last, .hidden)
-    }
-
-    @MainActor
-    func testRemovingResponderFromWindowDuringTrackpadGestureClearsHUD() {
-        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-        window.rootViewController = UIViewController()
-        window.rootViewController?.view.addSubview(view)
-        window.makeKeyAndVisible()
-        defer {
-            window.isHidden = true
-            window.rootViewController = nil
-        }
-
-        var receivedHUDStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
-        view.update(
-            isEnabled: true,
-            wantsFirstResponder: true,
-            activationToken: 1,
-            sendText: { _ in true },
-            sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
-        )
-
-        view.beginFloatingCursor(at: .init(x: 0, y: 0))
-        view.updateFloatingCursor(at: .init(x: 18, y: 0))
-        XCTAssertTrue(receivedHUDStates.contains { $0.isVisible })
-
-        // SwiftUI representable removal flows through removeFromSuperview ->
-        // didMoveToWindow with window == nil. The HUD must reset to hidden so
-        // the parent SwiftUI state doesn't strand.
-        view.removeFromSuperview()
-
-        XCTAssertEqual(receivedHUDStates.last, .hidden)
-    }
-
-    @MainActor
-    func testDismantleRepresentableDuringTrackpadGestureClearsHUD() {
-        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
-        var receivedHUDStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
-
-        view.update(
-            isEnabled: true,
-            wantsFirstResponder: true,
-            activationToken: 1,
-            sendText: { _ in true },
-            sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
-        )
-
-        view.beginFloatingCursor(at: .init(x: 0, y: 0))
-        view.updateFloatingCursor(at: .init(x: 18, y: 0))
-
-        GhosttyTerminalResponderRepresentable.dismantleUIView(view, coordinator: ())
-
-        XCTAssertEqual(receivedHUDStates.last, .hidden)
-    }
-
-    @MainActor
-    func testDisablingResponderDuringTrackpadGestureClearsHUD() {
-        let driver = GhosttyKeyboardCursorTrackpadDriver()
-        let view = GhosttyTerminalResponderUIView(trackpadDriver: driver)
-        var receivedHUDStates: [GhosttyKeyboardCursorTrackpad.HUDState] = []
-        var receivedEvents: [GhosttySurfaceKeyEvent] = []
+        var feedback: [GhosttyKeyboardCursorTrackpad.FeedbackState] = []
 
         view.update(
             isEnabled: true,
@@ -936,15 +783,87 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
                 receivedEvents.append($0)
                 return true
             },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
+            onTrackpadFeedbackChange: { feedback.append($0) }
         )
 
-        view.beginFloatingCursor(at: .init(x: 0, y: 0))
-        view.updateFloatingCursor(at: .init(x: 18, y: 0))
-        view.updateFloatingCursor(at: .init(x: 28, y: 0))
-        XCTAssertTrue(driver.isRepeatScheduled)
+        view.beginFloatingCursor(at: .zero)
+        view.updateFloatingCursor(at: .init(x: 36, y: 0))
+        view.endFloatingCursor()
+
+        XCTAssertEqual(receivedEvents.map(\.keyCode), [.arrowRight])
+        XCTAssertEqual(feedback, [
+            .active,
+            .init(
+                isVisible: true,
+                direction: .right,
+                committedTier: .one,
+                armingTier: nil,
+                armingProgress: 0
+            ),
+            .hidden,
+        ])
+    }
+
+    @MainActor
+    func testFloatingCursorPartialArmingSendsNothing() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedEvents: [GhosttySurfaceKeyEvent] = []
+        var feedback: [GhosttyKeyboardCursorTrackpad.FeedbackState] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: {
+                receivedEvents.append($0)
+                return true
+            },
+            onTrackpadFeedbackChange: { feedback.append($0) }
+        )
+
+        view.beginFloatingCursor(at: .zero)
+        view.updateFloatingCursor(at: .init(x: 22, y: 0))
+        view.endFloatingCursor()
+
+        XCTAssertTrue(receivedEvents.isEmpty)
+        XCTAssertEqual(feedback, [
+            .active,
+            .init(
+                isVisible: true,
+                direction: .right,
+                committedTier: .neutral,
+                armingTier: .one,
+                armingProgress: 0.5
+            ),
+            .hidden,
+        ])
+    }
+
+    @MainActor
+    func testDisablingResponderCancelsActiveTrackpadGesture() {
+        let driver = GhosttyKeyboardCursorTrackpadDriver()
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: driver)
+        var receivedEvents: [GhosttySurfaceKeyEvent] = []
+        var feedback: [GhosttyKeyboardCursorTrackpad.FeedbackState] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: {
+                receivedEvents.append($0)
+                return true
+            },
+            onTrackpadFeedbackChange: { feedback.append($0) }
+        )
+
+        view.beginFloatingCursor(at: .zero)
+        view.updateFloatingCursor(at: .init(x: 36, y: 0))
+        let eventCountBeforeDisable = receivedEvents.count
 
         view.update(
             isEnabled: false,
@@ -953,15 +872,11 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendText: { _ in true },
             sendPaste: { _ in true },
             sendKeyEvent: { _ in true },
-            onTrackpadStateChange: { state in
-                receivedHUDStates.append(state)
-            }
+            onTrackpadFeedbackChange: { feedback.append($0) }
         )
 
-        XCTAssertEqual(receivedHUDStates.last, .hidden)
-        XCTAssertFalse(driver.isRepeatScheduled)
-        let eventCountAfterDisable = receivedEvents.count
+        XCTAssertEqual(feedback.last, .hidden)
         driver.repeatTick(at: .greatestFiniteMagnitude)
-        XCTAssertEqual(receivedEvents.count, eventCountAfterDisable)
+        XCTAssertEqual(receivedEvents.count, eventCountBeforeDisable)
     }
 }


### PR DESCRIPTION
## Summary

Reworks trackpad navigation around the point where the long press begins. Moving away from that point chooses the direction and repeat speed, holding position keeps moving, and returning to the center stops it.

The on-screen indicator now shows the direction and speed being armed, with haptic feedback when each speed becomes active. This makes precise navigation easier without sacrificing faster movement through longer lists.

## Testing

- Tested on a physical iPhone
- Verified precise navigation, direction changes, all three speeds, and returning to center
- 59 focused tests passing