### PR TITLE
Fix tmux startup with Fish and csh

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalDisconnectReasonClassifier.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalDisconnectReasonClassifier.swift
@@ -65,15 +65,17 @@ enum GhosttyTerminalDisconnectReasonClassifier {
             return nil
         }
 
-        let stderr = diagnostics?.stderrPreview?.lowercased() ?? ""
-        let tmuxWasNotFound = stderr.contains("command not found") ||
-            stderr.contains("no such file or directory")
-
-        if status == 127 || tmuxWasNotFound {
+        let stderr = diagnostics?.stderrPreview ?? ""
+        if status == 127,
+           stderr.localizedCaseInsensitiveContains(SSHTmuxControlCommandBuilder.tmuxNotFoundMarker) {
             return "Install tmux on this server or update Executable Path."
         }
 
-        return "Check the tmux executable and its permissions, then try again."
+        if status == 126,
+           stderr.localizedCaseInsensitiveContains(SSHTmuxControlCommandBuilder.tmuxNotExecutableMarker) {
+            return "Check the tmux executable and its permissions, then try again."
+        }
+        return nil
     }
 
     private static func isServerUnreachable(_ error: any Error) -> Bool {

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
@@ -1,4 +1,7 @@
 enum SSHTmuxControlCommandBuilder {
+    static let tmuxNotFoundMarker = "remux: tmux executable not found"
+    static let tmuxNotExecutableMarker = "remux: tmux executable cannot be executed"
+
     private static let fallbackRemotePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     static func attachOrCreateControlSessionCommand(
@@ -6,19 +9,36 @@ enum SSHTmuxControlCommandBuilder {
         sessionName: String,
         initialViewport: TmuxControlViewport
     ) -> String {
-        let tmux = shellEscape(tmuxExecutable)
-        let session = shellEscape(sessionName)
-
-        // Single -C: pure control mode without the DCS 1000p envelope that
-        // -CC emits for in-terminal clients (and without -CC's hard tty
-        // requirement). The session channel is a bare exec stream feeding
-        // Ghostty's tmux session parser directly.
-        return """
-        export PATH="${PATH:+$PATH:}\(fallbackRemotePath)" TERM=xterm-256color; exec \(tmux) -C new-session -A -s \(session) -x \(initialViewport.columns) -y \(initialViewport.rows)
-        """
+        // The SSH login shell only parses this wrapper. /bin/sh owns the PATH
+        // expression so fish and csh do not need to understand POSIX syntax.
+        [
+            "exec /bin/sh -c '\(launchScript)' remux",
+            octalEncodedArgument(tmuxExecutable),
+            octalEncodedArgument(sessionName),
+            "\(initialViewport.columns)",
+            "\(initialViewport.rows)",
+        ].joined(separator: " ")
     }
 
-    private static func shellEscape(_ value: String) -> String {
-        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    private static let launchScript = [
+        #"PATH="${PATH:+$PATH:}\#(fallbackRemotePath)""#,
+        "export PATH",
+        "TERM=xterm-256color",
+        "export TERM",
+        #"tmux=$(printf %b "$1")"#,
+        #"session=$(printf %b "$2")"#,
+        #"resolved=$(command -v "$tmux" 2> /dev/null)"#,
+        #"if [ -x "$resolved" ]; then exec "$resolved" -C new-session -A -s "$session" -x "$3" -y "$4"; fi"#,
+        #"if [ -e "$tmux" ]; then echo "\#(tmuxNotExecutableMarker): $tmux" >&2; exit 126; fi"#,
+        #"echo "\#(tmuxNotFoundMarker): $tmux" >&2"#,
+        "exit 127",
+    ].joined(separator: "; ")
+
+    private static func octalEncodedArgument(_ value: String) -> String {
+        let bytes = value.utf8.map { byte in
+            let digits = String(byte, radix: 8)
+            return "\\0" + String(repeating: "0", count: 3 - digits.count) + digits
+        }
+        return "'\(bytes.joined())'"
     }
 }

--- a/RemuxAppTests/GhosttyTerminalDisconnectReasonClassifierTests.swift
+++ b/RemuxAppTests/GhosttyTerminalDisconnectReasonClassifierTests.swift
@@ -41,25 +41,6 @@ final class GhosttyTerminalDisconnectReasonClassifierTests: XCTestCase {
         )
         XCTAssertEqual(
             GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
-                SSHTmuxControlTransportError.remoteExit(127)
-            ).kind,
-            .tmuxUnavailable
-        )
-        let missingPathDiagnostics = SSHTmuxStartupDiagnostics(
-            stdoutByteCount: 0,
-            stderrByteCount: 45,
-            extendedDataByteCount: 0,
-            stderrPreview: "sh: /missing/tmux: No such file or directory\\x0A",
-            extendedDataPreview: nil
-        )
-        XCTAssertEqual(
-            GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
-                SSHTmuxControlTransportError.remoteExit(126, diagnostics: missingPathDiagnostics)
-            ).kind,
-            .tmuxUnavailable
-        )
-        XCTAssertEqual(
-            GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
                 SSHTmuxControlTransportError.channelRequestFailed(.exec)
             ).kind,
             .profile
@@ -93,6 +74,57 @@ final class GhosttyTerminalDisconnectReasonClassifierTests: XCTestCase {
                 SSHTmuxControlTransportError.controlSessionNoResponse(.seconds(15))
             ).kind,
             .profile
+        )
+    }
+
+    func testTmuxUnavailableRequiresLauncherMarker() {
+        let cases = [
+            (
+                127,
+                SSHTmuxControlCommandBuilder.tmuxNotFoundMarker,
+                "Install tmux on this server or update Executable Path."
+            ),
+            (
+                126,
+                SSHTmuxControlCommandBuilder.tmuxNotExecutableMarker,
+                "Check the tmux executable and its permissions, then try again."
+            ),
+        ]
+
+        for (status, marker, message) in cases {
+            let reason = GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
+                SSHTmuxControlTransportError.remoteExit(
+                    status,
+                    diagnostics: diagnostics(stderr: "\(marker): /usr/bin/tmux\\x0A")
+                )
+            )
+            XCTAssertEqual(reason.kind, .tmuxUnavailable)
+            XCTAssertEqual(reason.message, message)
+        }
+    }
+
+    func testShellFailuresAreNotReportedAsTmuxUnavailable() {
+        for (status, stderr) in [
+            (127, "fish: Unknown command: export\\x0A"),
+            (126, "fish: exec: /bin/sh: Permission denied\\x0A"),
+        ] {
+            let reason = GhosttyTerminalDisconnectReasonClassifier.transportStartFailure(
+                SSHTmuxControlTransportError.remoteExit(
+                    status,
+                    diagnostics: diagnostics(stderr: stderr)
+                )
+            )
+            XCTAssertEqual(reason.kind, .remoteExit)
+        }
+    }
+
+    private func diagnostics(stderr: String) -> SSHTmuxStartupDiagnostics {
+        SSHTmuxStartupDiagnostics(
+            stdoutByteCount: 0,
+            stderrByteCount: stderr.utf8.count,
+            extendedDataByteCount: 0,
+            stderrPreview: stderr,
+            extendedDataPreview: nil
         )
     }
 

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -1297,7 +1297,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         XCTAssertNoThrow(try promise.futureResult.wait())
     }
 
