### PR TITLE
show tmux window names in the window picker

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -195,6 +195,7 @@ struct GhosttyWindowSelectionSheet: View {
                 } label: {
                     GhosttyWindowSelectionTile(
                         displayIndex: window.displayIndex,
+                        displayName: window.displayName,
                         totalCount: window.totalCount,
                         paneCount: window.paneCount,
                         isSelected: window.isSelected,
@@ -657,6 +658,7 @@ private struct GhosttyRenderedPreviewSurface: View {
 
 private struct GhosttyWindowSelectionTile: View {
     let displayIndex: Int
+    let displayName: String
     let totalCount: Int
     let paneCount: Int
     let isSelected: Bool
@@ -667,7 +669,7 @@ private struct GhosttyWindowSelectionTile: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             previewSurface
-            captionRow
+            caption
         }
         .padding(layout.tilePadding)
         .frame(
@@ -709,31 +711,41 @@ private struct GhosttyWindowSelectionTile: View {
         }
     }
 
-    private var captionRow: some View {
-        HStack(spacing: 6) {
-            Text("\(displayIndex)")
-                .font(.system(size: 11, weight: .semibold))
-                .monospacedDigit()
-                .foregroundStyle(GhosttySheetPalette.tertiary)
+    private var caption: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text("\(displayIndex)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(GhosttySheetPalette.tertiary)
+
+                if !displayName.isEmpty {
+                    Text(displayName)
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(GhosttySheetPalette.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer(minLength: 0)
+
+                if isSelected {
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(chromeStyle.accent)
+                            .frame(width: 6, height: 6)
+
+                        Text("active")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(chromeStyle.accent)
+                    }
+                }
+            }
 
             Text(paneCountLabel)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(GhosttySheetPalette.secondary)
                 .lineLimit(1)
-
-            Spacer(minLength: 0)
-
-            if isSelected {
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(chromeStyle.accent)
-                        .frame(width: 6, height: 6)
-
-                    Text("active")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(chromeStyle.accent)
-                }
-            }
         }
         .padding(.horizontal, 2)
     }
@@ -745,10 +757,11 @@ private struct GhosttyWindowSelectionTile: View {
     private var accessibilityLabel: String {
         let paneText = "\(paneCount) \(paneCount == 1 ? "pane" : "panes")"
         let positional = "Window \(displayIndex) of \(totalCount)"
+        let named = displayName.isEmpty ? positional : "\(positional), \(displayName)"
         if isSelected {
-            return "\(positional), \(paneText), active"
+            return "\(named), \(paneText), active"
         }
-        return "\(positional), \(paneText)"
+        return "\(named), \(paneText)"
     }
 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -728,30 +728,21 @@ private struct GhosttyWindowSelectionTile: View {
                 }
 
                 Spacer(minLength: 0)
-
-                if isSelected {
-                    HStack(spacing: 4) {
-                        Circle()
-                            .fill(chromeStyle.accent)
-                            .frame(width: 6, height: 6)
-
-                        Text("active")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(chromeStyle.accent)
-                    }
-                }
             }
 
-            Text(paneCountLabel)
+            if paneCount > 1 {
+                HStack(spacing: 6) {
+                    Text("\(paneCount)")
+                        .monospacedDigit()
+
+                    Text("panes")
+                }
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(GhosttySheetPalette.secondary)
                 .lineLimit(1)
+            }
         }
         .padding(.horizontal, 2)
-    }
-
-    private var paneCountLabel: String {
-        "\(paneCount) \(paneCount == 1 ? "pane" : "panes")"
     }
 
     private var accessibilityLabel: String {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -826,19 +826,12 @@ private struct GhosttyPaneSelectionTile: View {
 
     private var captionRow: some View {
         HStack(spacing: 6) {
+            Text("\(displayIndex)")
+                .font(.system(size: 11, weight: .semibold))
+                .monospacedDigit()
+                .foregroundStyle(GhosttySheetPalette.tertiary)
+
             Spacer(minLength: 0)
-
-            if isSelected {
-                HStack(spacing: 4) {
-                    Circle()
-                        .fill(chromeStyle.accent)
-                        .frame(width: 6, height: 6)
-
-                    Text("active")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(chromeStyle.accent)
-                }
-            }
         }
         .padding(.horizontal, 2)
     }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalPresentationProjector.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalPresentationProjector.swift
@@ -252,6 +252,7 @@ struct GhosttyPaneSelectionSheetTopologyProjection: Equatable, Sendable {
 struct GhosttyWindowSelectionSheetRenderProjection: Equatable, Sendable {
     struct Window: Identifiable, Equatable, Sendable {
         let id: UUID
+        let displayName: String
         let displayIndex: Int
         let totalCount: Int
         let paneCount: Int
@@ -475,6 +476,7 @@ enum GhosttyTerminalPresentationProjector {
         let windows = topLevels.enumerated().map { index, topLevel in
             GhosttyWindowSelectionSheetRenderProjection.Window(
                 id: topLevel.id,
+                displayName: displaySafeWindowName(topLevel.name),
                 displayIndex: index + 1,
                 totalCount: totalCount,
                 paneCount: topLevel.leafIDs.count,
@@ -489,6 +491,13 @@ enum GhosttyTerminalPresentationProjector {
             previewLeafIDs: windows.compactMap(\.focusedPreviewPaneID),
             cellCount: totalCount
         )
+    }
+
+    private static func displaySafeWindowName(_ name: String) -> String {
+        name.unicodeScalars.reduce(into: "") { result, scalar in
+            guard scalar.properties.generalCategory != .control else { return }
+            result.unicodeScalars.append(scalar)
+        }
     }
 
     static func paneSelectionSheetRenderProjection(

--- a/RemuxApp/Sources/Ghostty/GhosttyTopLevelSurface.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTopLevelSurface.swift
@@ -2,15 +2,18 @@ import Foundation
 
 struct GhosttyTopLevelSurface: Identifiable, Equatable {
     let id: UUID
+    let name: String
     let leafIDs: [UUID]
     let focusedLeafID: UUID?
 
     init(
         id: UUID = UUID(),
+        name: String = "",
         leafIDs: [UUID],
         focusedLeafID: UUID? = nil
     ) {
         self.id = id
+        self.name = name
         self.leafIDs = leafIDs
         self.focusedLeafID = focusedLeafID.flatMap { leafIDs.contains($0) ? $0 : nil }
     }

--- a/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
+++ b/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
@@ -31,6 +31,7 @@ enum PanePreviewLayout {
     private static let defaultPreviewAspectRatio: CGFloat = 4.0 / 3.0
     private static let tilePadding: CGFloat = 8
     private static let captionHeight: CGFloat = 14
+    private static let windowCaptionHeight: CGFloat = 30
     private static let tileCaptionSpacing: CGFloat = 6
     private static let sheetChromeHeight: CGFloat = 162
     private static let maxSingleTileWidth: CGFloat = 390
@@ -118,7 +119,7 @@ enum PanePreviewLayout {
         )
         let previewWidth = max(1, tileWidth - tilePadding * 2)
         let previewHeight = ceil(previewWidth / defaultPreviewAspectRatio)
-        let tileHeight = previewHeight + tileCaptionSpacing + captionHeight + tilePadding * 2
+        let tileHeight = previewHeight + tileCaptionSpacing + windowCaptionHeight + tilePadding * 2
         let rowCount = Int(ceil(Double(cellCount) / Double(columnCount)))
         let gridHeight = CGFloat(rowCount) * tileHeight +
             CGFloat(max(rowCount - 1, 0)) * windowGridSpacing

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
@@ -28,7 +28,7 @@ enum SSHTmuxControlCommandBuilder {
         #"tmux=$(printf %b "$1")"#,
         #"session=$(printf %b "$2")"#,
         #"resolved=$(command -v "$tmux" 2> /dev/null)"#,
-        #"if [ -x "$resolved" ]; then exec "$resolved" -C new-session -A -s "$session" -x "$3" -y "$4"; fi"#,
+        #"if [ -x "$resolved" ]; then exec "$resolved" -u -C new-session -A -s "$session" -x "$3" -y "$4"; fi"#,
         #"if [ -e "$tmux" ]; then echo "\#(tmuxNotExecutableMarker): $tmux" >&2; exit 126; fi"#,
         #"echo "\#(tmuxNotFoundMarker): $tmux" >&2"#,
         "exit 127",

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -1,6 +1,14 @@
 import Foundation
 import GhosttyKit
 
+private func decodeTmuxString(_ bytes: ghostty_tmux_bytes_s) -> String {
+    guard let pointer = bytes.ptr, bytes.len > 0 else { return "" }
+    return String(
+        decoding: UnsafeBufferPointer(start: pointer, count: bytes.len),
+        as: UTF8.self
+    )
+}
+
 /// Queue-confined host for Ghostty's sans-I/O tmux control client.
 ///
 /// The SSH transport owns the wire. This type owns protocol parsing, copied
@@ -29,6 +37,7 @@ final class TmuxSessionController: @unchecked Sendable {
 
     struct WindowInfo: Equatable, Identifiable, Sendable {
         let id: TmuxWindowID
+        let name: String
         let active: Bool
         let zoomed: Bool
         let width: UInt32
@@ -394,7 +403,7 @@ final class TmuxSessionController: @unchecked Sendable {
             deferredNavigationIntent = nil
             successfulMutationRequiredAfterRevision = nil
             let exit = action.value.exit
-            let detail = Self.copyString(exit.detail)
+            let detail = decodeTmuxString(exit.detail)
             switch exit.reason {
             case GHOSTTY_TMUX_EXIT_UNSUPPORTED_VERSION:
                 publishState(.closed(.unsupportedVersion(detail)))
@@ -414,7 +423,7 @@ final class TmuxSessionController: @unchecked Sendable {
             handleCommandCompletion(action.value.command)
 
         case GHOSTTY_TMUX_ACTION_INPUT_FAILED:
-            _ = Self.copyString(action.value.input_failure)
+            _ = decodeTmuxString(action.value.input_failure)
             DispatchQueue.main.async { self.callbacks.onRequestFailed(.sendInput) }
 
         default:
@@ -442,7 +451,7 @@ final class TmuxSessionController: @unchecked Sendable {
         }
 
         let snapshot = TopologySnapshot(
-            sessionName: Self.copyString(action.session_name),
+            sessionName: decodeTmuxString(action.session_name),
             windows: accumulator.windows,
             panes: accumulator.panes,
             activeWindowID: accumulator.windows.first(where: \.active)?.id
@@ -581,7 +590,7 @@ final class TmuxSessionController: @unchecked Sendable {
         case GHOSTTY_TMUX_COMMAND_SKIPPED:
             break
         case GHOSTTY_TMUX_COMMAND_ERROR_BLOCK:
-            _ = Self.copyString(completion.body)
+            _ = decodeTmuxString(completion.body)
             DispatchQueue.main.async { self.callbacks.onRequestFailed(request) }
         default:
             DispatchQueue.main.async { self.callbacks.onRequestFailed(request) }
@@ -1317,7 +1326,7 @@ final class TmuxSessionController: @unchecked Sendable {
     ) -> Result<String, PaneCurrentDirectoryError> {
         switch completion.status {
         case GHOSTTY_TMUX_COMMAND_SUCCESS:
-            let path = Self.copyString(completion.body)
+            let path = decodeTmuxString(completion.body)
                 .trimmingCharacters(in: .newlines)
             guard path.hasPrefix("/"),
                   !path.contains("\0"),
@@ -1328,7 +1337,7 @@ final class TmuxSessionController: @unchecked Sendable {
         case GHOSTTY_TMUX_COMMAND_SKIPPED:
             return .failure(.commandSkipped)
         case GHOSTTY_TMUX_COMMAND_ERROR_BLOCK:
-            let detail = Self.copyString(completion.body)
+            let detail = decodeTmuxString(completion.body)
                 .trimmingCharacters(in: .newlines)
             return .failure(.commandFailed(detail))
         default:
@@ -1366,13 +1375,6 @@ final class TmuxSessionController: @unchecked Sendable {
         return topology.windows.first(where: { $0.id == windowID })?.activePaneID
     }
 
-    private static func copyString(_ bytes: ghostty_tmux_bytes_s) -> String {
-        guard let pointer = bytes.ptr, bytes.len > 0 else { return "" }
-        return String(
-            decoding: UnsafeBufferPointer(start: pointer, count: bytes.len),
-            as: UTF8.self
-        )
-    }
 }
 
 private struct TopologyAccumulator {
@@ -1385,6 +1387,7 @@ private struct TopologyAccumulator {
             let window = record.value.window
             windows.append(TmuxSessionController.WindowInfo(
                 id: TmuxWindowID(window.id),
+                name: decodeTmuxString(window.name),
                 active: window.active,
                 zoomed: window.zoomed,
                 width: Self.uint32(window.width),

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -155,6 +155,7 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
                 .map { identities.surfaceID(for: $0.id) }
             return GhosttyTopLevelSurface(
                 id: identities.surfaceID(for: window.id),
+                name: window.name,
                 leafIDs: paneIDs,
                 focusedLeafID: window.activePaneID.map { identities.surfaceID(for: $0) }
             )

--- a/RemuxAppTests/GhosttyTerminalPresentationProjectorTests.swift
+++ b/RemuxAppTests/GhosttyTerminalPresentationProjectorTests.swift
@@ -464,6 +464,30 @@ final class GhosttyTerminalPresentationProjectorTests: XCTestCase {
         XCTAssertNotEqual(projection.viewport.surfaceID, paneID)
     }
 
+    func testWindowSelectionProjectionRemovesControlScalarsOnceAndPreservesUnicode() throws {
+        let windowID = UUID()
+        let paneID = UUID()
+        let snapshot = GhosttyRuntimeSurfaceTopologySnapshot(
+            topLevels: [
+                GhosttyTopLevelSurface(
+                    id: windowID,
+                    name: "dé\u{0001}ploy\n-漢字",
+                    leafIDs: [paneID],
+                    focusedLeafID: paneID
+                ),
+            ],
+            selectedTopLevelID: windowID
+        )
+
+        let projection = GhosttyTerminalPresentationProjector
+            .windowSelectionSheetRenderProjection(snapshot: snapshot)
+
+        XCTAssertEqual(
+            try XCTUnwrap(projection.windows.first).displayName,
+            "déploy-漢字"
+        )
+    }
+
     func testTerminalReadyTraceFieldsPreserveExistingKeysAndAddRawReadinessFacts() throws {
         let workspaceID = try XCTUnwrap(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
         let selectedLeafID = try XCTUnwrap(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))

--- a/RemuxAppTests/PanePreviewLayoutTests.swift
+++ b/RemuxAppTests/PanePreviewLayoutTests.swift
@@ -43,15 +43,15 @@ final class PanePreviewLayoutTests: XCTestCase {
         let metrics = PanePreviewLayout.windowMetrics(cellCount: 2, availableWidth: 361)
 
         XCTAssertEqual(metrics.columnCount, 2)
-        XCTAssertEqual(metrics.tilePointSize, CGSize(width: 175, height: 156))
+        XCTAssertEqual(metrics.tilePointSize, CGSize(width: 175, height: 172))
         XCTAssertEqual(metrics.previewPointSize, CGSize(width: 159, height: 120))
-        XCTAssertEqual(metrics.sheetDetent, .fixed(318))
+        XCTAssertEqual(metrics.sheetDetent, .fixed(334))
     }
 
     func testWindowGridUsesLargeDetentAfterThreeRows() {
         XCTAssertEqual(
             PanePreviewLayout.windowMetrics(cellCount: 6, availableWidth: 361).sheetDetent,
-            .fixed(650)
+            .fixed(698)
         )
         XCTAssertEqual(
             PanePreviewLayout.windowMetrics(cellCount: 7, availableWidth: 361).sheetDetent,

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -1311,7 +1311,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
 
         XCTAssertTrue(command.hasPrefix("exec /bin/sh -c '"))
         XCTAssertTrue(command.contains(#"PATH="${PATH:+$PATH:}/opt/homebrew/bin"#))
-        XCTAssertTrue(command.contains(#"exec "$resolved" -C new-session -A"#))
+        XCTAssertTrue(command.contains(#"exec "$resolved" -u -C new-session -A"#))
         XCTAssertTrue(command.hasSuffix(" 45 37"))
     }
 

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -72,7 +72,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ).utf8))
         let currentDirectory = try await query.value
         XCTAssertEqual(currentDirectory, "/Users/macbook/scratchpad")
-        await shutDown(harness.controller)
     }
 
     func testPaneCurrentDirectoryReturnsCommandFailureWithoutRequestFailureUI() async throws {
@@ -107,7 +106,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             )
         }
         await fulfillment(of: [requestFailure], timeout: 0.05)
-        await shutDown(harness.controller)
     }
 
     func testShutdownResumesOutstandingPaneCurrentDirectoryQuery() async throws {
@@ -201,7 +199,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "select-pane -Z -t %2",
             paneID: 2,
         )
-        await shutDown(harness.controller)
     }
 
     func testPaneNavigationWaitsWhenCommandEndsBeforeTopology() async throws {
@@ -253,7 +250,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
-        await shutDown(harness.controller)
     }
 
     func testPaneNavigationUsesTopologyThatArrivedBeforeCompletion() async throws {
@@ -293,7 +289,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "select-pane -Z -t %2",
             paneID: 2,
         )
-        await shutDown(harness.controller)
     }
 
     func testPaneNavigationWaitsWhenSubmittedAfterCompletionBeforeTopology() async throws {
@@ -335,7 +330,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "select-pane -Z -t %2",
             paneID: 2,
         )
-        await shutDown(harness.controller)
     }
 
     func testPaneNavigationReevaluatesImmediatelyAfterCommandError() async throws {
@@ -363,7 +357,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "select-pane -Z -t %2",
             paneID: 2,
         )
-        await shutDown(harness.controller)
     }
 
     func testFailedPresentationRetryKeepsSameTargetRefreshAfterInFlightCompletion() async throws {
@@ -415,7 +408,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
-        await shutDown(harness.controller)
     }
 
     func testRepeatedCrossWindowUnzoomedSelectionDoesNotQueueSecondToggle() async throws {
@@ -449,7 +441,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             harness.recorder.takeStrings().isEmpty,
             "the repeated intent must re-evaluate as zero after the first group zooms"
         )
-        await shutDown(harness.controller)
     }
 
     func testDeferredZoomDoesNotToggleAfterWindowSelectionAlreadyZooms() async throws {
@@ -483,7 +474,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             harness.recorder.takeStrings().isEmpty,
             "the deferred zoom must re-evaluate to a no-op after the selection group zooms"
         )
-        await shutDown(harness.controller)
     }
 
     func testWindowNavigationCoalescesRollbackToLatestWindow() async throws {
@@ -504,7 +494,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
         XCTAssertEqual(harness.recorder.takeStrings(), ["select-window -t @0\n"])
-        await shutDown(harness.controller)
     }
 
     func testColdSplitSelectionEnqueuesPresentationThenRefreshInOneWrite() async throws {
@@ -521,7 +510,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "resize-pane -Z -t %2",
             paneID: 2,
         )
-        await shutDown(harness.controller)
     }
 
     func testRefreshCompletionReleasesReadinessWithoutSecondTerminalHandoff() async throws {
@@ -558,7 +546,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         }
 
         XCTAssertEqual(lifecycle.terminalPaneIDs, initialTerminalPaneIDs)
-        await shutDown(harness.controller)
     }
 
     func testTopBottomRoundTripRefreshesEachFullToSplitGridChange() async throws {
@@ -594,7 +581,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             command: "select-pane -Z -t %0",
             paneID: 0,
         )
-        await shutDown(harness.controller)
     }
 
     func testClientSizeRefreshesForRowOrColumnChangesInOneWrite() async throws {
@@ -637,7 +623,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             write.hasPrefix("refresh-client -C 100x40\ndisplay-message -p -t %0 ")
         )
         XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 4)
-        await shutDown(harness.controller)
     }
 
     func testInFlightGridRefreshFollowsViewportRevertExactlyOnce() async throws {
@@ -684,7 +669,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
-        await shutDown(harness.controller)
     }
 
     func testNewWindowAndSplitCommandsDoNotGainRefreshWork() async throws {
@@ -704,7 +688,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSplit(paneID: 0, direction: .right, zoom: true)
         await drain(harness.controller)
         XCTAssertEqual(harness.recorder.takeStrings(), ["split-window -h -Z -t %0\n"])
-        await shutDown(harness.controller)
     }
 
     func testNotReadyRefreshRetriesOnceAndDrainsAfterInitialPaneChanged() async throws {
@@ -733,7 +716,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         let write = try XCTUnwrap(writes.first)
         XCTAssertTrue(write.hasPrefix("display-message -p -t %1 "))
         XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 4)
-        await shutDown(harness.controller)
     }
 
     func testTopologyRemovalClearsDeferredPaneRefresh() async throws {
@@ -761,7 +743,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             [],
             "a removed pane must not retry its deferred refresh"
         )
-        await shutDown(harness.controller)
     }
 
     func testDetachedRequestReportsImmediateFailure() async throws {
@@ -869,6 +850,11 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         let runtime = try GhosttyKitRuntime()
         let recorder = ControllerOutboundRecorder()
         let controller = TmuxSessionController(callbacks: callbacks)
+        addTeardownBlock {
+            await withCheckedContinuation { continuation in
+                controller.shutdown { continuation.resume() }
+            }
+        }
         controller.setOutboundSink { recorder.append($0) }
         await drain(controller)
         try await withCheckedThrowingContinuation { continuation in
@@ -1011,33 +997,85 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTFail(failureMessage)
     }
 
-    private static let threePaneZoomedWindow =
-        "$42 @0 1 %0 83 44 "
-        + "85ff,83x44,0,0{27x44,0,0,0,27x44,28,0,1,27x44,56,0,2} "
-        + "b7dd,83x44,0,0,0\n"
+    private static let threePaneZoomedWindow = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "85ff,83x44,0,0{27x44,0,0,0,27x44,28,0,1,27x44,56,0,2}",
+        visibleLayout: "b7dd,83x44,0,0,0",
+        name: "window-0"
+    )
 
-    private static let splitTargetWindow =
-        "$42 @0 1 %0 83 44 b7dd,83x44,0,0,0 b7dd,83x44,0,0,0\n"
-        + "$42 @1 0 %1 83 44 "
-        + "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2} "
-        + "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}\n"
+    private static let splitTargetWindow = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "b7dd,83x44,0,0,0",
+        visibleLayout: "b7dd,83x44,0,0,0",
+        name: "window-0"
+    ) + windowRecord(
+        id: 1,
+        active: false,
+        paneID: 1,
+        layout: "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}",
+        visibleLayout: "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}",
+        name: "window-1"
+    )
 
-    private static let twoSinglePaneWindows =
-        "$42 @0 1 %0 83 44 b7dd,83x44,0,0,0 b7dd,83x44,0,0,0\n"
-        + "$42 @1 0 %1 83 44 b7de,83x44,0,0,1 b7de,83x44,0,0,1\n"
+    private static let twoSinglePaneWindows = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "b7dd,83x44,0,0,0",
+        visibleLayout: "b7dd,83x44,0,0,0",
+        name: "window-0"
+    ) + windowRecord(
+        id: 1,
+        active: false,
+        paneID: 1,
+        layout: "b7de,83x44,0,0,1",
+        visibleLayout: "b7de,83x44,0,0,1",
+        name: "window-1"
+    )
 
-    private static let onePaneWindow =
-        "$42 @0 1 %0 83 44 b7dd,83x44,0,0,0 b7dd,83x44,0,0,0\n"
+    private static let onePaneWindow = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "b7dd,83x44,0,0,0",
+        visibleLayout: "b7dd,83x44,0,0,0",
+        name: "window-0"
+    )
 
-    private static let twoPaneUnzoomedWindow =
-        "$42 @1 1 %1 83 44 "
-        + "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2} "
-        + "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}\n"
+    private static let twoPaneUnzoomedWindow = windowRecord(
+        id: 1,
+        active: true,
+        paneID: 1,
+        layout: "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}",
+        visibleLayout: "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}",
+        name: "window-1"
+    )
 
-    private static let twoPaneSameColumnZoomedWindow =
-        "$42 @0 1 %0 83 44 "
-        + "607b,83x44,0,0[83x22,0,0,0,83x21,0,23,1] "
-        + "b7dd,83x44,0,0,0\n"
+    private static let twoPaneSameColumnZoomedWindow = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "607b,83x44,0,0[83x22,0,0,0,83x21,0,23,1]",
+        visibleLayout: "b7dd,83x44,0,0,0",
+        name: "window-0"
+    )
+
+    private static func windowRecord(
+        id: Int,
+        active: Bool,
+        paneID: Int,
+        layout: String,
+        visibleLayout: String,
+        name: String
+    ) -> String {
+        "$42 @\(id) \(active ? 1 : 0) %\(paneID) 83 44 "
+            + "\(layout) \(visibleLayout) \(name)\n"
+    }
 }
 
 private actor RequestFailureRecorder {

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -885,7 +885,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             [
                 "display-message -p '#{version}'\n"
                     + "refresh-client -C 83x44\n"
-                    + "list-windows -F '#{session_id} #{window_id} #{window_active} #{pane_id} #{window_width} #{window_height} #{window_layout} #{window_visible_layout}'\n"
+                    + "list-windows -F '#{session_id} #{window_id} #{window_active} #{pane_id} #{window_width} #{window_height} #{window_layout} #{window_visible_layout} #{window_name}'\n"
             ]
         )
         controller.pump(Data(

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -45,10 +45,12 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         id: TmuxWindowID,
         active: Bool,
         paneID: TmuxPaneID?,
+        name: String = "",
         zoomed: Bool = true
     ) -> TmuxSessionController.WindowInfo {
         TmuxSessionController.WindowInfo(
             id: id,
+            name: name,
             active: active,
             zoomed: zoomed,
             width: 80,

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -88,8 +88,8 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         let twoWindows = TmuxSessionController.TopologySnapshot(
             sessionName: "fresh-test",
             windows: [
-                window(id: 1, active: true, paneID: 10),
-                window(id: 2, active: false, paneID: 20)
+                window(id: 1, active: true, paneID: 10, name: "editor"),
+                window(id: 2, active: false, paneID: 20, name: "logs")
             ],
             panes: [pane(id: 10, windowID: 1), pane(id: 20, windowID: 2)],
             activeWindowID: 1
@@ -101,12 +101,13 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
             first.windows.count, 2,
             "the first emitted topology must project immediately, not lag one update behind"
         )
+        XCTAssertEqual(first.windows.map(\.displayName), ["editor", "logs"])
         let firstPaneSurfaceID = try XCTUnwrap(first.previewLeafIDs.first)
         XCTAssertEqual(adapter.tmuxPaneID(for: firstPaneSurfaceID), 10)
 
         let oneWindow = TmuxSessionController.TopologySnapshot(
             sessionName: "fresh-test",
-            windows: [window(id: 1, active: true, paneID: 10)],
+            windows: [window(id: 1, active: true, paneID: 10, name: "renamed")],
             panes: [pane(id: 10, windowID: 1)],
             activeWindowID: 1
         )
@@ -118,7 +119,58 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
             "removing a non-current window must drop its tile on the same topology update"
         )
         XCTAssertEqual(second.windows.first?.totalCount, 1)
+        XCTAssertEqual(second.windows.first?.displayName, "renamed")
         XCTAssertEqual(second.cellCount, 1)
+
+        await session.shutdown()
+    }
+
+    func testNameOnlyTopologyUpdatePreservesSurfaceIdentityAndPanePreview() async throws {
+        let runtime = try GhosttyKitRuntime()
+        let session = makeSession(runtime: runtime)
+        let adapter = TmuxTerminalScreenAdapter()
+        adapter.activate(
+            session: session,
+            initialViewportHandler: { _, _ in },
+            clientSizeHandler: { _ in },
+            viewportStabilityHandler: { _ in }
+        )
+
+        let initial = TmuxSessionController.TopologySnapshot(
+            sessionName: "rename-test",
+            windows: [window(id: 1, active: true, paneID: 10, name: "editor")],
+            panes: [pane(id: 10, windowID: 1)],
+            activeWindowID: 1
+        )
+        session.handleTopology(initial)
+        let before = adapter.windowSelectionSheetRenderProjection()
+        let beforeWindowID = try XCTUnwrap(before.windows.first?.id)
+        let beforePaneID = try XCTUnwrap(before.previewLeafIDs.first)
+
+        let image = try makeImage(width: 4, height: 4)
+        var cache = TmuxPanePreviewImageCache(byteLimit: 1_024)
+        cache.store(preview(image), for: 10)
+        let initialByteCost = cache.totalByteCost
+
+        let renamed = TmuxSessionController.TopologySnapshot(
+            sessionName: "rename-test",
+            windows: [window(id: 1, active: true, paneID: 10, name: "déploy-漢字")],
+            panes: [pane(id: 10, windowID: 1)],
+            activeWindowID: 1
+        )
+        session.handleTopology(renamed)
+        let after = adapter.windowSelectionSheetRenderProjection()
+
+        XCTAssertEqual(after.windows.first?.displayName, "déploy-漢字")
+        XCTAssertEqual(after.windows.first?.id, beforeWindowID)
+        XCTAssertEqual(after.previewLeafIDs.first, beforePaneID)
+        XCTAssertEqual(
+            cache.retainOnly(Set(renamed.panes.map(\.id))),
+            [],
+            "a name-only topology update must not evict any pane preview"
+        )
+        XCTAssertTrue(cache.preview(for: 10)?.image === image)
+        XCTAssertEqual(cache.totalByteCost, initialByteCost)
 
         await session.shutdown()
     }

--- a/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
+++ b/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
@@ -214,6 +214,7 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
     ) -> TmuxSessionController.WindowInfo {
         .init(
             id: id,
+            name: "",
             active: active,
             zoomed: zoomed,
             width: 80,

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -767,6 +767,80 @@ final class RemuxAppUITests: XCTestCase {
         recordLiveTmuxWindowCaptureExpectation(sessionName: sessionName, windowIndex: 10, marker: marker)
     }
 
+    func testLiveWindowNamesAndRenameWhenConfigured() throws {
+        let sessionName: String
+        if let override = liveSessionNameOverride() {
+            guard override.range(
+                of: #"^remux-latency-[A-Za-z0-9._-]+$"#,
+                options: .regularExpression
+            ) != nil else {
+                throw LiveSSHCleanupHarnessError(
+                    description: "Refusing unsafe window-name fixture session \(override)."
+                )
+            }
+            sessionName = override
+        } else {
+            sessionName = try generatedLiveLatencySessionName("window-names")
+        }
+        defer {
+            cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+        }
+
+        try launchLiveSSHAppIfConfigured(traceRuntime: true, sessionNameOverride: sessionName)
+        openFirstSavedSession()
+        waitForLiveTerminalReady(timeout: 90)
+
+        sendTerminalCommand(
+            "tmux rename-window 'editor workspace'; tmux new-window -d -n 'build logs'"
+        )
+        hideKeyboardIfPresent()
+
+        openWindowsSheet()
+        let firstWindow = app.buttons["terminal.window.tile.1"]
+        let secondWindow = app.buttons["terminal.window.tile.2"]
+        XCTAssertTrue(firstWindow.waitForExistence(timeout: 10))
+        XCTAssertTrue(secondWindow.waitForExistence(timeout: 10))
+        wait(
+            for: [
+                expectation(
+                    for: NSPredicate(format: "label CONTAINS %@", "editor workspace"),
+                    evaluatedWith: firstWindow
+                ),
+                expectation(
+                    for: NSPredicate(format: "label CONTAINS %@", "build logs"),
+                    evaluatedWith: secondWindow
+                ),
+            ],
+            timeout: 20
+        )
+        attach(name: "live-window-names-initial")
+
+        dismissTopSheetIfPresent()
+        waitForLiveTerminalReady(timeout: 30)
+        sendTerminalCommand("tmux rename-window 'déploy-漢字'")
+        hideKeyboardIfPresent()
+
+        openWindowsSheet()
+        let renamedWindow = app.buttons["terminal.window.tile.1"]
+        XCTAssertTrue(renamedWindow.waitForExistence(timeout: 10))
+        wait(
+            for: [
+                expectation(
+                    for: NSPredicate(format: "label CONTAINS %@", "déploy-漢字"),
+                    evaluatedWith: renamedWindow
+                ),
+            ],
+            timeout: 20
+        )
+        XCTAssertTrue(
+            app.buttons["terminal.window.tile.2"].label.contains("build logs"),
+            "Renaming one window should preserve the other window's name."
+        )
+        attach(name: "live-window-name-unicode-renamed")
+
+        recordLiveTmuxWindowCountExpectation(sessionName: sessionName, expectedCount: 2)
+    }
+
     func testLiveDenseMixedTopologySelectsDeepPaneWhenConfigured() throws {
         try requireLivePreparedFixture("dense-mixed")
 

--- a/scripts/fetch_ghosttykit.sh
+++ b/scripts/fetch_ghosttykit.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # places it at the path configured in project.yml, so building Remux does not
 # require Zig or a Ghostty checkout.
 
-release_tag="ghosttykit-20260720"
-asset_sha256="2b12e269554af29b08636f29a916fb8f8d3f0788c0623576755a6dc38cb8568c"
+release_tag="ghosttykit-20260726"
+asset_sha256="e5137e3b5c866b9105d631d994e84e12d8c2bede253bb4e60e17900bd158563c"
 asset_url="https://github.com/h3nock/remux-ghostty/releases/download/${release_tag}/GhosttyKit.xcframework.zip"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/remux_live_ui_test_with_cleanup.sh
+++ b/scripts/remux_live_ui_test_with_cleanup.sh
@@ -283,6 +283,9 @@ for target in "${only_testing[@]}"; do
     *testLiveSSHTmuxActionCycleWhenConfigured)
       fixture_session="remux-latency-action-${stamp}"
       ;;
+    *testLiveWindowNamesAndRenameWhenConfigured)
+      fixture_session="remux-latency-window-names-${stamp}"
+      ;;
     *testLiveDenseMixedTopologySelectsDeepPaneWhenConfigured)
       fixture_name="dense-mixed"
       fixture_session="remux-latency-dense-mixed-${stamp}"


### PR DESCRIPTION
## Summary

This shows tmux window names in the window picker and keeps them updated when a window is renamed.

- carry window names from GhosttyKit into the app’s tmux topology
- start tmux control clients in UTF-8 mode
- show the window number and name together
- hide the pane count for windows with only one pane
- use the selection border instead of an “active” label in the window and pane pickers
- update the pinned GhosttyKit release for window-name support

## Testing

- Added tests for window-name propagation and rename updates.
- Tested the window and pane pickers on a physical device with Unicode names, live renames, and one- and multi-pane windows.