### PR TITLE
Fix keyboard dismissal race after Ctrl activation

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
@@ -40,6 +40,10 @@ struct GhosttyTerminalInputCoordinator: Equatable {
         isSoftwareKeyboardVisible = isVisible
 
         if isVisible {
+            // Presentation can finish after the user has already asked to
+            // dismiss the keyboard. Keep that explicit dismissal authoritative
+            // until UIKit confirms the keyboard is hidden.
+            guard !isDismissSystemKeyboardRequested else { return }
             isDismissSystemKeyboardRequested = false
             keyboardMode = keyboardMode.applyingSystemKeyboardVisibility(true)
             return

--- a/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
+++ b/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
@@ -62,6 +62,24 @@ final class GhosttyTerminalInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.isSoftwareKeyboardVisible)
     }
 
+    func testLateKeyboardShowDoesNotCancelExplicitDismissal() {
+        var coordinator = GhosttyTerminalInputCoordinator()
+        coordinator.showSystemKeyboard(isInputAvailable: true)
+        coordinator.toggleKeyboard(isInputAvailable: true)
+
+        coordinator.updateSoftwareKeyboardVisibility(true)
+
+        XCTAssertEqual(coordinator.keyboardMode, .hidden)
+        XCTAssertTrue(coordinator.isDismissSystemKeyboardRequested)
+        XCTAssertTrue(coordinator.isSoftwareKeyboardVisible)
+
+        coordinator.updateSoftwareKeyboardVisibility(false)
+
+        XCTAssertEqual(coordinator.keyboardMode, .hidden)
+        XCTAssertFalse(coordinator.isDismissSystemKeyboardRequested)
+        XCTAssertFalse(coordinator.isSoftwareKeyboardVisible)
+    }
+
     func testKeyboardVisibilityHidePreservesSystemModeWithoutExplicitDismissal() {
         var coordinator = GhosttyTerminalInputCoordinator()
         coordinator.showSystemKeyboard(isInputAvailable: true)


### PR DESCRIPTION
## Summary

Fixes the keyboard requiring a second tap to close after it was opened with Ctrl.

A late keyboard visibility event could override the first dismissal request. This keeps dismissal active until the keyboard is confirmed hidden.

## Testing

- Added regression coverage
- Verified in the simulator and on a physical device