-    func testControlSessionCommandAttachesOrCreatesNamedSession() {
+    func testControlSessionCommandDelegatesStartupToPOSIXShell() {
         let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
             tmuxExecutable: "tmux",
             sessionName: "base",
@@ -1309,16 +1309,18 @@ final class SSHTmuxControlTransportTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            command,
-            "export PATH=\"${PATH:+$PATH:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" TERM=xterm-256color; exec 'tmux' -C new-session -A -s 'base' -x 45 -y 37"
-        )
+        XCTAssertTrue(command.hasPrefix("exec /bin/sh -c '"))
+        XCTAssertTrue(command.contains(#"PATH="${PATH:+$PATH:}/opt/homebrew/bin"#))
+        XCTAssertTrue(command.contains(#"exec "$resolved" -C new-session -A"#))
+        XCTAssertTrue(command.hasSuffix(" 45 37"))
     }
 
-    func testControlSessionCommandShellEscapesValues() {
+    func testControlSessionCommandKeepsValuesOutOfLoginShellSyntax() {
+        let tmuxExecutable = "/home/owner's tools/tmux"
+        let sessionName = "owner's bäse! back\\slash"
         let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
-            tmuxExecutable: "/home/owner's tools/tmux",
-            sessionName: "owner's base",
+            tmuxExecutable: tmuxExecutable,
+            sessionName: sessionName,
             initialViewport: TmuxControlViewport(
                 columns: 120,
                 rows: 40,
@@ -1327,10 +1329,11 @@ final class SSHTmuxControlTransportTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            command,
-            "export PATH=\"${PATH:+$PATH:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" TERM=xterm-256color; exec '/home/owner'\"'\"'s tools/tmux' -C new-session -A -s 'owner'\"'\"'s base' -x 120 -y 40"
-        )
+        XCTAssertFalse(command.contains(tmuxExecutable))
+        XCTAssertFalse(command.contains(sessionName))
+        XCTAssertFalse(command.contains("\n"))
+        XCTAssertFalse(command.contains("!"))
+        XCTAssertTrue(command.hasSuffix(" 120 40"))
     }
 
     func testSendAfterCloseFailsInsteadOfQueueingBytes() async {


### PR DESCRIPTION
## Summary

Remux was sending POSIX shell syntax directly to the server’s login shell. Fish and csh could reject that syntax before tmux was launched, causing valid connections and custom tmux paths to fail.

This change runs the tmux startup logic through `/bin/sh`, preserves the server’s existing `PATH`, and only reports tmux as unavailable when it actually cannot be found or executed.

## Testing

- Unit tests pass.
- Verified tmux connections through Fish, csh, and tcsh.
- Verified both standard command lookup and custom executable paths.
- Verified the complete connection flow in the simulator.