### PR TITLE
Add configurable physical keyboard controls

### DIFF
--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */; };
 		AA0449DB0EEBE5F640BF6B79 /* GhosttyTerminalInputCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29658D4FE019C12073CC58BE /* GhosttyTerminalInputCoordinator.swift */; };
 		AB2DBE12494A327FBC54FF9D /* GhosttyScrollDeltaBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09E9400D2638AE72F1CEBFB /* GhosttyScrollDeltaBudgetTests.swift */; };
+		AF8E5918198DF16860CD6B31 /* CommandPaletteSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D2F772505F015FC57F02D0 /* CommandPaletteSearchTests.swift */; };
 		B056E6334A9EFBDB7FA305B3 /* TerminalPreviewCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FB23E143EA43A7AB28A323 /* TerminalPreviewCandidateTests.swift */; };
 		B3BF6CDA8110A71C8BDF0F85 /* GhosttyTmuxPrefixInputBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A510F3E8FC22231ACA4A8A99 /* GhosttyTmuxPrefixInputBuffer.swift */; };
 		B64AE1F77F8F69A612E230AD /* GhosttyTerminalResponderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05107088F3540B7C04D2007 /* GhosttyTerminalResponderViewTests.swift */; };
@@ -154,6 +155,7 @@
 		C37BEA72EEFDD7041F8E4059 /* GhosttyManagedSurfaceLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0CE2626790CFB617C7B39A /* GhosttyManagedSurfaceLookup.swift */; };
 		C3A8DE373D7176A8536D9523 /* RemuxAppDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCD1093451DAA47FF649549 /* RemuxAppDependencies.swift */; };
 		C5524C488C1300697E572AD5 /* RemuxLibrarySSHPrewarmCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2693DBF11402EDAEC946123A /* RemuxLibrarySSHPrewarmCoordinator.swift */; };
+		CA1177766D082C0DB02CE1A9 /* TerminalViewportSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947B5FE1F16167F78D09A88D /* TerminalViewportSnapshot.swift */; };
 		CC4A4379786ED8153C849967 /* SSHTmuxControlCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F094A10EBF0BCD867A6B270C /* SSHTmuxControlCommandBuilder.swift */; };
 		CD12942E9BEC15344DADB7BC /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CBF1D7B0CCEAA8D032C1DDC /* RootView.swift */; };
 		CD72317822BBD2753878DCA2 /* RemuxSFTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3F9F61A40DD02A7DD80980 /* RemuxSFTPClient.swift */; };
@@ -169,8 +171,10 @@
 		D7E2EF5FBDBD0CC24FC29257 /* ShortcutExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B77D12E9FC8E4FF183EC209 /* ShortcutExecutorTests.swift */; };
 		D90BFAB652BCFFB9901C5E31 /* GhosttyPanePreviewSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45C3C2EE05C5EE81A6CC979 /* GhosttyPanePreviewSession.swift */; };
 		DBC5F67F490AAC96F4918650 /* GhosttyKitControlSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF4BB00F78EE94D58937F98A /* GhosttyKitControlSurfaceTests.swift */; };
+		DC7088E72BDAE7823BF1FD5C /* CommandPaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C51A8139FD4BAC6577F1E3 /* CommandPaletteView.swift */; };
 		DEC0360F7ED54DE71B345B60 /* GhosttyTerminalPresentationProjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D407500AB027C206B65EE7C /* GhosttyTerminalPresentationProjector.swift */; };
 		DED4088C1635F130FC578C91 /* GhosttyTmuxPrefixInputBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9F4B4B0260131778AB2BA5 /* GhosttyTmuxPrefixInputBufferTests.swift */; };
+		DEFC98EB6D7B25D1BD3568CB /* CommandPaletteSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD81AE3F80531F5DA9F3A415 /* CommandPaletteSearch.swift */; };
 		E0787109BFFDE0C211C26BFB /* GhosttyScrollPhysicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216C560F444E51EAEA88D748 /* GhosttyScrollPhysicsView.swift */; };
 		E0B03B6D9CC8D0372605DAF2 /* GhosttySurfaceMouseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4CAA9116316609CF030FC /* GhosttySurfaceMouseEvent.swift */; };
 		E1A024BDF4C05481D447C104 /* SSHTmuxControlChannelDataRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2BCC7F60325417F2E882FF /* SSHTmuxControlChannelDataRouter.swift */; };
@@ -326,6 +330,7 @@
 		8ECDF46DC2F389505455C283 /* GhosttySingleViewportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySingleViewportView.swift; sourceTree = "<group>"; };
 		902AC3DF91A828A0CCB5FCB2 /* TerminalSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettings.swift; sourceTree = "<group>"; };
 		947084E6DA45D9EFB946CF51 /* RemuxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxApp.swift; sourceTree = "<group>"; };
+		947B5FE1F16167F78D09A88D /* TerminalViewportSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewportSnapshot.swift; sourceTree = "<group>"; };
 		94DD2F30DD98DCF438F312FA /* ShortcutStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutStoreTests.swift; sourceTree = "<group>"; };
 		94F9DD0E0F418199C5E8C0F1 /* GhosttyModifierState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyModifierState.swift; sourceTree = "<group>"; };
 		96D76300C343320C6DE2D629 /* RemuxUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = RemuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -354,10 +359,13 @@
 		B4C7136948AF9803FAAD6F82 /* GhosttyKeyboardCursorTrackpad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardCursorTrackpad.swift; sourceTree = "<group>"; };
 		B7C4481BDC2A74CA510A39D4 /* GhosttyShortcutSurfacePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyShortcutSurfacePalette.swift; sourceTree = "<group>"; };
 		B86EF87FE53CC20522F3ACB8 /* PhysicalKeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKeyboardMonitor.swift; sourceTree = "<group>"; };
+		B8C51A8139FD4BAC6577F1E3 /* CommandPaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteView.swift; sourceTree = "<group>"; };
 		B94CC628E68FDC18E59E9D79 /* GhosttyAttachmentTray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentTray.swift; sourceTree = "<group>"; };
+		B9D2F772505F015FC57F02D0 /* CommandPaletteSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchTests.swift; sourceTree = "<group>"; };
 		B9F00A0064AC2897BDF34495 /* GhosttyKeyboardVisibilityProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardVisibilityProjectionTests.swift; sourceTree = "<group>"; };
 		BA66578016B8B2B62FF2332F /* TmuxConnectionDraftValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxConnectionDraftValidatorTests.swift; sourceTree = "<group>"; };
 		BC76333B637D49B9A27CB798 /* ShortcutPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutPalette.swift; sourceTree = "<group>"; };
+		BD81AE3F80531F5DA9F3A415 /* CommandPaletteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearch.swift; sourceTree = "<group>"; };
 		BF6CD3A6EEDAD871DB47B5CF /* GhosttyFlowTraceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyFlowTraceStoreTests.swift; sourceTree = "<group>"; };
 		C09E9400D2638AE72F1CEBFB /* GhosttyScrollDeltaBudgetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyScrollDeltaBudgetTests.swift; sourceTree = "<group>"; };
 		C18E95DAAAF9312AED56CC0F /* TmuxTerminalSessionShutdownDrainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxTerminalSessionShutdownDrainTests.swift; sourceTree = "<group>"; };
@@ -466,6 +474,8 @@
 			children = (
 				AE3BF5A0EC8A00A5D4142B0F /* AppKeyboardCommandResponder.swift */,
 				DC3563813041EFFF953954E9 /* AppKeyboardCommandRouter.swift */,
+				BD81AE3F80531F5DA9F3A415 /* CommandPaletteSearch.swift */,
+				B8C51A8139FD4BAC6577F1E3 /* CommandPaletteView.swift */,
 				700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */,
 				8926D94B4AAF192302FC58E4 /* Haptic.swift */,
 				4236F0B51C9AB66CAA48E022 /* KeyboardSettingsView.swift */,
@@ -491,6 +501,7 @@
 			isa = PBXGroup;
 			children = (
 				DC7FD25C85A9D4A1E9D4B4E5 /* AppKeyboardCommandRouterTests.swift */,
+				B9D2F772505F015FC57F02D0 /* CommandPaletteSearchTests.swift */,
 				28EE543D2B247AE6C6A8C472 /* ConnectionProfileRepositoryTests.swift */,
 				DFD9AF0371D15A892B000530 /* DebugConnectionProfileSeederTests.swift */,
 				2A1CB6877AF169792137FA56 /* GhosttyAttachmentImageMarkupRendererTests.swift */,
@@ -664,6 +675,7 @@
 				820136FA2586D2054D312C3D /* SSHPrivateKeyInspector.swift */,
 				771B767054F02C52F17EB92B /* StarterShortcuts.swift */,
 				902AC3DF91A828A0CCB5FCB2 /* TerminalSettings.swift */,
+				947B5FE1F16167F78D09A88D /* TerminalViewportSnapshot.swift */,
 				85665F143AC61F871841ED90 /* TmuxConnectionTarget.swift */,
 			);
 			path = Domain;
@@ -885,6 +897,8 @@
 				806CBC7343808C8E4FF50F28 /* AppKeyboardCommandResponder.swift in Sources */,
 				D330DAF4BD8A2777D857A603 /* AppKeyboardCommandRouter.swift in Sources */,
 				3F71D9F3D7782DCD769CF47E /* ApplicationStorage.swift in Sources */,
+				DEFC98EB6D7B25D1BD3568CB /* CommandPaletteSearch.swift in Sources */,
+				DC7088E72BDAE7823BF1FD5C /* CommandPaletteView.swift in Sources */,
 				E35A4C6758E1D06E01EE5826 /* ConnectionProfileRepository.swift in Sources */,
 				39A58132CBB849E2CDF37BC2 /* DebugConnectionProfileSeeder.swift in Sources */,
 				3266F0AE9A1F836618FF115D /* DeterministicTmuxControlTransport.swift in Sources */,
@@ -986,6 +1000,7 @@
 				0494A11A7D6207165CFCDAD7 /* TerminalSettings.swift in Sources */,
 				A0D6CF5A40A4953636A1928F /* TerminalSettingsRepository.swift in Sources */,
 				4D354C37600CA12E917B566F /* TerminalThemePreviewRenderer.swift in Sources */,
+				CA1177766D082C0DB02CE1A9 /* TerminalViewportSnapshot.swift in Sources */,
 				936B7642F2B8F0B072D9CF0B /* TmuxConnectionTarget.swift in Sources */,
 				4809C175892171E7B13557EF /* TmuxControlTransport.swift in Sources */,
 				59082855C99ADBA1145126DB /* TmuxControlViewport.swift in Sources */,
@@ -1015,6 +1030,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1BB2A85A017835D07C45C88 /* AppKeyboardCommandRouterTests.swift in Sources */,
+				AF8E5918198DF16860CD6B31 /* CommandPaletteSearchTests.swift in Sources */,
 				8F75231F2CF7E597F4D0347F /* ConnectionProfileRepositoryTests.swift in Sources */,
 				434C420D221F1CAF2A633602 /* DebugConnectionProfileSeederTests.swift in Sources */,
 				EE488E8B043F3160004A3C20 /* GhosttyAttachmentImageMarkupRendererTests.swift in Sources */,

--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -13,8 +13,10 @@
 		036AB1FE9FEBF1EF99159FD1 /* ShortcutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9987EA1F7B5FDC3A50ECEA /* ShortcutStore.swift */; };
 		03DF1618812075C8E5C9B353 /* GhosttyTerminalInputCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA264E3527C3F2FC33AF435 /* GhosttyTerminalInputCoordinatorTests.swift */; };
 		0494A11A7D6207165CFCDAD7 /* TerminalSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902AC3DF91A828A0CCB5FCB2 /* TerminalSettings.swift */; };
+		050F663B3541C6F716B4348B /* KeyboardSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739E2E47D56DEB0CBC3A9769 /* KeyboardSettings.swift */; };
 		06F0AA3040EBCD8B9229B237 /* RemuxRootModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F57C8C6D3F75E3E07DDC9 /* RemuxRootModel.swift */; };
 		077974905B6ABD611204F949 /* RemuxPreparedTransportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB62707ACD4905DCE40ECBFA /* RemuxPreparedTransportCoordinator.swift */; };
+		08DB6253090B3309F5BCA95A /* AppKeyboardCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D967C13C5A420C58657176B /* AppKeyboardCommand.swift */; };
 		1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */; };
 		14890862E5A8BFE9BE759DB0 /* GhosttySurfaceKeyEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E84F774C17B5C4DB6B715A9 /* GhosttySurfaceKeyEventTests.swift */; };
 		14BCD2766E4ED765F45BA3AD /* GhosttyPanePreviewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07301EEDA55AAD40D17C26DA /* GhosttyPanePreviewSessionTests.swift */; };
@@ -125,6 +127,7 @@
 		A0BA158C314003057744D8A8 /* TmuxScreenModelForegroundActiveCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3952803B4C0F5E847EEDEB75 /* TmuxScreenModelForegroundActiveCheckTests.swift */; };
 		A0C7372F57EB2BA980CC0888 /* RemuxLibrarySSHPrewarmPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AA752EADDB9E6FBA8140A4 /* RemuxLibrarySSHPrewarmPlanner.swift */; };
 		A0D6CF5A40A4953636A1928F /* TerminalSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA39774D73AE5B6A77D824C /* TerminalSettingsRepository.swift */; };
+		A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */; };
 		A7AFC27CD8E0B30AFF1A32BF /* GhosttyAttachmentImageMarkupEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC550DCE031B69C4EDD3C6F5 /* GhosttyAttachmentImageMarkupEditor.swift */; };
 		A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */; };
 		AA0449DB0EEBE5F640BF6B79 /* GhosttyTerminalInputCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29658D4FE019C12073CC58BE /* GhosttyTerminalInputCoordinator.swift */; };
@@ -259,6 +262,7 @@
 		48AC2CE228C16D7E9DCD09BE /* ConnectionProfileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProfileRepository.swift; sourceTree = "<group>"; };
 		4B3782AB19C138622144EE40 /* RemuxPreparedTransportCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxPreparedTransportCoordinatorTests.swift; sourceTree = "<group>"; };
 		4D407500AB027C206B65EE7C /* GhosttyTerminalPresentationProjector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalPresentationProjector.swift; sourceTree = "<group>"; };
+		4D967C13C5A420C58657176B /* AppKeyboardCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeyboardCommand.swift; sourceTree = "<group>"; };
 		4E84F774C17B5C4DB6B715A9 /* GhosttySurfaceKeyEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceKeyEventTests.swift; sourceTree = "<group>"; };
 		532E9E62CF3E74FEE31F5C05 /* GhosttyTopLevelSurfaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTopLevelSurfaceTests.swift; sourceTree = "<group>"; };
 		5370A2DE2689DAF5E27E57FD /* TmuxPanePreviewImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxPanePreviewImageCache.swift; sourceTree = "<group>"; };
@@ -285,6 +289,7 @@
 		700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugConnectionProfileSeeder.swift; sourceTree = "<group>"; };
 		71B734F55FC22090646AD0D2 /* GhosttyPendingAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPendingAttachmentTests.swift; sourceTree = "<group>"; };
 		7303BA60EDF97F8E9F3BFB26 /* TerminalSettingsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettingsRepositoryTests.swift; sourceTree = "<group>"; };
+		739E2E47D56DEB0CBC3A9769 /* KeyboardSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettings.swift; sourceTree = "<group>"; };
 		73C4CC8673D390A85EC1741D /* RemuxSessionLiveForwardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxSessionLiveForwardTests.swift; sourceTree = "<group>"; };
 		74B1BE024B39B56C24D7F7A2 /* GhosttyTerminalViewportCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalViewportCoordinatorTests.swift; sourceTree = "<group>"; };
 		76659C49175055C3E15DB226 /* RemuxActiveSessionRuntimeReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxActiveSessionRuntimeReducer.swift; sourceTree = "<group>"; };
@@ -363,6 +368,7 @@
 		DFD9AF0371D15A892B000530 /* DebugConnectionProfileSeederTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugConnectionProfileSeederTests.swift; sourceTree = "<group>"; };
 		E05107088F3540B7C04D2007 /* GhosttyTerminalResponderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalResponderViewTests.swift; sourceTree = "<group>"; };
 		E0B4E47DA0DBB84F1301E14C /* GhosttyTerminalViewportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalViewportCoordinator.swift; sourceTree = "<group>"; };
+		E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsTests.swift; sourceTree = "<group>"; };
 		E3A4228D3F3885A93C87FD75 /* GhosttyAttachmentInteractiveImagePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentInteractiveImagePreview.swift; sourceTree = "<group>"; };
 		E4A946B4CBB7E49BCAA7D52B /* ShortcutCollectionIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCollectionIconView.swift; sourceTree = "<group>"; };
 		E509784BCB04CA957763EB32 /* DeterministicTmuxControlTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicTmuxControlTransport.swift; sourceTree = "<group>"; };
@@ -490,6 +496,7 @@
 				74B1BE024B39B56C24D7F7A2 /* GhosttyTerminalViewportCoordinatorTests.swift */,
 				0A9F4B4B0260131778AB2BA5 /* GhosttyTmuxPrefixInputBufferTests.swift */,
 				532E9E62CF3E74FEE31F5C05 /* GhosttyTopLevelSurfaceTests.swift */,
+				E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */,
 				603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */,
 				01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */,
 				03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */,
@@ -619,6 +626,8 @@
 		D9A30ED1878BFD3CD31E92C7 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				4D967C13C5A420C58657176B /* AppKeyboardCommand.swift */,
+				739E2E47D56DEB0CBC3A9769 /* KeyboardSettings.swift */,
 				5EFEF4C2C61B013DA831F7D9 /* Shortcut.swift */,
 				820136FA2586D2054D312C3D /* SSHPrivateKeyInspector.swift */,
 				771B767054F02C52F17EB92B /* StarterShortcuts.swift */,
@@ -839,6 +848,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08DB6253090B3309F5BCA95A /* AppKeyboardCommand.swift in Sources */,
 				3F71D9F3D7782DCD769CF47E /* ApplicationStorage.swift in Sources */,
 				E35A4C6758E1D06E01EE5826 /* ConnectionProfileRepository.swift in Sources */,
 				39A58132CBB849E2CDF37BC2 /* DebugConnectionProfileSeeder.swift in Sources */,
@@ -895,6 +905,7 @@
 				D78DD9D2C761CC45DB856D42 /* GhosttyTopLevelSurface.swift in Sources */,
 				C004B8CB3BEA6B9F5F7C43BF /* Haptic.swift in Sources */,
 				6959353E0AAA65D244C5B077 /* JSONFileStore.swift in Sources */,
+				050F663B3541C6F716B4348B /* KeyboardSettings.swift in Sources */,
 				69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */,
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
@@ -996,6 +1007,7 @@
 				E5127955E3EE44561EEFFB58 /* GhosttyTerminalViewportCoordinatorTests.swift in Sources */,
 				DED4088C1635F130FC578C91 /* GhosttyTmuxPrefixInputBufferTests.swift in Sources */,
 				584C4529515F7796EFE407C9 /* GhosttyTopLevelSurfaceTests.swift in Sources */,
+				A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */,
 				890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */,
 				1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */,
 				A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */,

--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		06F0AA3040EBCD8B9229B237 /* RemuxRootModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F57C8C6D3F75E3E07DDC9 /* RemuxRootModel.swift */; };
 		077974905B6ABD611204F949 /* RemuxPreparedTransportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB62707ACD4905DCE40ECBFA /* RemuxPreparedTransportCoordinator.swift */; };
 		08DB6253090B3309F5BCA95A /* AppKeyboardCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D967C13C5A420C58657176B /* AppKeyboardCommand.swift */; };
+		0F140689181F9F01026626C0 /* KeyboardSettingsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1F5F05BDDF96082E88D29 /* KeyboardSettingsRepositoryTests.swift */; };
 		1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */; };
 		14890862E5A8BFE9BE759DB0 /* GhosttySurfaceKeyEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E84F774C17B5C4DB6B715A9 /* GhosttySurfaceKeyEventTests.swift */; };
 		14BCD2766E4ED765F45BA3AD /* GhosttyPanePreviewSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07301EEDA55AAD40D17C26DA /* GhosttyPanePreviewSessionTests.swift */; };
@@ -102,6 +103,7 @@
 		7C99EDFDCE3B0927D26C1029 /* GhosttyAttachmentPasteboardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DD89E37AC083383B988185 /* GhosttyAttachmentPasteboardSnapshotTests.swift */; };
 		7D737693581BDF76436D61D9 /* GhosttyTerminalDisconnectReasonClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99082CEC90EA6D04B5BE5874 /* GhosttyTerminalDisconnectReasonClassifier.swift */; };
 		7FB696D68436C55D304387E4 /* TmuxTerminalScreenAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D507C4F64535720BC9A3F665 /* TmuxTerminalScreenAdapter.swift */; };
+		80FB4BFC7F113DA32E2DD8AC /* KeyboardSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245954B6C0BF1C23E87DDED3 /* KeyboardSettingsRepository.swift */; };
 		842E6402F6F631B4DB19B8DE /* GhosttyTerminalResponderTextInputShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBECAA1C7625528DD0831B /* GhosttyTerminalResponderTextInputShim.swift */; };
 		8538B4599CD88CEC07452142 /* GhosttyKitRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF11321286DB9076CB3FA983 /* GhosttyKitRuntime.swift */; };
 		890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */; };
@@ -211,6 +213,7 @@
 /* Begin PBXFileReference section */
 		00BF7405360DC035455D7ACE /* TmuxControlTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxControlTransport.swift; sourceTree = "<group>"; };
 		01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxActiveSessionCollectionTests.swift; sourceTree = "<group>"; };
+		02C1F5F05BDDF96082E88D29 /* KeyboardSettingsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsRepositoryTests.swift; sourceTree = "<group>"; };
 		03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxActiveSessionRuntimeReducerTests.swift; sourceTree = "<group>"; };
 		054929B68D4D41AF41FF0D8D /* GhosttyPendingAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPendingAttachment.swift; sourceTree = "<group>"; };
 		05617ECDC542A8A167C52296 /* ShortcutPaletteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutPaletteUITests.swift; sourceTree = "<group>"; };
@@ -233,6 +236,7 @@
 		21B59E540592993567162928 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		233453E510348B0E5F5B8C2C /* GhosttyKeyboardCursorTrackpadHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardCursorTrackpadHUD.swift; sourceTree = "<group>"; };
 		23F3CE22CD66E574D1A7196E /* GhosttySurfaceScrollGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceScrollGesture.swift; sourceTree = "<group>"; };
+		245954B6C0BF1C23E87DDED3 /* KeyboardSettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsRepository.swift; sourceTree = "<group>"; };
 		25DBECAA1C7625528DD0831B /* GhosttyTerminalResponderTextInputShim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalResponderTextInputShim.swift; sourceTree = "<group>"; };
 		25F0019F1714AE6BD9F41209 /* RemuxAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxAppUITests.swift; sourceTree = "<group>"; };
 		267386EB1A94C2A6029D90F6 /* TerminalRuntimeStatusPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeStatusPresentation.swift; sourceTree = "<group>"; };
@@ -496,6 +500,7 @@
 				74B1BE024B39B56C24D7F7A2 /* GhosttyTerminalViewportCoordinatorTests.swift */,
 				0A9F4B4B0260131778AB2BA5 /* GhosttyTmuxPrefixInputBufferTests.swift */,
 				532E9E62CF3E74FEE31F5C05 /* GhosttyTopLevelSurfaceTests.swift */,
+				02C1F5F05BDDF96082E88D29 /* KeyboardSettingsRepositoryTests.swift */,
 				E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */,
 				603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */,
 				01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */,
@@ -556,6 +561,7 @@
 				AE5B67646A0F14933B3FD8D8 /* ApplicationStorage.swift */,
 				48AC2CE228C16D7E9DCD09BE /* ConnectionProfileRepository.swift */,
 				0C7EBCE00319FF2879275BDD /* JSONFileStore.swift */,
+				245954B6C0BF1C23E87DDED3 /* KeyboardSettingsRepository.swift */,
 				DA9987EA1F7B5FDC3A50ECEA /* ShortcutStore.swift */,
 				AD50E6815BED6CB2E3B793C9 /* SSHCredentialStore.swift */,
 				6AA39774D73AE5B6A77D824C /* TerminalSettingsRepository.swift */,
@@ -906,6 +912,7 @@
 				C004B8CB3BEA6B9F5F7C43BF /* Haptic.swift in Sources */,
 				6959353E0AAA65D244C5B077 /* JSONFileStore.swift in Sources */,
 				050F663B3541C6F716B4348B /* KeyboardSettings.swift in Sources */,
+				80FB4BFC7F113DA32E2DD8AC /* KeyboardSettingsRepository.swift in Sources */,
 				69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */,
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
@@ -1007,6 +1014,7 @@
 				E5127955E3EE44561EEFFB58 /* GhosttyTerminalViewportCoordinatorTests.swift in Sources */,
 				DED4088C1635F130FC578C91 /* GhosttyTmuxPrefixInputBufferTests.swift in Sources */,
 				584C4529515F7796EFE407C9 /* GhosttyTopLevelSurfaceTests.swift in Sources */,
+				0F140689181F9F01026626C0 /* KeyboardSettingsRepositoryTests.swift in Sources */,
 				A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */,
 				890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */,
 				1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */,

--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		7C99EDFDCE3B0927D26C1029 /* GhosttyAttachmentPasteboardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84DD89E37AC083383B988185 /* GhosttyAttachmentPasteboardSnapshotTests.swift */; };
 		7D737693581BDF76436D61D9 /* GhosttyTerminalDisconnectReasonClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99082CEC90EA6D04B5BE5874 /* GhosttyTerminalDisconnectReasonClassifier.swift */; };
 		7FB696D68436C55D304387E4 /* TmuxTerminalScreenAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D507C4F64535720BC9A3F665 /* TmuxTerminalScreenAdapter.swift */; };
+		806CBC7343808C8E4FF50F28 /* AppKeyboardCommandResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3BF5A0EC8A00A5D4142B0F /* AppKeyboardCommandResponder.swift */; };
 		80FB4BFC7F113DA32E2DD8AC /* KeyboardSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 245954B6C0BF1C23E87DDED3 /* KeyboardSettingsRepository.swift */; };
 		842E6402F6F631B4DB19B8DE /* GhosttyTerminalResponderTextInputShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBECAA1C7625528DD0831B /* GhosttyTerminalResponderTextInputShim.swift */; };
 		8538B4599CD88CEC07452142 /* GhosttyKitRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF11321286DB9076CB3FA983 /* GhosttyKitRuntime.swift */; };
@@ -153,6 +154,7 @@
 		CE34427B2F8F5EB5AF5762AE /* RemuxSessionLiveForward.swift in Sources */ = {isa = PBXBuildFile; fileRef = D047E23F9EFC609398779342 /* RemuxSessionLiveForward.swift */; };
 		CFF1208F57BD8CE3BA9507F6 /* TmuxPanePreviewImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5370A2DE2689DAF5E27E57FD /* TmuxPanePreviewImageCache.swift */; };
 		D139ABC351802768520D8A4F /* TerminalRuntimeStatusPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267386EB1A94C2A6029D90F6 /* TerminalRuntimeStatusPresentation.swift */; };
+		D330DAF4BD8A2777D857A603 /* AppKeyboardCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3563813041EFFF953954E9 /* AppKeyboardCommandRouter.swift */; };
 		D3A27BCC972E451CDB6113E1 /* ShortcutCollectionIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A946B4CBB7E49BCAA7D52B /* ShortcutCollectionIconView.swift */; };
 		D4D164A1ADCB32103FFDE81E /* RemuxSessionLiveForwardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C4CC8673D390A85EC1741D /* RemuxSessionLiveForwardTests.swift */; };
 		D5BC8B5AFF97FD9FDD27D04A /* TmuxTerminalSessionShutdownDrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18E95DAAAF9312AED56CC0F /* TmuxTerminalSessionShutdownDrainTests.swift */; };
@@ -166,6 +168,7 @@
 		E0787109BFFDE0C211C26BFB /* GhosttyScrollPhysicsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 216C560F444E51EAEA88D748 /* GhosttyScrollPhysicsView.swift */; };
 		E0B03B6D9CC8D0372605DAF2 /* GhosttySurfaceMouseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC4CAA9116316609CF030FC /* GhosttySurfaceMouseEvent.swift */; };
 		E1A024BDF4C05481D447C104 /* SSHTmuxControlChannelDataRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2BCC7F60325417F2E882FF /* SSHTmuxControlChannelDataRouter.swift */; };
+		E1BB2A85A017835D07C45C88 /* AppKeyboardCommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7FD25C85A9D4A1E9D4B4E5 /* AppKeyboardCommandRouterTests.swift */; };
 		E312086F6A463AC00BC93C8E /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CB12DC1EC78CE1C1286BA4E /* GhosttyKit.xcframework */; };
 		E346403238D71C27A9124999 /* GhosttyAttachmentStagingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFA16C96FE00BC33898C788 /* GhosttyAttachmentStagingStore.swift */; };
 		E35A4C6758E1D06E01EE5826 /* ConnectionProfileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AC2CE228C16D7E9DCD09BE /* ConnectionProfileRepository.swift */; };
@@ -333,6 +336,7 @@
 		A9BEEA4655420D5DCEDE5C23 /* GhosttyPhoneChromeLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPhoneChromeLayoutTests.swift; sourceTree = "<group>"; };
 		AC550DCE031B69C4EDD3C6F5 /* GhosttyAttachmentImageMarkupEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentImageMarkupEditor.swift; sourceTree = "<group>"; };
 		AD50E6815BED6CB2E3B793C9 /* SSHCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentialStore.swift; sourceTree = "<group>"; };
+		AE3BF5A0EC8A00A5D4142B0F /* AppKeyboardCommandResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeyboardCommandResponder.swift; sourceTree = "<group>"; };
 		AE5B67646A0F14933B3FD8D8 /* ApplicationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStorage.swift; sourceTree = "<group>"; };
 		B1861094273B802BF30CB94A /* TmuxTerminalScreenAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxTerminalScreenAdapterTests.swift; sourceTree = "<group>"; };
 		B1AAF15C6761B24466DD78D6 /* TerminalRuntimeStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeStatusPresentationTests.swift; sourceTree = "<group>"; };
@@ -367,7 +371,9 @@
 		DB62707ACD4905DCE40ECBFA /* RemuxPreparedTransportCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxPreparedTransportCoordinator.swift; sourceTree = "<group>"; };
 		DB8184BF6C8C3A418E9BD893 /* TmuxTerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxTerminalSession.swift; sourceTree = "<group>"; };
 		DC2BCC7F60325417F2E882FF /* SSHTmuxControlChannelDataRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHTmuxControlChannelDataRouter.swift; sourceTree = "<group>"; };
+		DC3563813041EFFF953954E9 /* AppKeyboardCommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeyboardCommandRouter.swift; sourceTree = "<group>"; };
 		DC3FA910C9C3B9A094B8497A /* GhosttyRuntimeSurfaceTopologySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyRuntimeSurfaceTopologySnapshot.swift; sourceTree = "<group>"; };
+		DC7FD25C85A9D4A1E9D4B4E5 /* AppKeyboardCommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKeyboardCommandRouterTests.swift; sourceTree = "<group>"; };
 		DCC5D29DF530DB8A90FA8A60 /* GhosttyAttachmentPreviewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentPreviewStyle.swift; sourceTree = "<group>"; };
 		DFD9AF0371D15A892B000530 /* DebugConnectionProfileSeederTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugConnectionProfileSeederTests.swift; sourceTree = "<group>"; };
 		E05107088F3540B7C04D2007 /* GhosttyTerminalResponderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalResponderViewTests.swift; sourceTree = "<group>"; };
@@ -446,6 +452,8 @@
 		32334451C65B7C4F00E30040 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				AE3BF5A0EC8A00A5D4142B0F /* AppKeyboardCommandResponder.swift */,
+				DC3563813041EFFF953954E9 /* AppKeyboardCommandRouter.swift */,
 				700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */,
 				8926D94B4AAF192302FC58E4 /* Haptic.swift */,
 				E683A3CF94359C176CCEA22A /* RemuxActiveSessionCollection.swift */,
@@ -467,6 +475,7 @@
 		34D2E4930A61ACCECA627727 /* RemuxAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				DC7FD25C85A9D4A1E9D4B4E5 /* AppKeyboardCommandRouterTests.swift */,
 				28EE543D2B247AE6C6A8C472 /* ConnectionProfileRepositoryTests.swift */,
 				DFD9AF0371D15A892B000530 /* DebugConnectionProfileSeederTests.swift */,
 				2A1CB6877AF169792137FA56 /* GhosttyAttachmentImageMarkupRendererTests.swift */,
@@ -855,6 +864,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				08DB6253090B3309F5BCA95A /* AppKeyboardCommand.swift in Sources */,
+				806CBC7343808C8E4FF50F28 /* AppKeyboardCommandResponder.swift in Sources */,
+				D330DAF4BD8A2777D857A603 /* AppKeyboardCommandRouter.swift in Sources */,
 				3F71D9F3D7782DCD769CF47E /* ApplicationStorage.swift in Sources */,
 				E35A4C6758E1D06E01EE5826 /* ConnectionProfileRepository.swift in Sources */,
 				39A58132CBB849E2CDF37BC2 /* DebugConnectionProfileSeeder.swift in Sources */,
@@ -981,6 +992,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1BB2A85A017835D07C45C88 /* AppKeyboardCommandRouterTests.swift in Sources */,
 				8F75231F2CF7E597F4D0347F /* ConnectionProfileRepositoryTests.swift in Sources */,
 				434C420D221F1CAF2A633602 /* DebugConnectionProfileSeederTests.swift in Sources */,
 				EE488E8B043F3160004A3C20 /* GhosttyAttachmentImageMarkupRendererTests.swift in Sources */,

--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		21D804DB6768A5474BAB4DA2 /* GhosttySurfaceScrollGestureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451C5235FD50DD80CBC53CCC /* GhosttySurfaceScrollGestureTests.swift */; };
 		245F3E2F2ED1675C0BFC0318 /* TerminalSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FA18CCB40D2C7746D7D569 /* TerminalSettingsTests.swift */; };
 		2521091156DB41132937296A /* GhosttySurfaceScrollGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F3CE22CD66E574D1A7196E /* GhosttySurfaceScrollGesture.swift */; };
+		2564DAB06366F829FABAB6A2 /* PhysicalKeyboardChromeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC17C28FFBB1395C0D743429 /* PhysicalKeyboardChromeStateTests.swift */; };
 		27A320CC1E03C85158276F1D /* GhosttyKeyboardChromeModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636A73D3AA225CCADC20F687 /* GhosttyKeyboardChromeModeTests.swift */; };
 		281494ACA6BC4E311A642A37 /* GhosttyModifierState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F9DD0E0F418199C5E8C0F1 /* GhosttyModifierState.swift */; };
 		289D7673486A18F986C60788 /* TerminalPreviewStaticHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642B17B3F845A938C581F1AA /* TerminalPreviewStaticHTMLTests.swift */; };
@@ -50,6 +51,7 @@
 		3959173AC4F6B2A7849A6A1E /* GhosttyAttachmentStagingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9A68C878571836AC7EDA41 /* GhosttyAttachmentStagingStoreTests.swift */; };
 		39A58132CBB849E2CDF37BC2 /* DebugConnectionProfileSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */; };
 		3C845A0E1D2E5BE8627CA4DF /* GhosttySurfaceStatusOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E94EB8EAE8524275106704 /* GhosttySurfaceStatusOverlay.swift */; };
+		3D767131A34525BA338D0A95 /* PhysicalKeyboardChromeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9B6DDD3AF90D84DA9DD5ED /* PhysicalKeyboardChromeState.swift */; };
 		3E192E1F4E9DEC7691077660 /* GhosttyTerminalDisconnectReasonClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6195E1BD742AC775F143F912 /* GhosttyTerminalDisconnectReasonClassifierTests.swift */; };
 		3F60EA4DB041B4296572C2AB /* RemuxPreparedTransportCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A245FF40A1998FA618E6370 /* RemuxPreparedTransportCacheTests.swift */; };
 		3F71D9F3D7782DCD769CF47E /* ApplicationStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE5B67646A0F14933B3FD8D8 /* ApplicationStorage.swift */; };
@@ -133,6 +135,7 @@
 		A0BA158C314003057744D8A8 /* TmuxScreenModelForegroundActiveCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3952803B4C0F5E847EEDEB75 /* TmuxScreenModelForegroundActiveCheckTests.swift */; };
 		A0C7372F57EB2BA980CC0888 /* RemuxLibrarySSHPrewarmPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AA752EADDB9E6FBA8140A4 /* RemuxLibrarySSHPrewarmPlanner.swift */; };
 		A0D6CF5A40A4953636A1928F /* TerminalSettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA39774D73AE5B6A77D824C /* TerminalSettingsRepository.swift */; };
+		A274C20F87F776EFD421CCD6 /* PhysicalKeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86EF87FE53CC20522F3ACB8 /* PhysicalKeyboardMonitor.swift */; };
 		A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */; };
 		A7AFC27CD8E0B30AFF1A32BF /* GhosttyAttachmentImageMarkupEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC550DCE031B69C4EDD3C6F5 /* GhosttyAttachmentImageMarkupEditor.swift */; };
 		A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */; };
@@ -308,6 +311,7 @@
 		76659C49175055C3E15DB226 /* RemuxActiveSessionRuntimeReducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxActiveSessionRuntimeReducer.swift; sourceTree = "<group>"; };
 		771B767054F02C52F17EB92B /* StarterShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarterShortcuts.swift; sourceTree = "<group>"; };
 		78CD307268384537F5CF1219 /* TmuxPaneSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxPaneSurface.swift; sourceTree = "<group>"; };
+		7A9B6DDD3AF90D84DA9DD5ED /* PhysicalKeyboardChromeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKeyboardChromeState.swift; sourceTree = "<group>"; };
 		7C826602D9C963622FB26A40 /* TerminalThemePreviewRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalThemePreviewRenderer.swift; sourceTree = "<group>"; };
 		8151E185EE3CC5784181D01E /* GhosttyAttachmentTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentTransfer.swift; sourceTree = "<group>"; };
 		820136FA2586D2054D312C3D /* SSHPrivateKeyInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPrivateKeyInspector.swift; sourceTree = "<group>"; };
@@ -349,6 +353,7 @@
 		B38F49B9EC49FF6E9791967C /* GhosttyKeyboardVisibilityProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardVisibilityProjection.swift; sourceTree = "<group>"; };
 		B4C7136948AF9803FAAD6F82 /* GhosttyKeyboardCursorTrackpad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardCursorTrackpad.swift; sourceTree = "<group>"; };
 		B7C4481BDC2A74CA510A39D4 /* GhosttyShortcutSurfacePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyShortcutSurfacePalette.swift; sourceTree = "<group>"; };
+		B86EF87FE53CC20522F3ACB8 /* PhysicalKeyboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKeyboardMonitor.swift; sourceTree = "<group>"; };
 		B94CC628E68FDC18E59E9D79 /* GhosttyAttachmentTray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentTray.swift; sourceTree = "<group>"; };
 		B9F00A0064AC2897BDF34495 /* GhosttyKeyboardVisibilityProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardVisibilityProjectionTests.swift; sourceTree = "<group>"; };
 		BA66578016B8B2B62FF2332F /* TmuxConnectionDraftValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxConnectionDraftValidatorTests.swift; sourceTree = "<group>"; };
@@ -362,6 +367,7 @@
 		C7313F7C3049C269572F59B5 /* RemuxLibrarySSHPrewarmCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxLibrarySSHPrewarmCoordinatorTests.swift; sourceTree = "<group>"; };
 		C944FBD600E4357E517F2DD3 /* TrustedHostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustedHostStore.swift; sourceTree = "<group>"; };
 		CBAB7FE3E70E32E69462BBA1 /* GhosttyTmuxActionTargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTmuxActionTargetResolver.swift; sourceTree = "<group>"; };
+		CC17C28FFBB1395C0D743429 /* PhysicalKeyboardChromeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKeyboardChromeStateTests.swift; sourceTree = "<group>"; };
 		CC23D872C331C7574737CCDA /* RemuxSSHRootService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxSSHRootService.swift; sourceTree = "<group>"; };
 		CFE401B861C30DA18E8BE1C9 /* ShortcutsSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsSettingsSheet.swift; sourceTree = "<group>"; };
 		D047E23F9EFC609398779342 /* RemuxSessionLiveForward.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxSessionLiveForward.swift; sourceTree = "<group>"; };
@@ -464,6 +470,7 @@
 				8926D94B4AAF192302FC58E4 /* Haptic.swift */,
 				4236F0B51C9AB66CAA48E022 /* KeyboardSettingsView.swift */,
 				3EDEDB09EB6E734DE8A548B8 /* KeyboardShortcutCaptureView.swift */,
+				B86EF87FE53CC20522F3ACB8 /* PhysicalKeyboardMonitor.swift */,
 				E683A3CF94359C176CCEA22A /* RemuxActiveSessionCollection.swift */,
 				76659C49175055C3E15DB226 /* RemuxActiveSessionRuntimeReducer.swift */,
 				947084E6DA45D9EFB946CF51 /* RemuxApp.swift */,
@@ -521,6 +528,7 @@
 				E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */,
 				33A24ADAB8433C20DF835325 /* KeyboardShortcutCaptureTests.swift */,
 				603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */,
+				CC17C28FFBB1395C0D743429 /* PhysicalKeyboardChromeStateTests.swift */,
 				01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */,
 				03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */,
 				C7313F7C3049C269572F59B5 /* RemuxLibrarySSHPrewarmCoordinatorTests.swift */,
@@ -714,6 +722,7 @@
 				A510F3E8FC22231ACA4A8A99 /* GhosttyTmuxPrefixInputBuffer.swift */,
 				88095738876B31835109065A /* GhosttyTopLevelSurface.swift */,
 				F4748776DB3A0FEF2A152403 /* PanePreviewLayout.swift */,
+				7A9B6DDD3AF90D84DA9DD5ED /* PhysicalKeyboardChromeState.swift */,
 				E4A946B4CBB7E49BCAA7D52B /* ShortcutCollectionIconView.swift */,
 				60FE6CB3913B2DD433F57472 /* ShortcutExecutor.swift */,
 				BC76333B637D49B9A27CB798 /* ShortcutPalette.swift */,
@@ -936,6 +945,8 @@
 				08A2D7C1DD7B50537246FFC6 /* KeyboardSettingsView.swift in Sources */,
 				691315D4DDE736B84E7D89EF /* KeyboardShortcutCaptureView.swift in Sources */,
 				69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */,
+				3D767131A34525BA338D0A95 /* PhysicalKeyboardChromeState.swift in Sources */,
+				A274C20F87F776EFD421CCD6 /* PhysicalKeyboardMonitor.swift in Sources */,
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
 				8AEEBAE61E93788016C85F9F /* RemuxApp.swift in Sources */,
@@ -1041,6 +1052,7 @@
 				A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */,
 				8B37E662AD69B5C823F2BDB6 /* KeyboardShortcutCaptureTests.swift in Sources */,
 				890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */,
+				2564DAB06366F829FABAB6A2 /* PhysicalKeyboardChromeStateTests.swift in Sources */,
 				1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */,
 				A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */,
 				338BB72DDA774589D60E8D0D /* RemuxLibrarySSHPrewarmCoordinatorTests.swift in Sources */,

--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		050F663B3541C6F716B4348B /* KeyboardSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739E2E47D56DEB0CBC3A9769 /* KeyboardSettings.swift */; };
 		06F0AA3040EBCD8B9229B237 /* RemuxRootModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20F57C8C6D3F75E3E07DDC9 /* RemuxRootModel.swift */; };
 		077974905B6ABD611204F949 /* RemuxPreparedTransportCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB62707ACD4905DCE40ECBFA /* RemuxPreparedTransportCoordinator.swift */; };
+		08A2D7C1DD7B50537246FFC6 /* KeyboardSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4236F0B51C9AB66CAA48E022 /* KeyboardSettingsView.swift */; };
 		08DB6253090B3309F5BCA95A /* AppKeyboardCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D967C13C5A420C58657176B /* AppKeyboardCommand.swift */; };
 		0F140689181F9F01026626C0 /* KeyboardSettingsRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02C1F5F05BDDF96082E88D29 /* KeyboardSettingsRepositoryTests.swift */; };
 		1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */; };
@@ -89,6 +90,7 @@
 		6548541B3AD17F7D70BFE8C0 /* TerminalPreviewLiveWebTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5437829CC09E381C6615908 /* TerminalPreviewLiveWebTests.swift */; };
 		68AB6FD8F0F48EBAEDCA1F3D /* ShortcutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FE6CB3913B2DD433F57472 /* ShortcutExecutor.swift */; };
 		68F62C41042D69317C5A9FD3 /* GhosttyQuickLookPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FB03D3718F47ECDF15AEC3 /* GhosttyQuickLookPreview.swift */; };
+		691315D4DDE736B84E7D89EF /* KeyboardShortcutCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDEDB09EB6E734DE8A548B8 /* KeyboardShortcutCaptureView.swift */; };
 		6959353E0AAA65D244C5B077 /* JSONFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7EBCE00319FF2879275BDD /* JSONFileStore.swift */; };
 		69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4748776DB3A0FEF2A152403 /* PanePreviewLayout.swift */; };
 		71929CA0D4AE6FC5FA464C4B /* TerminalPreviewFileLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C60C2A339E149300CA7177 /* TerminalPreviewFileLoader.swift */; };
@@ -110,6 +112,7 @@
 		890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */; };
 		8AEEBAE61E93788016C85F9F /* RemuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947084E6DA45D9EFB946CF51 /* RemuxApp.swift */; };
 		8B1B766701C8B598CD3A5480 /* TmuxScreenModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B19046A43739DE9328A3612 /* TmuxScreenModel.swift */; };
+		8B37E662AD69B5C823F2BDB6 /* KeyboardShortcutCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A24ADAB8433C20DF835325 /* KeyboardShortcutCaptureTests.swift */; };
 		8E312AEB02A4AD0A312DD610 /* SSHTmuxControlInboundStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74058D995BF7376879755FE /* SSHTmuxControlInboundStream.swift */; };
 		8E7597434F30289D0A907FC8 /* GhosttyManagedSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1C511196E36EC63A430EB9 /* GhosttyManagedSurface.swift */; };
 		8E787177A7A3A043317795F0 /* TmuxTerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8184BF6C8C3A418E9BD893 /* TmuxTerminalSession.swift */; };
@@ -252,13 +255,16 @@
 		2D0CE2626790CFB617C7B39A /* GhosttyManagedSurfaceLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyManagedSurfaceLookup.swift; sourceTree = "<group>"; };
 		2DE43FCF1FB0A2A5205281A9 /* GhosttyTerminalDebugLatencyProbeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalDebugLatencyProbeControllerTests.swift; sourceTree = "<group>"; };
 		31CDE08ADC3CEED179BF9A2D /* GhosttyAttachmentImagePreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentImagePreviewData.swift; sourceTree = "<group>"; };
+		33A24ADAB8433C20DF835325 /* KeyboardShortcutCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutCaptureTests.swift; sourceTree = "<group>"; };
 		375579FD92E3B9A605C7E9EC /* GhosttyTerminalRuntimeStateReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalRuntimeStateReporter.swift; sourceTree = "<group>"; };
 		3952803B4C0F5E847EEDEB75 /* TmuxScreenModelForegroundActiveCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxScreenModelForegroundActiveCheckTests.swift; sourceTree = "<group>"; };
 		3B1C511196E36EC63A430EB9 /* GhosttyManagedSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyManagedSurface.swift; sourceTree = "<group>"; };
 		3EC4CAA9116316609CF030FC /* GhosttySurfaceMouseEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceMouseEvent.swift; sourceTree = "<group>"; };
+		3EDEDB09EB6E734DE8A548B8 /* KeyboardShortcutCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutCaptureView.swift; sourceTree = "<group>"; };
 		3F881DB2CF820F05DCDC2768 /* GhosttyRemoteAttachmentPathBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyRemoteAttachmentPathBuilderTests.swift; sourceTree = "<group>"; };
 		3FA2520FAE4E2D228D25CADB /* GhosttySurfaceSelectionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceSelectionSheet.swift; sourceTree = "<group>"; };
 		4149F2629A01104A454FA9EB /* GhosttyAttachmentPreviewSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentPreviewSheet.swift; sourceTree = "<group>"; };
+		4236F0B51C9AB66CAA48E022 /* KeyboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsView.swift; sourceTree = "<group>"; };
 		4268A9BCEA43005C3CE56AF7 /* TerminalPreviewLiveWeb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPreviewLiveWeb.swift; sourceTree = "<group>"; };
 		43E94EB8EAE8524275106704 /* GhosttySurfaceStatusOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttySurfaceStatusOverlay.swift; sourceTree = "<group>"; };
 		44349A06B1D86FBF3C2CB578 /* TerminalPreviewSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPreviewSession.swift; sourceTree = "<group>"; };
@@ -456,6 +462,8 @@
 				DC3563813041EFFF953954E9 /* AppKeyboardCommandRouter.swift */,
 				700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */,
 				8926D94B4AAF192302FC58E4 /* Haptic.swift */,
+				4236F0B51C9AB66CAA48E022 /* KeyboardSettingsView.swift */,
+				3EDEDB09EB6E734DE8A548B8 /* KeyboardShortcutCaptureView.swift */,
 				E683A3CF94359C176CCEA22A /* RemuxActiveSessionCollection.swift */,
 				76659C49175055C3E15DB226 /* RemuxActiveSessionRuntimeReducer.swift */,
 				947084E6DA45D9EFB946CF51 /* RemuxApp.swift */,
@@ -511,6 +519,7 @@
 				532E9E62CF3E74FEE31F5C05 /* GhosttyTopLevelSurfaceTests.swift */,
 				02C1F5F05BDDF96082E88D29 /* KeyboardSettingsRepositoryTests.swift */,
 				E10E50095565951A114EBBAA /* KeyboardSettingsTests.swift */,
+				33A24ADAB8433C20DF835325 /* KeyboardShortcutCaptureTests.swift */,
 				603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */,
 				01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */,
 				03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */,
@@ -924,6 +933,8 @@
 				6959353E0AAA65D244C5B077 /* JSONFileStore.swift in Sources */,
 				050F663B3541C6F716B4348B /* KeyboardSettings.swift in Sources */,
 				80FB4BFC7F113DA32E2DD8AC /* KeyboardSettingsRepository.swift in Sources */,
+				08A2D7C1DD7B50537246FFC6 /* KeyboardSettingsView.swift in Sources */,
+				691315D4DDE736B84E7D89EF /* KeyboardShortcutCaptureView.swift in Sources */,
 				69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */,
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
@@ -1028,6 +1039,7 @@
 				584C4529515F7796EFE407C9 /* GhosttyTopLevelSurfaceTests.swift in Sources */,
 				0F140689181F9F01026626C0 /* KeyboardSettingsRepositoryTests.swift in Sources */,
 				A2B201D6262B361BCC67D99F /* KeyboardSettingsTests.swift in Sources */,
+				8B37E662AD69B5C823F2BDB6 /* KeyboardShortcutCaptureTests.swift in Sources */,
 				890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */,
 				1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */,
 				A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */,

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -58,7 +58,7 @@ final class AppKeyboardCommandResponderView: UIView {
 
         if isEnabled {
             DispatchQueue.main.async { [weak self] in
-                guard let self, !self.hasFocusedTextInput else { return }
+                guard let self, !self.hasExternalFirstResponder else { return }
                 _ = self.becomeFirstResponder()
             }
         } else if isFirstResponder {
@@ -66,11 +66,11 @@ final class AppKeyboardCommandResponderView: UIView {
         }
     }
 
-    private var hasFocusedTextInput: Bool {
+    private var hasExternalFirstResponder: Bool {
         guard let window, let responder = firstResponder(in: window) else {
             return false
         }
-        return responder is any UITextInput
+        return responder !== self
     }
 
     private func firstResponder(in view: UIView) -> UIView? {

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -43,6 +43,7 @@ final class AppKeyboardCommandCenter: ObservableObject {
     }
 
     @Published private(set) var settings: KeyboardSettings = .default
+    @Published private(set) var availableCommands: [AppKeyboardCommand] = []
     private var commandHandler: ((AppKeyboardCommand) -> Void)?
     private weak var hostingController: AppKeyboardCommandHostingController?
     private var isShortcutCaptureActive = false
@@ -53,11 +54,15 @@ final class AppKeyboardCommandCenter: ObservableObject {
 
     func update(
         settings: KeyboardSettings,
+        availableCommands: [AppKeyboardCommand],
         onCommand: @escaping (AppKeyboardCommand) -> Void
     ) {
         commandHandler = onCommand
         if self.settings != settings {
             self.settings = settings
+        }
+        if self.availableCommands != availableCommands {
+            self.availableCommands = availableCommands
         }
     }
 
@@ -175,7 +180,11 @@ struct AppKeyboardCommandHost<Content: View>: UIViewControllerRepresentable {
             rootView: AnyView(content),
             commandCenter: center
         )
-        controller.update(settings: center.settings, commandCenter: center)
+        controller.update(
+            settings: center.settings,
+            availableCommands: center.availableCommands,
+            commandCenter: center
+        )
         center.register(controller)
         return controller
     }
@@ -184,7 +193,11 @@ struct AppKeyboardCommandHost<Content: View>: UIViewControllerRepresentable {
         _ controller: AppKeyboardCommandHostingController,
         context: Context
     ) {
-        controller.update(settings: center.settings, commandCenter: center)
+        controller.update(
+            settings: center.settings,
+            availableCommands: center.availableCommands,
+            commandCenter: center
+        )
         center.register(controller)
     }
 }
@@ -217,6 +230,7 @@ final class AppKeyboardCommandHostingController: UIViewController {
     private weak var commandCenter: AppKeyboardCommandCenter?
     private var appKeyCommands: [UIKeyCommand] = []
     private var keyboardSettings: KeyboardSettings = .default
+    private var availableCommands: [AppKeyboardCommand] = []
     private var isSuspended = false
 
     init(rootView: AnyView, commandCenter: AppKeyboardCommandCenter) {
@@ -283,13 +297,15 @@ final class AppKeyboardCommandHostingController: UIViewController {
 
     func update(
         settings: KeyboardSettings,
+        availableCommands: [AppKeyboardCommand],
         commandCenter: AppKeyboardCommandCenter
     ) {
         self.commandCenter = commandCenter
         keyboardSettings = settings
+        self.availableCommands = availableCommands
         appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
             settings: settings,
-            commands: AppKeyboardCommand.allCases,
+            commands: availableCommands,
             action: #selector(performAppKeyboardCommand(_:))
         )
     }
@@ -305,7 +321,8 @@ final class AppKeyboardCommandHostingController: UIViewController {
         guard !isSuspended else { return false }
         guard
             let command = AppKeyboardCommandResolver(settings: keyboardSettings)
-                .command(input: input, modifierFlags: modifierFlags)
+                .command(input: input, modifierFlags: modifierFlags),
+            availableCommands.contains(command)
         else {
             return false
         }
@@ -332,7 +349,8 @@ final class AppKeyboardCommandHostingController: UIViewController {
     private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
             let rawValue = sender.propertyList as? String,
-            let command = AppKeyboardCommand(rawValue: rawValue)
+            let command = AppKeyboardCommand(rawValue: rawValue),
+            availableCommands.contains(command)
         else {
             return
         }

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -261,7 +261,7 @@ final class AppKeyboardCommandHostingController: UIViewController {
         appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
             settings: settings,
             commands: AppKeyboardCommand.allCases.filter { !$0.requiresTerminal },
-            action: #selector(performAppKeyboardCommand(_:))
+            action: #selector(performGlobalAppKeyboardCommand(_:))
         )
     }
 
@@ -301,7 +301,7 @@ final class AppKeyboardCommandHostingController: UIViewController {
     }
 
     @objc
-    private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
+    private func performGlobalAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
             let rawValue = sender.propertyList as? String,
             let command = AppKeyboardCommand(rawValue: rawValue),

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -70,6 +70,19 @@ final class AppKeyboardCommandCenter: ObservableObject {
         commandHandler?(command)
     }
 
+    @discardableResult
+    func performIfAvailable(_ command: AppKeyboardCommand) -> Bool {
+        guard
+            !isShortcutCaptureActive,
+            availableCommands.contains(command),
+            let commandHandler
+        else {
+            return false
+        }
+        commandHandler(command)
+        return true
+    }
+
     func registerSelectedTerminal(
         owner: AnyObject,
         onCommand: @escaping (AppKeyboardCommand) -> Void
@@ -193,6 +206,7 @@ struct AppKeyboardCommandHost<Content: View>: UIViewControllerRepresentable {
         _ controller: AppKeyboardCommandHostingController,
         context: Context
     ) {
+        controller.updateContent(AnyView(content))
         controller.update(
             settings: center.settings,
             availableCommands: center.availableCommands,
@@ -293,6 +307,10 @@ final class AppKeyboardCommandHostingController: UIViewController {
         if !unhandledPresses.isEmpty {
             super.pressesBegan(unhandledPresses, with: event)
         }
+    }
+
+    func updateContent(_ rootView: AnyView) {
+        contentController.rootView = rootView
     }
 
     func update(

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -1,53 +1,93 @@
 import SwiftUI
 import UIKit
 
-struct AppKeyboardCommandResponder: UIViewRepresentable {
-    var settings: KeyboardSettings
-    var isEnabled: Bool
-    var onCommand: (AppKeyboardCommand) -> Void
-
-    func makeUIView(context: Context) -> AppKeyboardCommandResponderView {
-        AppKeyboardCommandResponderView()
-    }
-
-    func updateUIView(
-        _ view: AppKeyboardCommandResponderView,
-        context: Context
-    ) {
-        view.update(
-            settings: settings,
-            isEnabled: isEnabled,
-            onCommand: onCommand
-        )
-    }
-}
-
-final class AppKeyboardCommandResponderView: UIView {
-    private var appKeyCommands: [UIKeyCommand] = []
+@MainActor
+final class AppKeyboardCommandCenter: ObservableObject {
+    @Published private(set) var settings: KeyboardSettings = .default
     private var commandHandler: ((AppKeyboardCommand) -> Void)?
-    private var isEnabled = false
-
-    override var canBecomeFirstResponder: Bool {
-        isEnabled
-    }
-
-    override var keyCommands: [UIKeyCommand]? {
-        appKeyCommands
-    }
+    private weak var hostingController: AppKeyboardCommandHostingController?
+    private var isShortcutCaptureActive = false
 
     func update(
         settings: KeyboardSettings,
-        isEnabled: Bool,
         onCommand: @escaping (AppKeyboardCommand) -> Void
     ) {
-        self.isEnabled = isEnabled
         commandHandler = onCommand
-        appKeyCommands = AppKeyboardCommand.allCases.compactMap { command -> UIKeyCommand? in
+        if self.settings != settings {
+            self.settings = settings
+        }
+    }
+
+    func perform(_ command: AppKeyboardCommand) {
+        commandHandler?(command)
+    }
+
+    func register(_ hostingController: AppKeyboardCommandHostingController) {
+        self.hostingController = hostingController
+        hostingController.setSuspended(isShortcutCaptureActive)
+    }
+
+    func setShortcutCaptureActive(_ isActive: Bool) {
+        isShortcutCaptureActive = isActive
+        hostingController?.setSuspended(isActive)
+    }
+}
+
+private struct AppKeyboardCommandCenterKey: EnvironmentKey {
+    static let defaultValue: AppKeyboardCommandCenter? = nil
+}
+
+extension EnvironmentValues {
+    var appKeyboardCommandCenter: AppKeyboardCommandCenter? {
+        get { self[AppKeyboardCommandCenterKey.self] }
+        set { self[AppKeyboardCommandCenterKey.self] = newValue }
+    }
+}
+
+struct AppKeyboardCommandHost<Content: View>: UIViewControllerRepresentable {
+    @ObservedObject var center: AppKeyboardCommandCenter
+    private let content: Content
+
+    init(
+        center: AppKeyboardCommandCenter,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.center = center
+        self.content = content()
+    }
+
+    func makeUIViewController(context: Context) -> AppKeyboardCommandHostingController {
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(content),
+            commandCenter: center
+        )
+        controller.update(settings: center.settings, commandCenter: center)
+        center.register(controller)
+        return controller
+    }
+
+    func updateUIViewController(
+        _ controller: AppKeyboardCommandHostingController,
+        context: Context
+    ) {
+        controller.update(settings: center.settings, commandCenter: center)
+        center.register(controller)
+    }
+}
+
+@MainActor
+enum AppKeyboardKeyCommandBuilder {
+    static func commands(
+        settings: KeyboardSettings,
+        commands: [AppKeyboardCommand],
+        action: Selector
+    ) -> [UIKeyCommand] {
+        commands.compactMap { command -> UIKeyCommand? in
             guard let binding = settings.binding(for: command) else { return nil }
             let keyCommand = UIKeyCommand(
                 title: command.displayTitle,
                 image: nil,
-                action: #selector(performAppKeyboardCommand(_:)),
+                action: action,
                 input: binding.input,
                 modifierFlags: binding.modifiers.uiKeyModifierFlags,
                 propertyList: command.rawValue
@@ -55,44 +95,116 @@ final class AppKeyboardCommandResponderView: UIView {
             keyCommand.wantsPriorityOverSystemBehavior = true
             return keyCommand
         }
+    }
+}
 
-        if isEnabled {
-            DispatchQueue.main.async { [weak self] in
-                guard let self, !self.hasExternalFirstResponder else { return }
-                _ = self.becomeFirstResponder()
+final class AppKeyboardCommandHostingController: UIViewController {
+    private let contentController: UIHostingController<AnyView>
+    private weak var commandCenter: AppKeyboardCommandCenter?
+    private var appKeyCommands: [UIKeyCommand] = []
+    private var keyboardSettings: KeyboardSettings = .default
+    private var isSuspended = false
+
+    init(rootView: AnyView, commandCenter: AppKeyboardCommandCenter) {
+        contentController = UIHostingController(rootView: rootView)
+        self.commandCenter = commandCenter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+        addChild(contentController)
+        contentController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(contentController.view)
+        NSLayoutConstraint.activate([
+            contentController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            contentController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            contentController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            contentController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        contentController.didMove(toParent: self)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        _ = becomeFirstResponder()
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        return isSuspended ? [] : appKeyCommands
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        true
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var unhandledPresses: Set<UIPress> = []
+        for press in presses {
+            guard
+                let key = press.key,
+                handleKeyPress(
+                    input: key.charactersIgnoringModifiers,
+                    modifierFlags: key.modifierFlags
+                )
+            else {
+                unhandledPresses.insert(press)
+                continue
             }
-        } else if isFirstResponder {
-            resignFirstResponder()
+        }
+        if !unhandledPresses.isEmpty {
+            super.pressesBegan(unhandledPresses, with: event)
         }
     }
 
-    private var hasExternalFirstResponder: Bool {
-        guard let window, let responder = firstResponder(in: window) else {
+    func update(
+        settings: KeyboardSettings,
+        commandCenter: AppKeyboardCommandCenter
+    ) {
+        self.commandCenter = commandCenter
+        keyboardSettings = settings
+        appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
+            settings: settings,
+            commands: AppKeyboardCommand.allCases.filter { !$0.requiresTerminal },
+            action: #selector(performAppKeyboardCommand(_:))
+        )
+    }
+
+    func setSuspended(_ isSuspended: Bool) {
+        self.isSuspended = isSuspended
+    }
+
+    func handleKeyPress(
+        input: String,
+        modifierFlags: UIKeyModifierFlags
+    ) -> Bool {
+        guard !isSuspended else { return false }
+        guard
+            let command = AppKeyboardCommandResolver(settings: keyboardSettings)
+                .command(input: input, modifierFlags: modifierFlags),
+            !command.requiresTerminal
+        else {
             return false
         }
-        return responder !== self
-    }
-
-    private func firstResponder(in view: UIView) -> UIView? {
-        if view.isFirstResponder {
-            return view
-        }
-        for subview in view.subviews {
-            if let responder = firstResponder(in: subview) {
-                return responder
-            }
-        }
-        return nil
+        commandCenter?.perform(command)
+        return true
     }
 
     @objc
     private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
             let rawValue = sender.propertyList as? String,
-            let command = AppKeyboardCommand(rawValue: rawValue)
+            let command = AppKeyboardCommand(rawValue: rawValue),
+            !command.requiresTerminal
         else {
             return
         }
-        commandHandler?(command)
+        commandCenter?.perform(command)
     }
 }

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -48,6 +48,8 @@ final class AppKeyboardCommandCenter: ObservableObject {
     private var isShortcutCaptureActive = false
     private weak var commandPaletteOwner: AnyObject?
     private var commandPaletteHandlers: CommandPaletteHandlers?
+    private weak var selectedTerminalOwner: AnyObject?
+    private var selectedTerminalCommandHandler: ((AppKeyboardCommand) -> Void)?
 
     func update(
         settings: KeyboardSettings,
@@ -61,6 +63,33 @@ final class AppKeyboardCommandCenter: ObservableObject {
 
     func perform(_ command: AppKeyboardCommand) {
         commandHandler?(command)
+    }
+
+    func registerSelectedTerminal(
+        owner: AnyObject,
+        onCommand: @escaping (AppKeyboardCommand) -> Void
+    ) {
+        selectedTerminalOwner = owner
+        selectedTerminalCommandHandler = onCommand
+    }
+
+    func unregisterSelectedTerminal(owner: AnyObject) {
+        guard selectedTerminalOwner === owner else { return }
+        selectedTerminalOwner = nil
+        selectedTerminalCommandHandler = nil
+    }
+
+    @discardableResult
+    func performSelectedTerminal(_ command: AppKeyboardCommand) -> Bool {
+        guard
+            command.requiresTerminal,
+            selectedTerminalOwner != nil,
+            let selectedTerminalCommandHandler
+        else {
+            return false
+        }
+        selectedTerminalCommandHandler(command)
+        return true
     }
 
     func register(_ hostingController: AppKeyboardCommandHostingController) {
@@ -260,8 +289,8 @@ final class AppKeyboardCommandHostingController: UIViewController {
         keyboardSettings = settings
         appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
             settings: settings,
-            commands: AppKeyboardCommand.allCases.filter { !$0.requiresTerminal },
-            action: #selector(performGlobalAppKeyboardCommand(_:))
+            commands: AppKeyboardCommand.allCases,
+            action: #selector(performAppKeyboardCommand(_:))
         )
     }
 
@@ -276,8 +305,7 @@ final class AppKeyboardCommandHostingController: UIViewController {
         guard !isSuspended else { return false }
         guard
             let command = AppKeyboardCommandResolver(settings: keyboardSettings)
-                .command(input: input, modifierFlags: modifierFlags),
-            !command.requiresTerminal
+                .command(input: input, modifierFlags: modifierFlags)
         else {
             return false
         }
@@ -301,11 +329,10 @@ final class AppKeyboardCommandHostingController: UIViewController {
     }
 
     @objc
-    private func performGlobalAppKeyboardCommand(_ sender: UIKeyCommand) {
+    private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
             let rawValue = sender.propertyList as? String,
-            let command = AppKeyboardCommand(rawValue: rawValue),
-            !command.requiresTerminal
+            let command = AppKeyboardCommand(rawValue: rawValue)
         else {
             return
         }
@@ -321,5 +348,86 @@ final class AppKeyboardCommandHostingController: UIViewController {
             return
         }
         commandCenter?.perform(action)
+    }
+}
+
+struct SelectedTerminalKeyboardCommandRegistrationView: UIViewRepresentable {
+    let commandCenter: AppKeyboardCommandCenter?
+    let isSelected: Bool
+    let onCommand: (AppKeyboardCommand) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        view.isUserInteractionEnabled = false
+        context.coordinator.update(
+            commandCenter: commandCenter,
+            isSelected: isSelected,
+            onCommand: onCommand
+        )
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.update(
+            commandCenter: commandCenter,
+            isSelected: isSelected,
+            onCommand: onCommand
+        )
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.disconnect()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private weak var commandCenter: AppKeyboardCommandCenter?
+        private var onCommand: (AppKeyboardCommand) -> Void = { _ in }
+        private var isRegistered = false
+
+        func update(
+            commandCenter: AppKeyboardCommandCenter?,
+            isSelected: Bool,
+            onCommand: @escaping (AppKeyboardCommand) -> Void
+        ) {
+            self.onCommand = onCommand
+
+            if self.commandCenter !== commandCenter {
+                if isRegistered {
+                    self.commandCenter?.unregisterSelectedTerminal(owner: self)
+                }
+                self.commandCenter = commandCenter
+                isRegistered = false
+            }
+
+            guard isSelected, let commandCenter else {
+                if isRegistered {
+                    self.commandCenter?.unregisterSelectedTerminal(owner: self)
+                    isRegistered = false
+                }
+                return
+            }
+
+            guard !isRegistered else { return }
+            commandCenter.registerSelectedTerminal(
+                owner: self,
+                onCommand: { [weak self] command in
+                    self?.onCommand(command)
+                }
+            )
+            isRegistered = true
+        }
+
+        func disconnect() {
+            if isRegistered {
+                commandCenter?.unregisterSelectedTerminal(owner: self)
+            }
+            commandCenter = nil
+            isRegistered = false
+        }
     }
 }

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -1,12 +1,53 @@
 import SwiftUI
 import UIKit
 
+enum CommandPaletteKeyboardAction: String, CaseIterable {
+    case previousResult
+    case nextResult
+    case activateSelection
+    case dismiss
+
+    var input: String {
+        switch self {
+        case .previousResult:
+            UIKeyCommand.inputUpArrow
+        case .nextResult:
+            UIKeyCommand.inputDownArrow
+        case .activateSelection:
+            "\r"
+        case .dismiss:
+            UIKeyCommand.inputEscape
+        }
+    }
+
+    var displayTitle: String {
+        switch self {
+        case .previousResult:
+            "Previous Result"
+        case .nextResult:
+            "Next Result"
+        case .activateSelection:
+            "Choose Result"
+        case .dismiss:
+            "Close Command Palette"
+        }
+    }
+}
+
 @MainActor
 final class AppKeyboardCommandCenter: ObservableObject {
+    private struct CommandPaletteHandlers {
+        let onMoveSelection: (CommandPaletteSelectionDirection) -> Void
+        let onActivateSelection: () -> Void
+        let onDismiss: () -> Void
+    }
+
     @Published private(set) var settings: KeyboardSettings = .default
     private var commandHandler: ((AppKeyboardCommand) -> Void)?
     private weak var hostingController: AppKeyboardCommandHostingController?
     private var isShortcutCaptureActive = false
+    private weak var commandPaletteOwner: AnyObject?
+    private var commandPaletteHandlers: CommandPaletteHandlers?
 
     func update(
         settings: KeyboardSettings,
@@ -30,6 +71,50 @@ final class AppKeyboardCommandCenter: ObservableObject {
     func setShortcutCaptureActive(_ isActive: Bool) {
         isShortcutCaptureActive = isActive
         hostingController?.setSuspended(isActive)
+    }
+
+    func registerCommandPalette(
+        owner: AnyObject,
+        onMoveSelection: @escaping (CommandPaletteSelectionDirection) -> Void,
+        onActivateSelection: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        commandPaletteOwner = owner
+        commandPaletteHandlers = CommandPaletteHandlers(
+            onMoveSelection: onMoveSelection,
+            onActivateSelection: onActivateSelection,
+            onDismiss: onDismiss
+        )
+    }
+
+    func unregisterCommandPalette(owner: AnyObject) {
+        guard commandPaletteOwner === owner else { return }
+        commandPaletteOwner = nil
+        commandPaletteHandlers = nil
+    }
+
+    var hasRegisteredCommandPalette: Bool {
+        commandPaletteOwner != nil && commandPaletteHandlers != nil
+    }
+
+    func perform(_ action: CommandPaletteKeyboardAction) {
+        guard
+            commandPaletteOwner != nil,
+            let commandPaletteHandlers
+        else {
+            return
+        }
+
+        switch action {
+        case .previousResult:
+            commandPaletteHandlers.onMoveSelection(.previous)
+        case .nextResult:
+            commandPaletteHandlers.onMoveSelection(.next)
+        case .activateSelection:
+            commandPaletteHandlers.onActivateSelection()
+        case .dismiss:
+            commandPaletteHandlers.onDismiss()
+        }
     }
 }
 
@@ -137,7 +222,11 @@ final class AppKeyboardCommandHostingController: UIViewController {
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        return isSuspended ? [] : appKeyCommands
+        guard !isSuspended else { return [] }
+        guard commandCenter?.hasRegisteredCommandPalette == true else {
+            return appKeyCommands
+        }
+        return appKeyCommands + commandPaletteKeyCommands
     }
 
     override var canBecomeFirstResponder: Bool {
@@ -196,6 +285,21 @@ final class AppKeyboardCommandHostingController: UIViewController {
         return true
     }
 
+    private var commandPaletteKeyCommands: [UIKeyCommand] {
+        CommandPaletteKeyboardAction.allCases.map { action in
+            let command = UIKeyCommand(
+                title: action.displayTitle,
+                image: nil,
+                action: #selector(performCommandPaletteKeyboardAction(_:)),
+                input: action.input,
+                modifierFlags: [],
+                propertyList: action.rawValue
+            )
+            command.wantsPriorityOverSystemBehavior = true
+            return command
+        }
+    }
+
     @objc
     private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
@@ -206,5 +310,16 @@ final class AppKeyboardCommandHostingController: UIViewController {
             return
         }
         commandCenter?.perform(command)
+    }
+
+    @objc
+    private func performCommandPaletteKeyboardAction(_ sender: UIKeyCommand) {
+        guard
+            let rawValue = sender.propertyList as? String,
+            let action = CommandPaletteKeyboardAction(rawValue: rawValue)
+        else {
+            return
+        }
+        commandCenter?.perform(action)
     }
 }

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -58,11 +58,31 @@ final class AppKeyboardCommandResponderView: UIView {
 
         if isEnabled {
             DispatchQueue.main.async { [weak self] in
-                _ = self?.becomeFirstResponder()
+                guard let self, !self.hasFocusedTextInput else { return }
+                _ = self.becomeFirstResponder()
             }
         } else if isFirstResponder {
             resignFirstResponder()
         }
+    }
+
+    private var hasFocusedTextInput: Bool {
+        guard let window, let responder = firstResponder(in: window) else {
+            return false
+        }
+        return responder is any UITextInput
+    }
+
+    private func firstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let responder = firstResponder(in: subview) {
+                return responder
+            }
+        }
+        return nil
     }
 
     @objc

--- a/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandResponder.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+import UIKit
+
+struct AppKeyboardCommandResponder: UIViewRepresentable {
+    var settings: KeyboardSettings
+    var isEnabled: Bool
+    var onCommand: (AppKeyboardCommand) -> Void
+
+    func makeUIView(context: Context) -> AppKeyboardCommandResponderView {
+        AppKeyboardCommandResponderView()
+    }
+
+    func updateUIView(
+        _ view: AppKeyboardCommandResponderView,
+        context: Context
+    ) {
+        view.update(
+            settings: settings,
+            isEnabled: isEnabled,
+            onCommand: onCommand
+        )
+    }
+}
+
+final class AppKeyboardCommandResponderView: UIView {
+    private var appKeyCommands: [UIKeyCommand] = []
+    private var commandHandler: ((AppKeyboardCommand) -> Void)?
+    private var isEnabled = false
+
+    override var canBecomeFirstResponder: Bool {
+        isEnabled
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        appKeyCommands
+    }
+
+    func update(
+        settings: KeyboardSettings,
+        isEnabled: Bool,
+        onCommand: @escaping (AppKeyboardCommand) -> Void
+    ) {
+        self.isEnabled = isEnabled
+        commandHandler = onCommand
+        appKeyCommands = AppKeyboardCommand.allCases.compactMap { command -> UIKeyCommand? in
+            guard let binding = settings.binding(for: command) else { return nil }
+            let keyCommand = UIKeyCommand(
+                title: command.displayTitle,
+                image: nil,
+                action: #selector(performAppKeyboardCommand(_:)),
+                input: binding.input,
+                modifierFlags: binding.modifiers.uiKeyModifierFlags,
+                propertyList: command.rawValue
+            )
+            keyCommand.wantsPriorityOverSystemBehavior = true
+            return keyCommand
+        }
+
+        if isEnabled {
+            DispatchQueue.main.async { [weak self] in
+                _ = self?.becomeFirstResponder()
+            }
+        } else if isFirstResponder {
+            resignFirstResponder()
+        }
+    }
+
+    @objc
+    private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
+        guard
+            let rawValue = sender.propertyList as? String,
+            let command = AppKeyboardCommand(rawValue: rawValue)
+        else {
+            return
+        }
+        commandHandler?(command)
+    }
+}

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -7,6 +7,30 @@ struct AppKeyboardCommandRouteContext: Equatable {
     var orderedActiveSessionIDs: [SavedWorkspace.ID]
 }
 
+struct TerminalKeyboardReadiness: Equatable {
+    private var readyAttempts: Set<TerminalRuntimeAttemptKey> = []
+
+    mutating func update(
+        isReady: Bool,
+        for attempt: TerminalRuntimeAttemptKey
+    ) {
+        if isReady {
+            readyAttempts.insert(attempt)
+        } else {
+            readyAttempts.remove(attempt)
+        }
+    }
+
+    mutating func retain(_ attempts: [TerminalRuntimeAttemptKey]) {
+        readyAttempts.formIntersection(attempts)
+    }
+
+    func isReady(for attempt: TerminalRuntimeAttemptKey?) -> Bool {
+        guard let attempt else { return false }
+        return readyAttempts.contains(attempt)
+    }
+}
+
 enum AppKeyboardCommandRoute: Equatable {
     case terminal(AppKeyboardCommand)
     case showHome

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -22,7 +22,7 @@ enum AppKeyboardCommandRouter {
         in context: AppKeyboardCommandRouteContext
     ) -> AppKeyboardCommandRoute {
         switch command {
-        case .previousWindow, .nextWindow, .windows, .panes, .attachments:
+        case .previousWindow, .nextWindow, .windows, .newWindow, .panes, .attachments:
             guard
                 context.selectedSessionID != nil,
                 context.isSelectedTerminalReady

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -17,6 +17,12 @@ enum AppKeyboardCommandRoute: Equatable {
 }
 
 enum AppKeyboardCommandRouter {
+    static func availableCommands(
+        in context: AppKeyboardCommandRouteContext
+    ) -> [AppKeyboardCommand] {
+        AppKeyboardCommand.allCases.filter { isAvailable($0, in: context) }
+    }
+
     static func route(
         _ command: AppKeyboardCommand,
         in context: AppKeyboardCommandRouteContext

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -92,9 +92,19 @@ struct AppKeyboardCommandResolver {
         input: String,
         modifierFlags: UIKeyModifierFlags
     ) -> AppKeyboardCommand? {
+        command(
+            input: input,
+            modifiers: KeyboardKeyModifiers(modifierFlags)
+        )
+    }
+
+    func command(
+        input: String,
+        modifiers: KeyboardKeyModifiers
+    ) -> AppKeyboardCommand? {
         let binding = KeyboardKeyBinding(
             input: Self.normalizedInput(input),
-            modifiers: KeyboardKeyModifiers(modifierFlags)
+            modifiers: modifiers
         )
         return commandsByBinding[binding]
     }

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -1,0 +1,128 @@
+import Foundation
+import UIKit
+
+struct AppKeyboardCommandRouteContext: Equatable {
+    var selectedSessionID: SavedWorkspace.ID?
+    var orderedActiveSessionIDs: [SavedWorkspace.ID]
+}
+
+enum AppKeyboardCommandRoute: Equatable {
+    case terminal(AppKeyboardCommand)
+    case showHome
+    case showCommandPalette
+    case showSession(SavedWorkspace.ID)
+    case unavailable
+}
+
+enum AppKeyboardCommandRouter {
+    static func route(
+        _ command: AppKeyboardCommand,
+        in context: AppKeyboardCommandRouteContext
+    ) -> AppKeyboardCommandRoute {
+        switch command {
+        case .previousWindow, .nextWindow, .windows, .panes, .attachments:
+            guard context.selectedSessionID != nil else { return .unavailable }
+            return .terminal(command)
+
+        case .home:
+            return .showHome
+
+        case .commandPalette:
+            return .showCommandPalette
+
+        case .previousSession:
+            return sessionRoute(offset: -1, in: context)
+
+        case .nextSession:
+            return sessionRoute(offset: 1, in: context)
+        }
+    }
+
+    static func isAvailable(
+        _ command: AppKeyboardCommand,
+        in context: AppKeyboardCommandRouteContext
+    ) -> Bool {
+        route(command, in: context) != .unavailable
+    }
+
+    private static func sessionRoute(
+        offset: Int,
+        in context: AppKeyboardCommandRouteContext
+    ) -> AppKeyboardCommandRoute {
+        let ids = context.orderedActiveSessionIDs
+        guard !ids.isEmpty else { return .unavailable }
+
+        guard
+            let selectedSessionID = context.selectedSessionID,
+            let selectedIndex = ids.firstIndex(of: selectedSessionID)
+        else {
+            return .showSession(offset < 0 ? ids[ids.count - 1] : ids[0])
+        }
+
+        let destinationIndex = (selectedIndex + offset + ids.count) % ids.count
+        return .showSession(ids[destinationIndex])
+    }
+}
+
+struct AppKeyboardCommandResolver {
+    private let commandsByBinding: [KeyboardKeyBinding: AppKeyboardCommand]
+
+    init(settings: KeyboardSettings) {
+        self.commandsByBinding = Dictionary(
+            uniqueKeysWithValues: AppKeyboardCommand.allCases.compactMap { command in
+                settings.binding(for: command).map { ($0, command) }
+            }
+        )
+    }
+
+    func command(
+        input: String,
+        modifierFlags: UIKeyModifierFlags
+    ) -> AppKeyboardCommand? {
+        let binding = KeyboardKeyBinding(
+            input: Self.normalizedInput(input),
+            modifiers: KeyboardKeyModifiers(modifierFlags)
+        )
+        return commandsByBinding[binding]
+    }
+
+    private static func normalizedInput(_ input: String) -> String {
+        input.count == 1 ? input.lowercased() : input
+    }
+}
+
+extension KeyboardKeyModifiers {
+    init(_ flags: UIKeyModifierFlags) {
+        var value: KeyboardKeyModifiers = []
+        if flags.contains(.command) {
+            value.insert(.command)
+        }
+        if flags.contains(.shift) {
+            value.insert(.shift)
+        }
+        if flags.contains(.alternate) {
+            value.insert(.option)
+        }
+        if flags.contains(.control) {
+            value.insert(.control)
+        }
+        self = value
+    }
+
+    var uiKeyModifierFlags: UIKeyModifierFlags {
+        var value: UIKeyModifierFlags = []
+        if contains(.command) {
+            value.insert(.command)
+        }
+        if contains(.shift) {
+            value.insert(.shift)
+        }
+        if contains(.option) {
+            value.insert(.alternate)
+        }
+        if contains(.control) {
+            value.insert(.control)
+        }
+        return value
+    }
+}

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct AppKeyboardCommandRouteContext: Equatable {
     var selectedSessionID: SavedWorkspace.ID?
+    var isSelectedTerminalReady: Bool
     var orderedActiveSessionIDs: [SavedWorkspace.ID]
 }
 
@@ -21,7 +22,12 @@ enum AppKeyboardCommandRouter {
     ) -> AppKeyboardCommandRoute {
         switch command {
         case .previousWindow, .nextWindow, .windows, .panes, .attachments:
-            guard context.selectedSessionID != nil else { return .unavailable }
+            guard
+                context.selectedSessionID != nil,
+                context.isSelectedTerminalReady
+            else {
+                return .unavailable
+            }
             return .terminal(command)
 
         case .home:

--- a/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
+++ b/RemuxApp/Sources/App/AppKeyboardCommandRouter.swift
@@ -12,6 +12,7 @@ enum AppKeyboardCommandRoute: Equatable {
     case showHome
     case showCommandPalette
     case showSession(SavedWorkspace.ID)
+    case adjustFontSize(by: Float32)
     case unavailable
 }
 
@@ -35,6 +36,12 @@ enum AppKeyboardCommandRouter {
 
         case .commandPalette:
             return .showCommandPalette
+
+        case .increaseFontSize:
+            return .adjustFontSize(by: 1)
+
+        case .decreaseFontSize:
+            return .adjustFontSize(by: -1)
 
         case .previousSession:
             return sessionRoute(offset: -1, in: context)

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -62,10 +62,15 @@ enum CommandPaletteSelection {
 struct CommandPaletteState: Equatable {
     private(set) var results: [CommandPaletteItem]
     private(set) var selectedResultID: CommandPaletteItem.ID?
+    private(set) var appliedQuery: String
 
-    init(results: [CommandPaletteItem]) {
+    init(
+        results: [CommandPaletteItem],
+        appliedQuery: String = ""
+    ) {
         self.results = results
         selectedResultID = CommandPaletteSelection.initialID(in: results)
+        self.appliedQuery = appliedQuery
     }
 
     var selectedResult: CommandPaletteItem? {
@@ -80,18 +85,27 @@ struct CommandPaletteState: Equatable {
         selectedResultID = CommandPaletteSelection.initialID(in: newResults)
     }
 
+    mutating func replaceResults(
+        _ newResults: [CommandPaletteItem],
+        for query: String
+    ) {
+        appliedQuery = query
+        replaceResults(newResults)
+    }
+
     mutating func refreshAvailability(
         query: String,
         commands: [CommandPaletteItem],
         snapshots: [TerminalViewportSnapshot]
     ) {
-        let currentSelection = selectedResultID
+        let currentSelection = query == appliedQuery ? selectedResultID : nil
         replaceResults(
             CommandPaletteSearch.results(
                 query: query,
                 commands: commands,
                 snapshots: snapshots
-            )
+            ),
+            for: query
         )
         if let currentSelection,
            results.contains(where: {

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -12,6 +12,21 @@ struct CommandPaletteItem: Identifiable, Equatable {
     let title: String
     let subtitle: String?
     let action: CommandPaletteAction
+    let isEnabled: Bool
+
+    init(
+        id: String,
+        title: String,
+        subtitle: String?,
+        action: CommandPaletteAction,
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+        self.isEnabled = isEnabled
+    }
 }
 
 enum CommandPaletteSearch {
@@ -41,6 +56,7 @@ enum CommandPaletteSearch {
                             snapshot.serverName,
                             snapshot.sessionName,
                             snapshot.windowName,
+                            "Pane \(snapshot.paneIndex)",
                         ].joined(separator: " · "),
                         action: .viewport(snapshot)
                     )

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -29,6 +29,36 @@ struct CommandPaletteItem: Identifiable, Equatable {
     }
 }
 
+enum CommandPaletteSelectionDirection {
+    case previous
+    case next
+}
+
+enum CommandPaletteSelection {
+    static func initialID(in results: [CommandPaletteItem]) -> CommandPaletteItem.ID? {
+        results.first(where: \.isEnabled)?.id
+    }
+
+    static func moving(
+        from selectedID: CommandPaletteItem.ID?,
+        direction: CommandPaletteSelectionDirection,
+        in results: [CommandPaletteItem]
+    ) -> CommandPaletteItem.ID? {
+        let enabledResults = results.filter(\.isEnabled)
+        guard !enabledResults.isEmpty else { return nil }
+        guard
+            let selectedID,
+            let selectedIndex = enabledResults.firstIndex(where: { $0.id == selectedID })
+        else {
+            return direction == .previous ? enabledResults.last?.id : enabledResults.first?.id
+        }
+
+        let offset = direction == .previous ? -1 : 1
+        let nextIndex = min(max(selectedIndex + offset, 0), enabledResults.count - 1)
+        return enabledResults[nextIndex].id
+    }
+}
+
 enum CommandPaletteSearch {
     static func results(
         query: String,

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -76,8 +76,30 @@ struct CommandPaletteState: Equatable {
     }
 
     mutating func replaceResults(_ newResults: [CommandPaletteItem]) {
+        let currentSelection = selectedResultID
         results = newResults
-        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+        if let currentSelection,
+           newResults.contains(where: {
+               $0.id == currentSelection && $0.isEnabled
+           }) {
+            selectedResultID = currentSelection
+        } else {
+            selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+        }
+    }
+
+    mutating func refresh(
+        query: String,
+        commands: [CommandPaletteItem],
+        snapshots: [TerminalViewportSnapshot]
+    ) {
+        replaceResults(
+            CommandPaletteSearch.results(
+                query: query,
+                commands: commands,
+                snapshots: snapshots
+            )
+        )
     }
 
     mutating func moveSelection(

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -59,6 +59,38 @@ enum CommandPaletteSelection {
     }
 }
 
+struct CommandPaletteState: Equatable {
+    private(set) var results: [CommandPaletteItem]
+    private(set) var selectedResultID: CommandPaletteItem.ID?
+
+    init(results: [CommandPaletteItem]) {
+        self.results = results
+        selectedResultID = CommandPaletteSelection.initialID(in: results)
+    }
+
+    var selectedResult: CommandPaletteItem? {
+        guard let selectedResultID else { return nil }
+        return results.first {
+            $0.id == selectedResultID && $0.isEnabled
+        }
+    }
+
+    mutating func replaceResults(_ newResults: [CommandPaletteItem]) {
+        results = newResults
+        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+    }
+
+    mutating func moveSelection(
+        _ direction: CommandPaletteSelectionDirection
+    ) {
+        selectedResultID = CommandPaletteSelection.moving(
+            from: selectedResultID,
+            direction: direction,
+            in: results
+        )
+    }
+}
+
 enum CommandPaletteSearch {
     static func results(
         query: String,

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -76,23 +76,16 @@ struct CommandPaletteState: Equatable {
     }
 
     mutating func replaceResults(_ newResults: [CommandPaletteItem]) {
-        let currentSelection = selectedResultID
         results = newResults
-        if let currentSelection,
-           newResults.contains(where: {
-               $0.id == currentSelection && $0.isEnabled
-           }) {
-            selectedResultID = currentSelection
-        } else {
-            selectedResultID = CommandPaletteSelection.initialID(in: newResults)
-        }
+        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
     }
 
-    mutating func refresh(
+    mutating func refreshAvailability(
         query: String,
         commands: [CommandPaletteItem],
         snapshots: [TerminalViewportSnapshot]
     ) {
+        let currentSelection = selectedResultID
         replaceResults(
             CommandPaletteSearch.results(
                 query: query,
@@ -100,6 +93,12 @@ struct CommandPaletteState: Equatable {
                 snapshots: snapshots
             )
         )
+        if let currentSelection,
+           results.contains(where: {
+               $0.id == currentSelection && $0.isEnabled
+           }) {
+            selectedResultID = currentSelection
+        }
     }
 
     mutating func moveSelection(

--- a/RemuxApp/Sources/App/CommandPaletteSearch.swift
+++ b/RemuxApp/Sources/App/CommandPaletteSearch.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum CommandPaletteAction: Equatable {
+    case addConnection
+    case newSession(SavedServer.ID)
+    case appCommand(AppKeyboardCommand)
+    case viewport(TerminalViewportSnapshot)
+}
+
+struct CommandPaletteItem: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let subtitle: String?
+    let action: CommandPaletteAction
+}
+
+enum CommandPaletteSearch {
+    static func results(
+        query: String,
+        commands: [CommandPaletteItem],
+        snapshots: [TerminalViewportSnapshot]
+    ) -> [CommandPaletteItem] {
+        let query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else { return commands }
+
+        let matchingCommands = commands.filter {
+            $0.title.localizedCaseInsensitiveContains(query)
+                || $0.subtitle?.localizedCaseInsensitiveContains(query) == true
+        }
+        let matchingText = snapshots.flatMap { snapshot in
+            snapshot.text
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .enumerated()
+                .compactMap { lineNumber, line -> CommandPaletteItem? in
+                    let snippet = String(line).trimmingCharacters(in: .whitespaces)
+                    guard snippet.localizedCaseInsensitiveContains(query) else { return nil }
+                    return CommandPaletteItem(
+                        id: "viewport:\(snapshot.workspaceID):\(snapshot.paneID):\(lineNumber)",
+                        title: snippet.isEmpty ? "Matching blank line" : snippet,
+                        subtitle: [
+                            snapshot.serverName,
+                            snapshot.sessionName,
+                            snapshot.windowName,
+                        ].joined(separator: " · "),
+                        action: .viewport(snapshot)
+                    )
+                }
+        }
+        return matchingCommands + matchingText
+    }
+}

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -162,16 +162,18 @@ struct CommandPaletteView: View {
                     try? await Task.sleep(for: .milliseconds(120))
                 }
                 guard !Task.isCancelled else { return }
-                paletteState.refresh(
-                    query: value,
-                    commands: commands,
-                    snapshots: snapshots()
+                paletteState.replaceResults(
+                    CommandPaletteSearch.results(
+                        query: value,
+                        commands: commands,
+                        snapshots: snapshots()
+                    )
                 )
             }
         }
         .onChange(of: commands) { _, updatedCommands in
             searchTask?.cancel()
-            paletteState.refresh(
+            paletteState.refreshAvailability(
                 query: query,
                 commands: updatedCommands,
                 snapshots: snapshots()

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -1,6 +1,19 @@
 import SwiftUI
 import UIKit
 
+enum CommandPaletteLayout {
+    static let maximumVisibleResultCount = 6
+    static let inputRowHeight: CGFloat = 44
+    static let resultRowHeight: CGFloat = 56
+    static let emptyResultHeight: CGFloat = 120
+
+    static func resultAreaHeight(for resultCount: Int) -> CGFloat {
+        guard resultCount > 0 else { return emptyResultHeight }
+        return CGFloat(min(resultCount, maximumVisibleResultCount))
+            * resultRowHeight
+    }
+}
+
 struct CommandPaletteView: View {
     let commands: [CommandPaletteItem]
     let snapshots: () -> [TerminalViewportSnapshot]
@@ -8,9 +21,23 @@ struct CommandPaletteView: View {
     let onDismiss: () -> Void
 
     @State private var query = ""
-    @State private var results: [CommandPaletteItem] = []
-    @State private var selectedResultID: CommandPaletteItem.ID?
+    @State private var paletteState: CommandPaletteState
     @State private var searchTask: Task<Void, Never>?
+
+    init(
+        commands: [CommandPaletteItem],
+        snapshots: @escaping () -> [TerminalViewportSnapshot],
+        onSelect: @escaping (CommandPaletteAction) -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.commands = commands
+        self.snapshots = snapshots
+        self.onSelect = onSelect
+        self.onDismiss = onDismiss
+        _paletteState = State(
+            initialValue: CommandPaletteState(results: commands)
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -29,19 +56,21 @@ struct CommandPaletteView: View {
                 }
                 .buttonStyle(.plain)
             }
-            .padding()
+            .padding(.horizontal, 12)
+            .frame(height: CommandPaletteLayout.inputRowHeight)
             .background(LibraryHomePalette.rowSurface)
 
             Divider()
                 .overlay(LibraryHomePalette.separator)
 
-            if results.isEmpty {
+            if paletteState.results.isEmpty {
                 ContentUnavailableView.search(text: query)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: CommandPaletteLayout.emptyResultHeight)
                     .background(LibraryHomePalette.background)
             } else {
                 ScrollViewReader { proxy in
-                    List(results) { item in
+                    List(paletteState.results) { item in
                         Button {
                             onSelect(item.action)
                         } label: {
@@ -55,14 +84,29 @@ struct CommandPaletteView: View {
                                         .lineLimit(1)
                                 }
                             }
+                            .frame(
+                                maxWidth: .infinity,
+                                minHeight: CommandPaletteLayout.resultRowHeight,
+                                alignment: .leading
+                            )
+                            .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
                         .accessibilityIdentifier("command-palette.item.\(item.id)")
                         .accessibilityAddTraits(
-                            item.id == selectedResultID ? .isSelected : []
+                            item.id == paletteState.selectedResultID ? .isSelected : []
                         )
                         .disabled(!item.isEnabled)
+                        .listRowInsets(
+                            EdgeInsets(
+                                top: 0,
+                                leading: 16,
+                                bottom: 0,
+                                trailing: 16
+                            )
+                        )
                         .listRowBackground(
-                            item.id == selectedResultID
+                            item.id == paletteState.selectedResultID
                                 ? LibraryHomePalette.controlAccent.opacity(0.22)
                                 : LibraryHomePalette.rowSurface
                         )
@@ -72,7 +116,12 @@ struct CommandPaletteView: View {
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
                     .background(LibraryHomePalette.background)
-                    .onChange(of: selectedResultID) { _, id in
+                    .frame(
+                        height: CommandPaletteLayout.resultAreaHeight(
+                            for: paletteState.results.count
+                        )
+                    )
+                    .onChange(of: paletteState.selectedResultID) { _, id in
                         guard let id else { return }
                         withAnimation {
                             proxy.scrollTo(id, anchor: .center)
@@ -81,7 +130,8 @@ struct CommandPaletteView: View {
                 }
             }
         }
-        .frame(maxWidth: 620, maxHeight: 520)
+        .frame(maxWidth: 620)
+        .fixedSize(horizontal: false, vertical: true)
         .background(
             LibraryHomePalette.background,
             in: RoundedRectangle(cornerRadius: 18)
@@ -91,12 +141,9 @@ struct CommandPaletteView: View {
                 .stroke(LibraryHomePalette.separator, lineWidth: 1)
         }
         .shadow(radius: 30)
-        .padding()
+        .padding(16)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("command-palette")
-        .task {
-            updateResults(commands)
-        }
         .onChange(of: query) { _, value in
             searchTask?.cancel()
             searchTask = Task { @MainActor in
@@ -119,27 +166,15 @@ struct CommandPaletteView: View {
     }
 
     private func updateResults(_ newResults: [CommandPaletteItem]) {
-        results = newResults
-        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+        paletteState.replaceResults(newResults)
     }
 
     private func moveSelection(_ direction: CommandPaletteSelectionDirection) {
-        selectedResultID = CommandPaletteSelection.moving(
-            from: selectedResultID,
-            direction: direction,
-            in: results
-        )
+        paletteState.moveSelection(direction)
     }
 
     private func activateSelectedResult() {
-        guard
-            let selectedResultID,
-            let result = results.first(where: {
-                $0.id == selectedResultID && $0.isEnabled
-            })
-        else {
-            return
-        }
+        guard let result = paletteState.selectedResult else { return }
         onSelect(result.action)
     }
 }
@@ -202,6 +237,14 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
 
     override var keyCommands: [UIKeyCommand]? {
         [
+            priorityKeyCommand(
+                input: UIKeyCommand.inputUpArrow,
+                action: #selector(selectPreviousResult)
+            ),
+            priorityKeyCommand(
+                input: UIKeyCommand.inputDownArrow,
+                action: #selector(selectNextResult)
+            ),
             priorityKeyCommand(
                 input: "\r",
                 action: #selector(activateSelection)
@@ -295,6 +338,16 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
         )
         command.wantsPriorityOverSystemBehavior = true
         return command
+    }
+
+    @objc
+    private func selectPreviousResult() {
+        onMoveSelection?(.previous)
+    }
+
+    @objc
+    private func selectNextResult() {
+        onMoveSelection?(.next)
     }
 
     @objc

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct CommandPaletteView: View {
+    let commands: [CommandPaletteItem]
+    let snapshots: () -> [TerminalViewportSnapshot]
+    let onSelect: (CommandPaletteAction) -> Void
+    let onDismiss: () -> Void
+
+    @State private var query = ""
+    @State private var results: [CommandPaletteItem] = []
+    @State private var searchTask: Task<Void, Never>?
+    @FocusState private var isSearchFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Image(systemName: "command")
+                TextField("Type a command or search visible terminals", text: $query)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .focused($isSearchFocused)
+                    .accessibilityIdentifier("command-palette.search")
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .buttonStyle(.plain)
+            }
+            .padding()
+
+            Divider()
+
+            if results.isEmpty {
+                ContentUnavailableView.search(text: query)
+            } else {
+                List(results) { item in
+                    Button {
+                        onSelect(item.action)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(item.title)
+                                .lineLimit(1)
+                            if let subtitle = item.subtitle {
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                        }
+                    }
+                    .accessibilityIdentifier("command-palette.item.\(item.id)")
+                }
+                .listStyle(.plain)
+            }
+        }
+        .frame(maxWidth: 620, maxHeight: 520)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18))
+        .shadow(radius: 30)
+        .padding()
+        .accessibilityIdentifier("command-palette")
+        .onAppear {
+            results = commands
+            isSearchFocused = true
+        }
+        .onChange(of: query) { _, value in
+            searchTask?.cancel()
+            searchTask = Task { @MainActor in
+                if !value.isEmpty {
+                    try? await Task.sleep(for: .milliseconds(120))
+                }
+                guard !Task.isCancelled else { return }
+                results = CommandPaletteSearch.results(
+                    query: value,
+                    commands: commands,
+                    snapshots: snapshots()
+                )
+            }
+        }
+        .onDisappear {
+            searchTask?.cancel()
+        }
+    }
+}

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -306,7 +306,7 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
             .alternate,
             .control,
         ]
-        guard modifierFlags.intersection(actionModifiers).isEmpty else {
+        guard modifierFlags.isDisjoint(with: actionModifiers) else {
             return false
         }
 

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -180,6 +180,7 @@ struct CommandPaletteView: View {
 }
 
 private struct CommandPaletteSearchField: UIViewRepresentable {
+    @Environment(\.appKeyboardCommandCenter) private var commandCenter
     @Binding var text: String
     let onMoveSelection: (CommandPaletteSelectionDirection) -> Void
     let onActivateSelection: () -> Void
@@ -215,6 +216,14 @@ private struct CommandPaletteSearchField: UIViewRepresentable {
         field.onMoveSelection = onMoveSelection
         field.onActivateSelection = onActivateSelection
         field.onDismiss = onDismiss
+        field.setCommandCenter(commandCenter)
+    }
+
+    static func dismantleUIView(
+        _ field: CommandPaletteTextField,
+        coordinator: ()
+    ) {
+        field.unregisterCommandPalette()
     }
 }
 
@@ -223,6 +232,7 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
     var onMoveSelection: ((CommandPaletteSelectionDirection) -> Void)?
     var onActivateSelection: (() -> Void)?
     var onDismiss: (() -> Void)?
+    private weak var commandCenter: AppKeyboardCommandCenter?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -235,29 +245,13 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
         fatalError("init(coder:) is unavailable")
     }
 
-    override var keyCommands: [UIKeyCommand]? {
-        [
-            priorityKeyCommand(
-                input: UIKeyCommand.inputUpArrow,
-                action: #selector(selectPreviousResult)
-            ),
-            priorityKeyCommand(
-                input: UIKeyCommand.inputDownArrow,
-                action: #selector(selectNextResult)
-            ),
-            priorityKeyCommand(
-                input: "\r",
-                action: #selector(activateSelection)
-            ),
-            priorityKeyCommand(
-                input: UIKeyCommand.inputEscape,
-                action: #selector(dismissPalette)
-            ),
-        ]
-    }
-
     override func didMoveToWindow() {
         super.didMoveToWindow()
+        if window == nil {
+            unregisterCommandPalette()
+            return
+        }
+        registerCommandPalette()
         focusWhenAttached()
     }
 
@@ -327,37 +321,32 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
         return false
     }
 
-    private func priorityKeyCommand(
-        input: String,
-        action: Selector
-    ) -> UIKeyCommand {
-        let command = UIKeyCommand(
-            input: input,
-            modifierFlags: [],
-            action: action
+    func setCommandCenter(_ commandCenter: AppKeyboardCommandCenter?) {
+        if self.commandCenter !== commandCenter {
+            unregisterCommandPalette()
+            self.commandCenter = commandCenter
+        }
+        registerCommandPalette()
+    }
+
+    func unregisterCommandPalette() {
+        commandCenter?.unregisterCommandPalette(owner: self)
+    }
+
+    private func registerCommandPalette() {
+        guard window != nil else { return }
+        commandCenter?.registerCommandPalette(
+            owner: self,
+            onMoveSelection: { [weak self] direction in
+                self?.onMoveSelection?(direction)
+            },
+            onActivateSelection: { [weak self] in
+                self?.onActivateSelection?()
+            },
+            onDismiss: { [weak self] in
+                self?.onDismiss?()
+            }
         )
-        command.wantsPriorityOverSystemBehavior = true
-        return command
-    }
-
-    @objc
-    private func selectPreviousResult() {
-        onMoveSelection?(.previous)
-    }
-
-    @objc
-    private func selectNextResult() {
-        onMoveSelection?(.next)
-    }
-
-    @objc
-    private func activateSelection() {
-        onActivateSelection?()
-    }
-
-    @objc
-    private func dismissPalette() {
-        onDismiss?()
     }
 
     @objc

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -28,11 +28,15 @@ struct CommandPaletteView: View {
                 .buttonStyle(.plain)
             }
             .padding()
+            .background(LibraryHomePalette.rowSurface)
 
             Divider()
+                .overlay(LibraryHomePalette.separator)
 
             if results.isEmpty {
                 ContentUnavailableView.search(text: query)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(LibraryHomePalette.background)
             } else {
                 List(results) { item in
                     Button {
@@ -51,17 +55,30 @@ struct CommandPaletteView: View {
                     }
                     .accessibilityIdentifier("command-palette.item.\(item.id)")
                     .disabled(!item.isEnabled)
+                    .listRowBackground(LibraryHomePalette.rowSurface)
+                    .listRowSeparatorTint(LibraryHomePalette.separator)
                 }
                 .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(LibraryHomePalette.background)
             }
         }
         .frame(maxWidth: 620, maxHeight: 520)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18))
+        .background(
+            LibraryHomePalette.background,
+            in: RoundedRectangle(cornerRadius: 18)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(LibraryHomePalette.separator, lineWidth: 1)
+        }
         .shadow(radius: 30)
         .padding()
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("command-palette")
-        .onAppear {
+        .task {
             results = commands
+            await Task.yield()
             isSearchFocused = true
         }
         .onChange(of: query) { _, value in

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -162,22 +162,24 @@ struct CommandPaletteView: View {
                     try? await Task.sleep(for: .milliseconds(120))
                 }
                 guard !Task.isCancelled else { return }
-                updateResults(
-                    CommandPaletteSearch.results(
-                        query: value,
-                        commands: commands,
-                        snapshots: snapshots()
-                    )
+                paletteState.refresh(
+                    query: value,
+                    commands: commands,
+                    snapshots: snapshots()
                 )
             }
+        }
+        .onChange(of: commands) { _, updatedCommands in
+            searchTask?.cancel()
+            paletteState.refresh(
+                query: query,
+                commands: updatedCommands,
+                snapshots: snapshots()
+            )
         }
         .onDisappear {
             searchTask?.cancel()
         }
-    }
-
-    private func updateResults(_ newResults: [CommandPaletteItem]) {
-        paletteState.replaceResults(newResults)
     }
 
     private func moveSelection(_ direction: CommandPaletteSelectionDirection) {

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct CommandPaletteView: View {
     let commands: [CommandPaletteItem]
@@ -8,18 +9,19 @@ struct CommandPaletteView: View {
 
     @State private var query = ""
     @State private var results: [CommandPaletteItem] = []
+    @State private var selectedResultID: CommandPaletteItem.ID?
     @State private var searchTask: Task<Void, Never>?
-    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
                 Image(systemName: "command")
-                TextField("Type a command or search visible terminals", text: $query)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused($isSearchFocused)
-                    .accessibilityIdentifier("command-palette.search")
+                CommandPaletteSearchField(
+                    text: $query,
+                    onMoveSelection: moveSelection,
+                    onActivateSelection: activateSelectedResult,
+                    onDismiss: onDismiss
+                )
                 Button {
                     onDismiss()
                 } label: {
@@ -38,29 +40,45 @@ struct CommandPaletteView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(LibraryHomePalette.background)
             } else {
-                List(results) { item in
-                    Button {
-                        onSelect(item.action)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(item.title)
-                                .lineLimit(1)
-                            if let subtitle = item.subtitle {
-                                Text(subtitle)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                ScrollViewReader { proxy in
+                    List(results) { item in
+                        Button {
+                            onSelect(item.action)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(item.title)
                                     .lineLimit(1)
+                                if let subtitle = item.subtitle {
+                                    Text(subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
                             }
                         }
+                        .accessibilityIdentifier("command-palette.item.\(item.id)")
+                        .accessibilityAddTraits(
+                            item.id == selectedResultID ? .isSelected : []
+                        )
+                        .disabled(!item.isEnabled)
+                        .listRowBackground(
+                            item.id == selectedResultID
+                                ? LibraryHomePalette.controlAccent.opacity(0.22)
+                                : LibraryHomePalette.rowSurface
+                        )
+                        .listRowSeparatorTint(LibraryHomePalette.separator)
+                        .id(item.id)
                     }
-                    .accessibilityIdentifier("command-palette.item.\(item.id)")
-                    .disabled(!item.isEnabled)
-                    .listRowBackground(LibraryHomePalette.rowSurface)
-                    .listRowSeparatorTint(LibraryHomePalette.separator)
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .background(LibraryHomePalette.background)
+                    .onChange(of: selectedResultID) { _, id in
+                        guard let id else { return }
+                        withAnimation {
+                            proxy.scrollTo(id, anchor: .center)
+                        }
+                    }
                 }
-                .listStyle(.plain)
-                .scrollContentBackground(.hidden)
-                .background(LibraryHomePalette.background)
             }
         }
         .frame(maxWidth: 620, maxHeight: 520)
@@ -77,9 +95,7 @@ struct CommandPaletteView: View {
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("command-palette")
         .task {
-            results = commands
-            await Task.yield()
-            isSearchFocused = true
+            updateResults(commands)
         }
         .onChange(of: query) { _, value in
             searchTask?.cancel()
@@ -88,15 +104,211 @@ struct CommandPaletteView: View {
                     try? await Task.sleep(for: .milliseconds(120))
                 }
                 guard !Task.isCancelled else { return }
-                results = CommandPaletteSearch.results(
-                    query: value,
-                    commands: commands,
-                    snapshots: snapshots()
+                updateResults(
+                    CommandPaletteSearch.results(
+                        query: value,
+                        commands: commands,
+                        snapshots: snapshots()
+                    )
                 )
             }
         }
         .onDisappear {
             searchTask?.cancel()
         }
+    }
+
+    private func updateResults(_ newResults: [CommandPaletteItem]) {
+        results = newResults
+        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+    }
+
+    private func moveSelection(_ direction: CommandPaletteSelectionDirection) {
+        selectedResultID = CommandPaletteSelection.moving(
+            from: selectedResultID,
+            direction: direction,
+            in: results
+        )
+    }
+
+    private func activateSelectedResult() {
+        guard
+            let selectedResultID,
+            let result = results.first(where: {
+                $0.id == selectedResultID && $0.isEnabled
+            })
+        else {
+            return
+        }
+        onSelect(result.action)
+    }
+}
+
+private struct CommandPaletteSearchField: UIViewRepresentable {
+    @Binding var text: String
+    let onMoveSelection: (CommandPaletteSelectionDirection) -> Void
+    let onActivateSelection: () -> Void
+    let onDismiss: () -> Void
+
+    func makeUIView(context: Context) -> CommandPaletteTextField {
+        let field = CommandPaletteTextField()
+        field.placeholder = "Type a command or search visible terminals"
+        field.autocapitalizationType = .none
+        field.autocorrectionType = .no
+        field.returnKeyType = .go
+        field.borderStyle = .none
+        field.backgroundColor = .clear
+        field.textColor = .label
+        field.tintColor = .label
+        field.accessibilityIdentifier = "command-palette.search"
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        configure(field)
+        return field
+    }
+
+    func updateUIView(_ field: CommandPaletteTextField, context: Context) {
+        configure(field)
+    }
+
+    private func configure(_ field: CommandPaletteTextField) {
+        if field.text != text {
+            field.text = text
+        }
+        field.onTextChange = { value in
+            text = value
+        }
+        field.onMoveSelection = onMoveSelection
+        field.onActivateSelection = onActivateSelection
+        field.onDismiss = onDismiss
+    }
+}
+
+final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
+    var onTextChange: ((String) -> Void)?
+    var onMoveSelection: ((CommandPaletteSelectionDirection) -> Void)?
+    var onActivateSelection: (() -> Void)?
+    var onDismiss: (() -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        delegate = self
+        addTarget(self, action: #selector(textDidChange), for: .editingChanged)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is unavailable")
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+        [
+            priorityKeyCommand(
+                input: "\r",
+                action: #selector(activateSelection)
+            ),
+            priorityKeyCommand(
+                input: UIKeyCommand.inputEscape,
+                action: #selector(dismissPalette)
+            ),
+        ]
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        focusWhenAttached()
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var unhandledPresses: Set<UIPress> = []
+        for press in presses {
+            guard
+                let key = press.key,
+                handleKeyPress(
+                    input: key.charactersIgnoringModifiers,
+                    modifierFlags: key.modifierFlags
+                )
+            else {
+                unhandledPresses.insert(press)
+                continue
+            }
+        }
+        if !unhandledPresses.isEmpty {
+            super.pressesBegan(unhandledPresses, with: event)
+        }
+    }
+
+    func handleKeyPress(
+        input: String,
+        modifierFlags: UIKeyModifierFlags
+    ) -> Bool {
+        let actionModifiers: UIKeyModifierFlags = [
+            .command,
+            .shift,
+            .alternate,
+            .control,
+        ]
+        guard modifierFlags.intersection(actionModifiers).isEmpty else {
+            return false
+        }
+
+        switch input {
+        case UIKeyCommand.inputUpArrow:
+            onMoveSelection?(.previous)
+        case UIKeyCommand.inputDownArrow:
+            onMoveSelection?(.next)
+        case "\r", "\n":
+            onActivateSelection?()
+        case UIKeyCommand.inputEscape:
+            onDismiss?()
+        default:
+            return false
+        }
+        return true
+    }
+
+    func focusWhenAttached() {
+        guard window != nil, !isFirstResponder else { return }
+        if becomeFirstResponder() {
+            return
+        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.window != nil, !self.isFirstResponder else {
+                return
+            }
+            _ = self.becomeFirstResponder()
+        }
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        onActivateSelection?()
+        return false
+    }
+
+    private func priorityKeyCommand(
+        input: String,
+        action: Selector
+    ) -> UIKeyCommand {
+        let command = UIKeyCommand(
+            input: input,
+            modifierFlags: [],
+            action: action
+        )
+        command.wantsPriorityOverSystemBehavior = true
+        return command
+    }
+
+    @objc
+    private func activateSelection() {
+        onActivateSelection?()
+    }
+
+    @objc
+    private func dismissPalette() {
+        onDismiss?()
+    }
+
+    @objc
+    private func textDidChange() {
+        onTextChange?(text ?? "")
     }
 }

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -6,6 +6,9 @@ enum CommandPaletteLayout {
     static let inputRowHeight: CGFloat = 44
     static let resultRowHeight: CGFloat = 56
     static let emptyResultHeight: CGFloat = 120
+    static let screenMargin: CGFloat = 20
+    static let cardInset: CGFloat = 10
+    static let innerCornerRadius: CGFloat = 12
 
     static func resultAreaHeight(for resultCount: Int) -> CGFloat {
         guard resultCount > 0 else { return emptyResultHeight }
@@ -76,6 +79,7 @@ struct CommandPaletteView: View {
                         } label: {
                             VStack(alignment: .leading, spacing: 3) {
                                 Text(item.title)
+                                    .font(.subheadline)
                                     .lineLimit(1)
                                 if let subtitle = item.subtitle {
                                     Text(subtitle)
@@ -130,6 +134,13 @@ struct CommandPaletteView: View {
                 }
             }
         }
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: CommandPaletteLayout.innerCornerRadius,
+                style: .continuous
+            )
+        )
+        .padding(CommandPaletteLayout.cardInset)
         .frame(maxWidth: 620)
         .fixedSize(horizontal: false, vertical: true)
         .background(
@@ -140,10 +151,10 @@ struct CommandPaletteView: View {
             RoundedRectangle(cornerRadius: 18)
                 .stroke(LibraryHomePalette.separator, lineWidth: 1)
         }
-        .shadow(radius: 30)
-        .padding(16)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("command-palette")
+        .shadow(radius: 30)
+        .padding(CommandPaletteLayout.screenMargin)
         .onChange(of: query) { _, value in
             searchTask?.cancel()
             searchTask = Task { @MainActor in
@@ -198,6 +209,10 @@ private struct CommandPaletteSearchField: UIViewRepresentable {
         field.tintColor = .label
         field.accessibilityIdentifier = "command-palette.search"
         field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(
+            .defaultLow,
+            for: .horizontal
+        )
         configure(field)
         return field
     }
@@ -236,6 +251,8 @@ final class CommandPaletteTextField: UITextField, UITextFieldDelegate {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        font = UIFont.preferredFont(forTextStyle: .footnote)
+        adjustsFontForContentSizeCategory = true
         delegate = self
         addTarget(self, action: #selector(textDidChange), for: .editingChanged)
     }

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -167,7 +167,8 @@ struct CommandPaletteView: View {
                         query: value,
                         commands: commands,
                         snapshots: snapshots()
-                    )
+                    ),
+                    for: value
                 )
             }
         }

--- a/RemuxApp/Sources/App/CommandPaletteView.swift
+++ b/RemuxApp/Sources/App/CommandPaletteView.swift
@@ -50,6 +50,7 @@ struct CommandPaletteView: View {
                         }
                     }
                     .accessibilityIdentifier("command-palette.item.\(item.id)")
+                    .disabled(!item.isEnabled)
                 }
                 .listStyle(.plain)
             }

--- a/RemuxApp/Sources/App/KeyboardSettingsView.swift
+++ b/RemuxApp/Sources/App/KeyboardSettingsView.swift
@@ -71,6 +71,13 @@ struct KeyboardSettingsView: View {
                     Text("Use at least one modifier key.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    if let validationMessage {
+                        Text(validationMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .multilineTextAlignment(.center)
+                            .accessibilityIdentifier("keyboard-settings.capture.validation")
+                    }
                     KeyboardShortcutCaptureView { result in
                         switch result {
                         case .success(let binding):

--- a/RemuxApp/Sources/App/KeyboardSettingsView.swift
+++ b/RemuxApp/Sources/App/KeyboardSettingsView.swift
@@ -126,6 +126,8 @@ struct KeyboardSettingsView: View {
             onChange(updated)
         } catch KeyboardSettings.ValidationError.duplicateBinding(let existingCommand) {
             validationMessage = "That shortcut is already assigned to \(existingCommand.displayTitle)."
+        } catch KeyboardSettings.ValidationError.reservedSystemShortcut {
+            validationMessage = "⌘ H is reserved by iPadOS. Choose another shortcut."
         } catch {
             validationMessage = "A shortcut needs a key and at least one modifier."
         }

--- a/RemuxApp/Sources/App/KeyboardSettingsView.swift
+++ b/RemuxApp/Sources/App/KeyboardSettingsView.swift
@@ -46,7 +46,6 @@ struct KeyboardSettingsView: View {
                             .accessibilityIdentifier("keyboard-settings.clear.\(command.rawValue)")
                         }
                     }
-                    .accessibilityIdentifier("keyboard-settings.binding.\(command.rawValue)")
                 }
             }
 

--- a/RemuxApp/Sources/App/KeyboardSettingsView.swift
+++ b/RemuxApp/Sources/App/KeyboardSettingsView.swift
@@ -28,13 +28,12 @@ struct KeyboardSettingsView: View {
             Section("Key Bindings") {
                 ForEach(AppKeyboardCommand.allCases) { command in
                     HStack {
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text(command.displayTitle)
-                            Text(bindingDescription(settings.binding(for: command)))
-                                .font(.caption.monospaced())
-                                .foregroundStyle(.secondary)
-                        }
+                        Text(command.displayTitle)
                         Spacer()
+                        Text(KeyboardBindingDescription.text(settings.binding(for: command)))
+                            .font(.body.monospaced())
+                            .foregroundStyle(.secondary)
+                            .frame(maxHeight: .infinity, alignment: .center)
                         Button("Set") {
                             validationMessage = nil
                             capturingCommand = command
@@ -125,7 +124,10 @@ struct KeyboardSettingsView: View {
         }
     }
 
-    private func bindingDescription(_ binding: KeyboardKeyBinding?) -> String {
+}
+
+enum KeyboardBindingDescription {
+    static func text(_ binding: KeyboardKeyBinding?) -> String {
         guard let binding else { return "Unassigned" }
         var parts: [String] = []
         if binding.modifiers.contains(.control) { parts.append("⌃") }
@@ -133,10 +135,10 @@ struct KeyboardSettingsView: View {
         if binding.modifiers.contains(.shift) { parts.append("⇧") }
         if binding.modifiers.contains(.command) { parts.append("⌘") }
         parts.append(keyDescription(binding.input))
-        return parts.joined()
+        return parts.joined(separator: " ")
     }
 
-    private func keyDescription(_ input: String) -> String {
+    private static func keyDescription(_ input: String) -> String {
         switch input {
         case UIKeyCommand.inputLeftArrow:
             "←"

--- a/RemuxApp/Sources/App/KeyboardSettingsView.swift
+++ b/RemuxApp/Sources/App/KeyboardSettingsView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import UIKit
+
+struct KeyboardSettingsView: View {
+    @State private var settings: KeyboardSettings
+    @State private var capturingCommand: AppKeyboardCommand?
+    @State private var validationMessage: String?
+    let onChange: (KeyboardSettings) -> Void
+
+    init(
+        initialSettings: KeyboardSettings,
+        onChange: @escaping (KeyboardSettings) -> Void
+    ) {
+        _settings = State(initialValue: initialSettings)
+        self.onChange = onChange
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle(
+                    "Hide button bar when a physical keyboard is connected",
+                    isOn: hideButtonBarBinding
+                )
+                .accessibilityIdentifier("keyboard-settings.hide-button-bar")
+            }
+
+            Section("Key Bindings") {
+                ForEach(AppKeyboardCommand.allCases) { command in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(command.displayTitle)
+                            Text(bindingDescription(settings.binding(for: command)))
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Button("Set") {
+                            validationMessage = nil
+                            capturingCommand = command
+                        }
+                        .accessibilityIdentifier("keyboard-settings.set.\(command.rawValue)")
+                        if settings.binding(for: command) != nil {
+                            Button("Clear") {
+                                update(command, binding: nil)
+                            }
+                            .accessibilityIdentifier("keyboard-settings.clear.\(command.rawValue)")
+                        }
+                    }
+                    .accessibilityIdentifier("keyboard-settings.binding.\(command.rawValue)")
+                }
+            }
+
+            if let validationMessage {
+                Section {
+                    Text(validationMessage)
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier("keyboard-settings.validation")
+                }
+            }
+        }
+        .navigationTitle("Physical Keyboard")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("keyboard-settings.form")
+        .sheet(item: $capturingCommand) { command in
+            NavigationStack {
+                VStack(spacing: 20) {
+                    Image(systemName: "keyboard")
+                        .font(.system(size: 48))
+                    Text("Press the shortcut for \(command.displayTitle)")
+                        .multilineTextAlignment(.center)
+                    Text("Use at least one modifier key.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    KeyboardShortcutCaptureView { result in
+                        switch result {
+                        case .success(let binding):
+                            update(command, binding: binding)
+                            if validationMessage == nil {
+                                capturingCommand = nil
+                            }
+                        case .failure:
+                            validationMessage = "A shortcut needs a key and at least one modifier."
+                        }
+                    }
+                    .frame(width: 1, height: 1)
+                }
+                .padding()
+                .navigationTitle("Set Shortcut")
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { capturingCommand = nil }
+                    }
+                }
+            }
+            .presentationDetents([.medium])
+        }
+    }
+
+    private var hideButtonBarBinding: Binding<Bool> {
+        Binding(
+            get: { settings.hideButtonBarWhenPhysicalKeyboardConnected },
+            set: { value in
+                var updated = settings
+                updated.hideButtonBarWhenPhysicalKeyboardConnected = value
+                settings = updated
+                onChange(updated)
+            }
+        )
+    }
+
+    private func update(
+        _ command: AppKeyboardCommand,
+        binding: KeyboardKeyBinding?
+    ) {
+        do {
+            let updated = try settings.validated(updating: command, to: binding)
+            settings = updated
+            validationMessage = nil
+            onChange(updated)
+        } catch KeyboardSettings.ValidationError.duplicateBinding(let existingCommand) {
+            validationMessage = "That shortcut is already assigned to \(existingCommand.displayTitle)."
+        } catch {
+            validationMessage = "A shortcut needs a key and at least one modifier."
+        }
+    }
+
+    private func bindingDescription(_ binding: KeyboardKeyBinding?) -> String {
+        guard let binding else { return "Unassigned" }
+        var parts: [String] = []
+        if binding.modifiers.contains(.control) { parts.append("⌃") }
+        if binding.modifiers.contains(.option) { parts.append("⌥") }
+        if binding.modifiers.contains(.shift) { parts.append("⇧") }
+        if binding.modifiers.contains(.command) { parts.append("⌘") }
+        parts.append(keyDescription(binding.input))
+        return parts.joined()
+    }
+
+    private func keyDescription(_ input: String) -> String {
+        switch input {
+        case UIKeyCommand.inputLeftArrow:
+            "←"
+        case UIKeyCommand.inputRightArrow:
+            "→"
+        case UIKeyCommand.inputUpArrow:
+            "↑"
+        case UIKeyCommand.inputDownArrow:
+            "↓"
+        default:
+            input.uppercased()
+        }
+    }
+}

--- a/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
+++ b/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import UIKit
+
+enum KeyboardShortcutCapture {
+    enum ValidationError: Error, Equatable {
+        case missingKey
+        case missingModifier
+    }
+
+    static func binding(
+        input: String,
+        modifierFlags: UIKeyModifierFlags
+    ) throws -> KeyboardKeyBinding {
+        guard !input.isEmpty else { throw ValidationError.missingKey }
+        let modifiers = KeyboardKeyModifiers(modifierFlags)
+        guard !modifiers.isEmpty else { throw ValidationError.missingModifier }
+        return KeyboardKeyBinding(
+            input: input.count == 1 ? input.lowercased() : input,
+            modifiers: modifiers
+        )
+    }
+
+    static func clearedBinding() -> KeyboardKeyBinding? {
+        nil
+    }
+}
+
+struct KeyboardShortcutCaptureView: UIViewRepresentable {
+    let onCapture: (Result<KeyboardKeyBinding, Error>) -> Void
+
+    func makeUIView(context: Context) -> KeyboardShortcutCaptureUIView {
+        let view = KeyboardShortcutCaptureUIView()
+        view.onCapture = onCapture
+        return view
+    }
+
+    func updateUIView(_ view: KeyboardShortcutCaptureUIView, context: Context) {
+        view.onCapture = onCapture
+        DispatchQueue.main.async { [weak view] in
+            _ = view?.becomeFirstResponder()
+        }
+    }
+}
+
+final class KeyboardShortcutCaptureUIView: UIView {
+    var onCapture: ((Result<KeyboardKeyBinding, Error>) -> Void)?
+
+    override var canBecomeFirstResponder: Bool { true }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        guard let key = presses.first?.key else {
+            super.pressesBegan(presses, with: event)
+            return
+        }
+
+        do {
+            let binding = try KeyboardShortcutCapture.binding(
+                input: key.charactersIgnoringModifiers,
+                modifierFlags: key.modifierFlags
+            )
+            onCapture?(.success(binding))
+        } catch {
+            onCapture?(.failure(error))
+        }
+    }
+}

--- a/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
+++ b/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
@@ -26,16 +26,19 @@ enum KeyboardShortcutCapture {
 }
 
 struct KeyboardShortcutCaptureView: UIViewRepresentable {
+    @Environment(\.appKeyboardCommandCenter) private var commandCenter
     let onCapture: (Result<KeyboardKeyBinding, Error>) -> Void
 
     func makeUIView(context: Context) -> KeyboardShortcutCaptureUIView {
         let view = KeyboardShortcutCaptureUIView()
         view.onCapture = onCapture
+        view.commandCenter = commandCenter
         return view
     }
 
     func updateUIView(_ view: KeyboardShortcutCaptureUIView, context: Context) {
         view.onCapture = onCapture
+        view.commandCenter = commandCenter
         DispatchQueue.main.async { [weak view] in
             _ = view?.becomeFirstResponder()
         }
@@ -44,8 +47,32 @@ struct KeyboardShortcutCaptureView: UIViewRepresentable {
 
 final class KeyboardShortcutCaptureUIView: UIView {
     var onCapture: ((Result<KeyboardKeyBinding, Error>) -> Void)?
+    weak var commandCenter: AppKeyboardCommandCenter?
 
     override var canBecomeFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        let didBecomeFirstResponder = super.becomeFirstResponder()
+        if didBecomeFirstResponder {
+            commandCenter?.setShortcutCaptureActive(true)
+        }
+        return didBecomeFirstResponder
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let didResignFirstResponder = super.resignFirstResponder()
+        if didResignFirstResponder {
+            commandCenter?.setShortcutCaptureActive(false)
+        }
+        return didResignFirstResponder
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            commandCenter?.setShortcutCaptureActive(false)
+        }
+    }
 
     override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         guard let key = presses.first?.key else {

--- a/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
+++ b/RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift
@@ -19,10 +19,6 @@ enum KeyboardShortcutCapture {
             modifiers: modifiers
         )
     }
-
-    static func clearedBinding() -> KeyboardKeyBinding? {
-        nil
-    }
 }
 
 struct KeyboardShortcutCaptureView: UIViewRepresentable {

--- a/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
+++ b/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
@@ -5,7 +5,7 @@ import GameController
 final class PhysicalKeyboardMonitor: ObservableObject {
     @Published private(set) var isConnected: Bool
     nonisolated(unsafe) private var notificationTokens: [NSObjectProtocol] = []
-    nonisolated(unsafe) private let notificationCenter: NotificationCenter
+    private let notificationCenter: NotificationCenter
 
     init(
         notificationCenter: NotificationCenter = .default,

--- a/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
+++ b/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
@@ -1,0 +1,40 @@
+import Foundation
+import GameController
+
+@MainActor
+final class PhysicalKeyboardMonitor: ObservableObject {
+    @Published private(set) var isConnected: Bool
+    nonisolated(unsafe) private var notificationTokens: [NSObjectProtocol] = []
+    nonisolated(unsafe) private let notificationCenter: NotificationCenter
+
+    init(
+        notificationCenter: NotificationCenter = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.notificationCenter = notificationCenter
+        isConnected = environment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] == "1"
+            || GCKeyboard.coalesced != nil
+
+        for name in [NSNotification.Name.GCKeyboardDidConnect, .GCKeyboardDidDisconnect] {
+            notificationTokens.append(
+                notificationCenter.addObserver(
+                    forName: name,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.isConnected =
+                            environment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] == "1"
+                            || GCKeyboard.coalesced != nil
+                    }
+                }
+            )
+        }
+    }
+
+    deinit {
+        for token in notificationTokens {
+            notificationCenter.removeObserver(token)
+        }
+    }
+}

--- a/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
+++ b/RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift
@@ -1,6 +1,21 @@
 import Foundation
 import GameController
 
+struct PhysicalKeyboardConnectionProjection {
+    static func isConnected(
+        environment: [String: String],
+        isSystemKeyboardConnected: Bool
+    ) -> Bool {
+        if environment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] == "1" {
+            return true
+        }
+        if environment["REMUX_UI_TESTING"] == "1" {
+            return false
+        }
+        return isSystemKeyboardConnected
+    }
+}
+
 @MainActor
 final class PhysicalKeyboardMonitor: ObservableObject {
     @Published private(set) var isConnected: Bool
@@ -12,8 +27,10 @@ final class PhysicalKeyboardMonitor: ObservableObject {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
         self.notificationCenter = notificationCenter
-        isConnected = environment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] == "1"
-            || GCKeyboard.coalesced != nil
+        isConnected = PhysicalKeyboardConnectionProjection.isConnected(
+            environment: environment,
+            isSystemKeyboardConnected: GCKeyboard.coalesced != nil
+        )
 
         for name in [NSNotification.Name.GCKeyboardDidConnect, .GCKeyboardDidDisconnect] {
             notificationTokens.append(
@@ -23,9 +40,10 @@ final class PhysicalKeyboardMonitor: ObservableObject {
                     queue: .main
                 ) { [weak self] _ in
                     Task { @MainActor [weak self] in
-                        self?.isConnected =
-                            environment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] == "1"
-                            || GCKeyboard.coalesced != nil
+                        self?.isConnected = PhysicalKeyboardConnectionProjection.isConnected(
+                            environment: environment,
+                            isSystemKeyboardConnected: GCKeyboard.coalesced != nil
+                        )
                     }
                 }
             )

--- a/RemuxApp/Sources/App/RemuxApp.swift
+++ b/RemuxApp/Sources/App/RemuxApp.swift
@@ -26,6 +26,8 @@ enum GhosttyKitBuildModePolicy {
 
 @main
 struct RemuxApp: App {
+    @StateObject private var keyboardCommandCenter = AppKeyboardCommandCenter()
+
     init() {
         #if !DEBUG
         if let failure = GhosttyKitBuildModePolicy.releaseValidationFailure(
@@ -38,7 +40,10 @@ struct RemuxApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            AppKeyboardCommandHost(center: keyboardCommandCenter) {
+                RootView()
+                    .environment(\.appKeyboardCommandCenter, keyboardCommandCenter)
+            }
         }
     }
 }

--- a/RemuxApp/Sources/App/RemuxAppDependencies.swift
+++ b/RemuxApp/Sources/App/RemuxAppDependencies.swift
@@ -13,6 +13,7 @@ private enum RemuxConnectionTimeouts {
 struct RemuxAppDependencies: Sendable {
     let profileRepository: any ConnectionProfileRepository
     let settingsRepository: any TerminalSettingsRepository
+    let keyboardSettingsRepository: any KeyboardSettingsRepository
     let shortcutRepository: any ShortcutRepository
     let credentialStore: any SSHCredentialStore
     let trustedHostStore: TrustedHostStore
@@ -40,6 +41,7 @@ struct RemuxAppDependencies: Sendable {
     init(
         profileRepository: any ConnectionProfileRepository,
         settingsRepository: any TerminalSettingsRepository,
+        keyboardSettingsRepository: any KeyboardSettingsRepository,
         shortcutRepository: any ShortcutRepository,
         credentialStore: any SSHCredentialStore,
         trustedHostStore: TrustedHostStore,
@@ -66,6 +68,7 @@ struct RemuxAppDependencies: Sendable {
     ) {
         self.profileRepository = profileRepository
         self.settingsRepository = settingsRepository
+        self.keyboardSettingsRepository = keyboardSettingsRepository
         self.shortcutRepository = shortcutRepository
         self.credentialStore = credentialStore
         self.trustedHostStore = trustedHostStore
@@ -111,6 +114,7 @@ struct RemuxAppDependencies: Sendable {
         return RemuxAppDependencies(
             profileRepository: FileBackedConnectionProfileRepository(rootURL: root),
             settingsRepository: FileBackedTerminalSettingsRepository(rootURL: root),
+            keyboardSettingsRepository: FileBackedKeyboardSettingsRepository(rootURL: root),
             shortcutRepository: FileBackedShortcutRepository(rootURL: root),
             credentialStore: credentialStore,
             trustedHostStore: TrustedHostStore(rootURL: root)
@@ -301,6 +305,7 @@ struct RemuxAppDependencies: Sendable {
         return RemuxAppDependencies(
             profileRepository: InMemoryConnectionProfileRepository(),
             settingsRepository: InMemoryTerminalSettingsRepository(),
+            keyboardSettingsRepository: InMemoryKeyboardSettingsRepository(),
             shortcutRepository: InMemoryShortcutRepository(),
             credentialStore: InMemorySSHCredentialStore(),
             trustedHostStore: TrustedHostStore(rootURL: root),
@@ -423,6 +428,18 @@ private actor InMemoryTerminalSettingsRepository: TerminalSettingsRepository {
 
     func saveSettings(_ settings: TerminalSettings) async throws {
         self.settings = settings
+    }
+}
+
+private actor InMemoryKeyboardSettingsRepository: KeyboardSettingsRepository {
+    private var settings = KeyboardSettings.default
+
+    func loadSettings() async throws -> KeyboardSettings {
+        settings
+    }
+
+    func saveSettings(_ settings: KeyboardSettings) async throws {
+        self.settings = try settings.validated()
     }
 }
 

--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -131,6 +131,7 @@ final class RemuxRootModel: ObservableObject {
     @Published private(set) var state: State = .loading
     @Published private(set) var library: ConnectionLibrarySnapshot = .empty
     @Published private(set) var terminalSettings: TerminalSettings = .default
+    @Published private(set) var keyboardSettings: KeyboardSettings = .default
     @Published private(set) var activeSessions: [ActiveTerminalSession] = []
 
     var activeTerminalScreenEntries: [ActiveTerminalScreenEntry] {
@@ -188,7 +189,10 @@ final class RemuxRootModel: ObservableObject {
             try await dependencies.seedDebugConnectionIfRequested()
 #endif
 
-            terminalSettings = try await dependencies.settingsRepository.loadSettings()
+            async let loadedTerminalSettings = dependencies.settingsRepository.loadSettings()
+            async let loadedKeyboardSettings = dependencies.keyboardSettingsRepository.loadSettings()
+            terminalSettings = try await loadedTerminalSettings
+            keyboardSettings = try await loadedKeyboardSettings
             library = try await dependencies.profileRepository.loadSnapshot()
             state = .library
             scheduleLibrarySSHPrewarm(snapshot: library)
@@ -199,7 +203,10 @@ final class RemuxRootModel: ObservableObject {
 
     func showLibrary() async {
         do {
-            terminalSettings = try await dependencies.settingsRepository.loadSettings()
+            async let loadedTerminalSettings = dependencies.settingsRepository.loadSettings()
+            async let loadedKeyboardSettings = dependencies.keyboardSettingsRepository.loadSettings()
+            terminalSettings = try await loadedTerminalSettings
+            keyboardSettings = try await loadedKeyboardSettings
             library = try await dependencies.profileRepository.loadSnapshot()
             state = .library
             scheduleLibrarySSHPrewarm(snapshot: library)
@@ -786,6 +793,15 @@ final class RemuxRootModel: ObservableObject {
             terminalSettings = updated
             try applyTerminalSettingsToActiveSessions(updated)
             try await dependencies.settingsRepository.saveSettings(updated)
+        } catch {
+            transitionToFailed(error)
+        }
+    }
+
+    func updateKeyboardSettings(_ settings: KeyboardSettings) async {
+        do {
+            keyboardSettings = try settings.validated()
+            try await dependencies.keyboardSettingsRepository.saveSettings(keyboardSettings)
         } catch {
             transitionToFailed(error)
         }

--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -798,6 +798,18 @@ final class RemuxRootModel: ObservableObject {
         }
     }
 
+    func adjustTerminalFontSize(
+        by delta: Float32,
+        effectiveDefault: Float32
+    ) async {
+        await updateTerminalSettings { settings in
+            settings.adjustFontSize(
+                by: delta,
+                effectiveDefault: effectiveDefault
+            )
+        }
+    }
+
     func updateKeyboardSettings(_ settings: KeyboardSettings) async {
         do {
             keyboardSettings = try settings.validated()

--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -154,6 +154,7 @@ final class RemuxRootModel: ObservableObject {
     private let terminalScreenModelFactory: TerminalScreenModelFactory
     private var terminalScreenModels: [TerminalRuntimeAttemptKey: TmuxScreenModel] = [:]
     private var currentAppLifecyclePhase: GhosttyAppLifecyclePhase?
+    private var terminalFontSizeAdjustmentTask: Task<Void, Never>?
 
     init(
         dependencies: RemuxAppDependencies,
@@ -804,6 +805,21 @@ final class RemuxRootModel: ObservableObject {
     ) async {
         await updateTerminalSettings { settings in
             settings.adjustFontSize(
+                by: delta,
+                effectiveDefault: effectiveDefault
+            )
+        }
+    }
+
+    func enqueueTerminalFontSizeAdjustment(
+        by delta: Float32,
+        effectiveDefault: Float32
+    ) {
+        let precedingTask = terminalFontSizeAdjustmentTask
+        terminalFontSizeAdjustmentTask = Task { [weak self] in
+            await precedingTask?.value
+            guard let self else { return }
+            await adjustTerminalFontSize(
                 by: delta,
                 effectiveDefault: effectiveDefault
             )

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -351,6 +351,17 @@ private struct RemuxWorkspaceShell: View {
             isCommandPalettePresented = true
         case .showSession(let id):
             model.showActiveSession(id)
+        case .adjustFontSize(let delta):
+            let effectiveDefault =
+                GhosttyTerminalAppearancePolicy.currentDeviceFontSize(
+                    settings: model.terminalSettings
+                ) ?? TerminalSettings.defaultExplicitFontSize
+            Task {
+                await model.adjustTerminalFontSize(
+                    by: delta,
+                    effectiveDefault: effectiveDefault
+                )
+            }
         case .unavailable:
             break
         }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -204,6 +204,7 @@ private struct RemuxWorkspaceShell: View {
                 snapshot: model.library,
                 activeSessions: model.activeSessions,
                 terminalSettings: model.terminalSettings,
+                keyboardSettings: model.keyboardSettings,
                 onAddServer: model.beginNewServer,
                 onAddWorkspace: { serverID in
                     Task { await model.beginNewWorkspace(for: serverID) }
@@ -238,6 +239,11 @@ private struct RemuxWorkspaceShell: View {
                         await model.updateTerminalSettings { current in
                             current = settings
                         }
+                    }
+                },
+                onKeyboardSettingsChange: { settings in
+                    Task {
+                        await model.updateKeyboardSettings(settings)
                     }
                 }
             )
@@ -407,6 +413,7 @@ private struct ConnectionLibraryView: View {
     let snapshot: ConnectionLibrarySnapshot
     let activeSessions: [ActiveTerminalSession]
     let terminalSettings: TerminalSettings
+    let keyboardSettings: KeyboardSettings
     let onAddServer: () -> Void
     let onAddWorkspace: (SavedServer.ID) -> Void
     let onEditServer: (SavedServer.ID) -> Void
@@ -417,6 +424,7 @@ private struct ConnectionLibraryView: View {
     let onDeleteServer: (SavedServer.ID) -> Void
     let onDeleteWorkspace: (SavedWorkspace.ID) -> Void
     let onSettingsChange: (TerminalSettings) -> Void
+    let onKeyboardSettingsChange: (KeyboardSettings) -> Void
 
     @State private var showsAllConnectedSessions = false
     @State private var showsAllRecentSessions = false
@@ -449,7 +457,9 @@ private struct ConnectionLibraryView: View {
                 NavigationLink {
                     TerminalSettingsView(
                         initialSettings: terminalSettings,
-                        onChange: onSettingsChange
+                        keyboardSettings: keyboardSettings,
+                        onChange: onSettingsChange,
+                        onKeyboardSettingsChange: onKeyboardSettingsChange
                     )
                 } label: {
                     Image(systemName: "gearshape")
@@ -1226,18 +1236,34 @@ private func serverSummary(
 
 private struct TerminalSettingsView: View {
     @State private var settings: TerminalSettings
+    let keyboardSettings: KeyboardSettings
     let onChange: (TerminalSettings) -> Void
+    let onKeyboardSettingsChange: (KeyboardSettings) -> Void
 
     init(
         initialSettings: TerminalSettings,
-        onChange: @escaping (TerminalSettings) -> Void
+        keyboardSettings: KeyboardSettings,
+        onChange: @escaping (TerminalSettings) -> Void,
+        onKeyboardSettingsChange: @escaping (KeyboardSettings) -> Void
     ) {
         _settings = State(initialValue: initialSettings)
+        self.keyboardSettings = keyboardSettings
         self.onChange = onChange
+        self.onKeyboardSettingsChange = onKeyboardSettingsChange
     }
 
     var body: some View {
         Form {
+            Section {
+                NavigationLink("Physical Keyboard") {
+                    KeyboardSettingsView(
+                        initialSettings: keyboardSettings,
+                        onChange: onKeyboardSettingsChange
+                    )
+                }
+                .accessibilityIdentifier("settings.physical-keyboard")
+            }
+
             Section("Font") {
                 Toggle("Use default size", isOn: useDefaultFontBinding)
                     .tint(LibraryHomePalette.controlAccent)

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -131,6 +131,10 @@ private struct RemuxWorkspaceShell: View {
     private var keyboardCommandContext: AppKeyboardCommandRouteContext {
         AppKeyboardCommandRouteContext(
             selectedSessionID: selectedTerminalID,
+            isSelectedTerminalReady: model.activeTerminalScreenEntries.first(where: {
+                $0.id == selectedTerminalID
+            })?.model.terminalScreenAdapter.terminalInteractionProjection
+                .isInputAvailable == true,
             orderedActiveSessionIDs: model.activeSessions
                 .sorted { $0.target.workspace.lastOpenedAt > $1.target.workspace.lastOpenedAt }
                 .map(\.id)

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -155,16 +155,16 @@ private struct RemuxWorkspaceShell: View {
             )
         }
         items += AppKeyboardCommand.allCases.compactMap { command in
-            guard command != .commandPalette,
-                  AppKeyboardCommandRouter.isAvailable(command, in: keyboardCommandContext)
-            else {
-                return nil
-            }
+            guard command != .commandPalette else { return nil }
             return CommandPaletteItem(
                 id: "command:\(command.rawValue)",
                 title: command.displayTitle,
                 subtitle: nil,
-                action: .appCommand(command)
+                action: .appCommand(command),
+                isEnabled: AppKeyboardCommandRouter.isAvailable(
+                    command,
+                    in: keyboardCommandContext
+                )
             )
         }
         return items

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -100,6 +100,9 @@ private struct RemuxWorkspaceShell: View {
         .onChange(of: model.keyboardSettings) { _, _ in
             updateAppKeyboardCommandCenter()
         }
+        .onChange(of: keyboardCommandContext) { _, _ in
+            updateAppKeyboardCommandCenter()
+        }
         .onChange(of: model.activeTerminalScreenEntries.map(\.id)) { _, ids in
             guard !ids.isEmpty else {
                 retainedTerminalID = nil
@@ -369,6 +372,9 @@ private struct RemuxWorkspaceShell: View {
     private func updateAppKeyboardCommandCenter() {
         appKeyboardCommandCenter?.update(
             settings: model.keyboardSettings,
+            availableCommands: AppKeyboardCommandRouter.availableCommands(
+                in: keyboardCommandContext
+            ),
             onCommand: performKeyboardCommand
         )
     }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -62,6 +62,7 @@ private struct RemuxWorkspaceShell: View {
     @StateObject private var physicalKeyboardMonitor = PhysicalKeyboardMonitor()
     @State private var retainedTerminalID: SavedWorkspace.ID?
     @State private var isCommandPalettePresented = false
+    @State private var terminalKeyboardReadiness = TerminalKeyboardReadiness()
 
     var body: some View {
         ZStack {
@@ -115,6 +116,11 @@ private struct RemuxWorkspaceShell: View {
 
             retainedTerminalID = ids[0]
         }
+        .onChange(
+            of: model.activeTerminalScreenEntries.map(\.runtimeAttemptKey)
+        ) { _, attempts in
+            terminalKeyboardReadiness.retain(attempts)
+        }
     }
 
     private var selectedTerminalID: SavedWorkspace.ID? {
@@ -130,12 +136,14 @@ private struct RemuxWorkspaceShell: View {
     }
 
     private var keyboardCommandContext: AppKeyboardCommandRouteContext {
-        AppKeyboardCommandRouteContext(
+        let selectedAttempt = model.activeTerminalScreenEntries.first(where: {
+            $0.id == selectedTerminalID
+        })?.runtimeAttemptKey
+        return AppKeyboardCommandRouteContext(
             selectedSessionID: selectedTerminalID,
-            isSelectedTerminalReady: model.activeTerminalScreenEntries.first(where: {
-                $0.id == selectedTerminalID
-            })?.model.terminalScreenAdapter.terminalInteractionProjection
-                .isInputAvailable == true,
+            isSelectedTerminalReady: terminalKeyboardReadiness.isReady(
+                for: selectedAttempt
+            ),
             orderedActiveSessionIDs: model.activeSessions
                 .sorted { $0.target.workspace.lastOpenedAt > $1.target.workspace.lastOpenedAt }
                 .map(\.id)
@@ -198,6 +206,12 @@ private struct RemuxWorkspaceShell: View {
                     isPhysicalKeyboardConnected: physicalKeyboardMonitor.isConnected,
                     isAppInputOwnerPresented: isCommandPalettePresented,
                     onAppKeyboardCommand: performKeyboardCommand,
+                    onTerminalInputAvailabilityChange: { isReady in
+                        terminalKeyboardReadiness.update(
+                            isReady: isReady,
+                            for: entry.runtimeAttemptKey
+                        )
+                    },
                     onReconnect: {
                         model.reconnectActiveSession(entry.id, source: .manualButton)
                     },
@@ -428,6 +442,7 @@ private struct ActiveTerminalSessionView: View {
     let isPhysicalKeyboardConnected: Bool
     let isAppInputOwnerPresented: Bool
     let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
+    let onTerminalInputAvailabilityChange: (Bool) -> Void
     let onReconnect: () -> Void
     let onUpdateCredentials: () -> Void
     let onEditServer: () -> Void
@@ -444,6 +459,7 @@ private struct ActiveTerminalSessionView: View {
         isPhysicalKeyboardConnected: Bool,
         isAppInputOwnerPresented: Bool,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void,
+        onTerminalInputAvailabilityChange: @escaping (Bool) -> Void,
         onReconnect: @escaping () -> Void,
         onUpdateCredentials: @escaping () -> Void,
         onEditServer: @escaping () -> Void,
@@ -457,6 +473,7 @@ private struct ActiveTerminalSessionView: View {
         self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
         self.isAppInputOwnerPresented = isAppInputOwnerPresented
         self.onAppKeyboardCommand = onAppKeyboardCommand
+        self.onTerminalInputAvailabilityChange = onTerminalInputAvailabilityChange
         self.onReconnect = onReconnect
         self.onUpdateCredentials = onUpdateCredentials
         self.onEditServer = onEditServer
@@ -482,6 +499,7 @@ private struct ActiveTerminalSessionView: View {
                 isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
                 isAppInputOwnerPresented: isAppInputOwnerPresented,
                 onAppKeyboardCommand: onAppKeyboardCommand,
+                onTerminalInputAvailabilityChange: onTerminalInputAvailabilityChange,
                 attachmentTransferServiceFactory: entry.attachmentTransferServiceFactory,
                 onPreviewSelection: previewSelectionHandler,
                 onReconnect: onReconnect,

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -73,6 +73,20 @@ private struct RemuxWorkspaceShell: View {
             )
             .frame(width: 1, height: 1)
             .opacity(0.01)
+
+            if isCommandPalettePresented {
+                Color.black.opacity(0.28)
+                    .ignoresSafeArea()
+                    .onTapGesture { isCommandPalettePresented = false }
+                    .zIndex(20)
+                CommandPaletteView(
+                    commands: commandPaletteItems,
+                    snapshots: viewportSnapshots,
+                    onSelect: selectCommandPaletteAction,
+                    onDismiss: { isCommandPalettePresented = false }
+                )
+                .zIndex(21)
+            }
         }
         .onAppear {
             model.handleAppLifecyclePhase(
@@ -121,6 +135,49 @@ private struct RemuxWorkspaceShell: View {
                 .sorted { $0.target.workspace.lastOpenedAt > $1.target.workspace.lastOpenedAt }
                 .map(\.id)
         )
+    }
+
+    private var commandPaletteItems: [CommandPaletteItem] {
+        var items = [
+            CommandPaletteItem(
+                id: "add-connection",
+                title: "Add Connection",
+                subtitle: nil,
+                action: .addConnection
+            ),
+        ]
+        items += model.library.servers.map { server in
+            CommandPaletteItem(
+                id: "new-session:\(server.id)",
+                title: "New Session on \(server.displayName)",
+                subtitle: server.host,
+                action: .newSession(server.id)
+            )
+        }
+        items += AppKeyboardCommand.allCases.compactMap { command in
+            guard command != .commandPalette,
+                  AppKeyboardCommandRouter.isAvailable(command, in: keyboardCommandContext)
+            else {
+                return nil
+            }
+            return CommandPaletteItem(
+                id: "command:\(command.rawValue)",
+                title: command.displayTitle,
+                subtitle: nil,
+                action: .appCommand(command)
+            )
+        }
+        return items
+    }
+
+    private func viewportSnapshots() -> [TerminalViewportSnapshot] {
+        model.activeTerminalScreenEntries.flatMap { entry in
+            entry.model.terminalScreenAdapter.viewportSnapshots(
+                workspaceID: entry.id,
+                serverName: entry.model.target.server.displayName,
+                sessionName: entry.presentation.sessionName
+            )
+        }
     }
 
     private var activeTerminalLayer: some View {
@@ -291,6 +348,27 @@ private struct RemuxWorkspaceShell: View {
             model.showActiveSession(id)
         case .unavailable:
             break
+        }
+    }
+
+    private func selectCommandPaletteAction(_ action: CommandPaletteAction) {
+        isCommandPalettePresented = false
+        switch action {
+        case .addConnection:
+            model.beginNewServer()
+        case .newSession(let serverID):
+            Task { await model.beginNewWorkspace(for: serverID) }
+        case .appCommand(let command):
+            performKeyboardCommand(command)
+        case .viewport(let snapshot):
+            model.showActiveSession(snapshot.workspaceID)
+            guard let entry = model.activeTerminalScreenEntries.first(where: {
+                $0.id == snapshot.workspaceID
+            }) else {
+                return
+            }
+            _ = entry.model.terminalScreenAdapter.focusTmuxTopLevel(snapshot.windowID)
+            _ = entry.model.terminalScreenAdapter.focusTmuxPane(snapshot.paneID)
         }
     }
 }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -195,6 +195,7 @@ private struct RemuxWorkspaceShell: View {
                     shortcutStore: shortcutStore,
                     keyboardSettings: model.keyboardSettings,
                     isPhysicalKeyboardConnected: physicalKeyboardMonitor.isConnected,
+                    isAppInputOwnerPresented: isCommandPalettePresented,
                     onAppKeyboardCommand: performKeyboardCommand,
                     onReconnect: {
                         model.reconnectActiveSession(entry.id, source: .manualButton)
@@ -402,6 +403,7 @@ private struct ActiveTerminalSessionView: View {
     let shortcutStore: ShortcutStore
     let keyboardSettings: KeyboardSettings
     let isPhysicalKeyboardConnected: Bool
+    let isAppInputOwnerPresented: Bool
     let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     let onReconnect: () -> Void
     let onUpdateCredentials: () -> Void
@@ -417,6 +419,7 @@ private struct ActiveTerminalSessionView: View {
         shortcutStore: ShortcutStore,
         keyboardSettings: KeyboardSettings,
         isPhysicalKeyboardConnected: Bool,
+        isAppInputOwnerPresented: Bool,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void,
         onReconnect: @escaping () -> Void,
         onUpdateCredentials: @escaping () -> Void,
@@ -429,6 +432,7 @@ private struct ActiveTerminalSessionView: View {
         self.shortcutStore = shortcutStore
         self.keyboardSettings = keyboardSettings
         self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
+        self.isAppInputOwnerPresented = isAppInputOwnerPresented
         self.onAppKeyboardCommand = onAppKeyboardCommand
         self.onReconnect = onReconnect
         self.onUpdateCredentials = onUpdateCredentials
@@ -453,6 +457,7 @@ private struct ActiveTerminalSessionView: View {
                 shortcutStore: shortcutStore,
                 keyboardSettings: keyboardSettings,
                 isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
+                isAppInputOwnerPresented: isAppInputOwnerPresented,
                 onAppKeyboardCommand: onAppKeyboardCommand,
                 attachmentTransferServiceFactory: entry.attachmentTransferServiceFactory,
                 onPreviewSelection: previewSelectionHandler,
@@ -796,7 +801,7 @@ private struct ConnectionLibraryView: View {
     }
 }
 
-private enum LibraryHomePalette {
+enum LibraryHomePalette {
     static let background = Color(uiColor: .libraryHomeBackground)
     static let rowSurface = Color(uiColor: .libraryHomeRowSurface)
     static let separator = Color(uiColor: .libraryHomeSeparator)
@@ -1351,6 +1356,7 @@ private struct TerminalSettingsView: View {
                 }
                 .accessibilityIdentifier("settings.physical-keyboard")
             }
+            .libraryHomeListRowSurface()
 
             Section("Font") {
                 Toggle("Use default size", isOn: useDefaultFontBinding)

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -58,6 +58,7 @@ private struct RemuxWorkspaceShell: View {
     @Environment(\.scenePhase) private var scenePhase
     @ObservedObject var model: RemuxRootModel
     let shortcutStore: ShortcutStore
+    @StateObject private var physicalKeyboardMonitor = PhysicalKeyboardMonitor()
     @State private var retainedTerminalID: SavedWorkspace.ID?
     @State private var isCommandPalettePresented = false
 
@@ -132,6 +133,7 @@ private struct RemuxWorkspaceShell: View {
                     isSelected: isSelected,
                     shortcutStore: shortcutStore,
                     keyboardSettings: model.keyboardSettings,
+                    isPhysicalKeyboardConnected: physicalKeyboardMonitor.isConnected,
                     onAppKeyboardCommand: performKeyboardCommand,
                     onReconnect: {
                         model.reconnectActiveSession(entry.id, source: .manualButton)
@@ -317,6 +319,7 @@ private struct ActiveTerminalSessionView: View {
     let isSelected: Bool
     let shortcutStore: ShortcutStore
     let keyboardSettings: KeyboardSettings
+    let isPhysicalKeyboardConnected: Bool
     let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     let onReconnect: () -> Void
     let onUpdateCredentials: () -> Void
@@ -331,6 +334,7 @@ private struct ActiveTerminalSessionView: View {
         isSelected: Bool,
         shortcutStore: ShortcutStore,
         keyboardSettings: KeyboardSettings,
+        isPhysicalKeyboardConnected: Bool,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void,
         onReconnect: @escaping () -> Void,
         onUpdateCredentials: @escaping () -> Void,
@@ -342,6 +346,7 @@ private struct ActiveTerminalSessionView: View {
         self.isSelected = isSelected
         self.shortcutStore = shortcutStore
         self.keyboardSettings = keyboardSettings
+        self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
         self.onAppKeyboardCommand = onAppKeyboardCommand
         self.onReconnect = onReconnect
         self.onUpdateCredentials = onUpdateCredentials
@@ -365,6 +370,7 @@ private struct ActiveTerminalSessionView: View {
                 isTerminalCovered: previewSession.isPresented,
                 shortcutStore: shortcutStore,
                 keyboardSettings: keyboardSettings,
+                isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
                 onAppKeyboardCommand: onAppKeyboardCommand,
                 attachmentTransferServiceFactory: entry.attachmentTransferServiceFactory,
                 onPreviewSelection: previewSelectionHandler,

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -356,12 +356,10 @@ private struct RemuxWorkspaceShell: View {
                 GhosttyTerminalAppearancePolicy.currentDeviceFontSize(
                     settings: model.terminalSettings
                 ) ?? TerminalSettings.defaultExplicitFontSize
-            Task {
-                await model.adjustTerminalFontSize(
-                    by: delta,
-                    effectiveDefault: effectiveDefault
-                )
-            }
+            model.enqueueTerminalFontSizeAdjustment(
+                by: delta,
+                effectiveDefault: effectiveDefault
+            )
         case .unavailable:
             break
         }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -340,8 +340,9 @@ private struct RemuxWorkspaceShell: View {
 
     private func performKeyboardCommand(_ command: AppKeyboardCommand) {
         switch AppKeyboardCommandRouter.route(command, in: keyboardCommandContext) {
-        case .terminal:
-            break
+        case .terminal(let command):
+            guard !isCommandPalettePresented else { return }
+            appKeyboardCommandCenter?.performSelectedTerminal(command)
         case .showHome:
             isCommandPalettePresented = false
             dismissKeyboard()

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -59,11 +59,19 @@ private struct RemuxWorkspaceShell: View {
     @ObservedObject var model: RemuxRootModel
     let shortcutStore: ShortcutStore
     @State private var retainedTerminalID: SavedWorkspace.ID?
+    @State private var isCommandPalettePresented = false
 
     var body: some View {
         ZStack {
             activeTerminalLayer
             routeLayer
+            AppKeyboardCommandResponder(
+                settings: model.keyboardSettings,
+                isEnabled: selectedTerminalID == nil,
+                onCommand: performKeyboardCommand
+            )
+            .frame(width: 1, height: 1)
+            .opacity(0.01)
         }
         .onAppear {
             model.handleAppLifecyclePhase(
@@ -105,6 +113,15 @@ private struct RemuxWorkspaceShell: View {
         selectedTerminalID ?? retainedTerminalID ?? model.activeTerminalScreenEntries.first?.id
     }
 
+    private var keyboardCommandContext: AppKeyboardCommandRouteContext {
+        AppKeyboardCommandRouteContext(
+            selectedSessionID: selectedTerminalID,
+            orderedActiveSessionIDs: model.activeSessions
+                .sorted { $0.target.workspace.lastOpenedAt > $1.target.workspace.lastOpenedAt }
+                .map(\.id)
+        )
+    }
+
     private var activeTerminalLayer: some View {
         ZStack {
             ForEach(model.activeTerminalScreenEntries) { entry in
@@ -114,6 +131,8 @@ private struct RemuxWorkspaceShell: View {
                     entry: entry,
                     isSelected: isSelected,
                     shortcutStore: shortcutStore,
+                    keyboardSettings: model.keyboardSettings,
+                    onAppKeyboardCommand: performKeyboardCommand,
                     onReconnect: {
                         model.reconnectActiveSession(entry.id, source: .manualButton)
                     },
@@ -251,6 +270,21 @@ private struct RemuxWorkspaceShell: View {
         "session.show.\(workspaceID.uuidString)"
     }
 
+    private func performKeyboardCommand(_ command: AppKeyboardCommand) {
+        switch AppKeyboardCommandRouter.route(command, in: keyboardCommandContext) {
+        case .terminal:
+            break
+        case .showHome:
+            dismissKeyboard()
+            Task { await model.showLibrary() }
+        case .showCommandPalette:
+            isCommandPalettePresented = true
+        case .showSession(let id):
+            model.showActiveSession(id)
+        case .unavailable:
+            break
+        }
+    }
 }
 
 struct RemuxAppLifecycleProjection: Equatable {
@@ -276,6 +310,8 @@ private struct ActiveTerminalSessionView: View {
     let entry: ActiveTerminalScreenEntry
     let isSelected: Bool
     let shortcutStore: ShortcutStore
+    let keyboardSettings: KeyboardSettings
+    let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     let onReconnect: () -> Void
     let onUpdateCredentials: () -> Void
     let onEditServer: () -> Void
@@ -288,6 +324,8 @@ private struct ActiveTerminalSessionView: View {
         entry: ActiveTerminalScreenEntry,
         isSelected: Bool,
         shortcutStore: ShortcutStore,
+        keyboardSettings: KeyboardSettings,
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void,
         onReconnect: @escaping () -> Void,
         onUpdateCredentials: @escaping () -> Void,
         onEditServer: @escaping () -> Void,
@@ -297,6 +335,8 @@ private struct ActiveTerminalSessionView: View {
         self.entry = entry
         self.isSelected = isSelected
         self.shortcutStore = shortcutStore
+        self.keyboardSettings = keyboardSettings
+        self.onAppKeyboardCommand = onAppKeyboardCommand
         self.onReconnect = onReconnect
         self.onUpdateCredentials = onUpdateCredentials
         self.onEditServer = onEditServer
@@ -318,6 +358,8 @@ private struct ActiveTerminalSessionView: View {
                 isSelected: isSelected,
                 isTerminalCovered: previewSession.isPresented,
                 shortcutStore: shortcutStore,
+                keyboardSettings: keyboardSettings,
+                onAppKeyboardCommand: onAppKeyboardCommand,
                 attachmentTransferServiceFactory: entry.attachmentTransferServiceFactory,
                 onPreviewSelection: previewSelectionHandler,
                 onReconnect: onReconnect,

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -56,6 +56,7 @@ private struct RemuxRootContentView: View {
 
 private struct RemuxWorkspaceShell: View {
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.appKeyboardCommandCenter) private var appKeyboardCommandCenter
     @ObservedObject var model: RemuxRootModel
     let shortcutStore: ShortcutStore
     @StateObject private var physicalKeyboardMonitor = PhysicalKeyboardMonitor()
@@ -66,13 +67,6 @@ private struct RemuxWorkspaceShell: View {
         ZStack {
             activeTerminalLayer
             routeLayer
-            AppKeyboardCommandResponder(
-                settings: model.keyboardSettings,
-                isEnabled: selectedTerminalID == nil,
-                onCommand: performKeyboardCommand
-            )
-            .frame(width: 1, height: 1)
-            .opacity(0.01)
 
             if isCommandPalettePresented {
                 Color.black.opacity(0.28)
@@ -89,6 +83,7 @@ private struct RemuxWorkspaceShell: View {
             }
         }
         .onAppear {
+            updateAppKeyboardCommandCenter()
             model.handleAppLifecyclePhase(
                 RemuxAppLifecycleProjection(scenePhase: scenePhase).appLifecyclePhase
             )
@@ -101,6 +96,9 @@ private struct RemuxWorkspaceShell: View {
         .onChange(of: selectedTerminalID) { _, newValue in
             guard let newValue else { return }
             retainedTerminalID = newValue
+        }
+        .onChange(of: model.keyboardSettings) { _, _ in
+            updateAppKeyboardCommandCenter()
         }
         .onChange(of: model.activeTerminalScreenEntries.map(\.id)) { _, ids in
             guard !ids.isEmpty else {
@@ -345,11 +343,13 @@ private struct RemuxWorkspaceShell: View {
         case .terminal:
             break
         case .showHome:
+            isCommandPalettePresented = false
             dismissKeyboard()
             Task { await model.showLibrary() }
         case .showCommandPalette:
             isCommandPalettePresented = true
         case .showSession(let id):
+            isCommandPalettePresented = false
             model.showActiveSession(id)
         case .adjustFontSize(let delta):
             let effectiveDefault =
@@ -363,6 +363,13 @@ private struct RemuxWorkspaceShell: View {
         case .unavailable:
             break
         }
+    }
+
+    private func updateAppKeyboardCommandCenter() {
+        appKeyboardCommandCenter?.update(
+            settings: model.keyboardSettings,
+            onCommand: performKeyboardCommand
+        )
     }
 
     private func selectCommandPaletteAction(_ action: CommandPaletteAction) {

--- a/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
+++ b/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
@@ -7,6 +7,7 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
     case nextSession
     case home
     case windows
+    case newWindow
     case panes
     case attachments
     case increaseFontSize
@@ -29,6 +30,8 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
             "Home"
         case .windows:
             "Session Windows"
+        case .newWindow:
+            "New Window"
         case .panes:
             "Panes"
         case .attachments:
@@ -44,7 +47,7 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
 
     var requiresTerminal: Bool {
         switch self {
-        case .previousWindow, .nextWindow, .windows, .panes, .attachments:
+        case .previousWindow, .nextWindow, .windows, .newWindow, .panes, .attachments:
             true
         case .previousSession, .nextSession, .home, .commandPalette,
              .increaseFontSize, .decreaseFontSize:

--- a/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
+++ b/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
+    case previousWindow
+    case nextWindow
+    case previousSession
+    case nextSession
+    case home
+    case windows
+    case panes
+    case attachments
+    case commandPalette
+
+    var id: String { rawValue }
+
+    var displayTitle: String {
+        switch self {
+        case .previousWindow:
+            "Previous Window"
+        case .nextWindow:
+            "Next Window"
+        case .previousSession:
+            "Previous Session"
+        case .nextSession:
+            "Next Session"
+        case .home:
+            "Home"
+        case .windows:
+            "Session Windows"
+        case .panes:
+            "Panes"
+        case .attachments:
+            "Attachments"
+        case .commandPalette:
+            "Command Palette"
+        }
+    }
+
+    var requiresTerminal: Bool {
+        switch self {
+        case .previousWindow, .nextWindow, .windows, .panes, .attachments:
+            true
+        case .previousSession, .nextSession, .home, .commandPalette:
+            false
+        }
+    }
+}

--- a/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
+++ b/RemuxApp/Sources/Domain/AppKeyboardCommand.swift
@@ -9,6 +9,8 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
     case windows
     case panes
     case attachments
+    case increaseFontSize
+    case decreaseFontSize
     case commandPalette
 
     var id: String { rawValue }
@@ -33,6 +35,10 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
             "Attachments"
         case .commandPalette:
             "Command Palette"
+        case .increaseFontSize:
+            "Increase Font Size"
+        case .decreaseFontSize:
+            "Decrease Font Size"
         }
     }
 
@@ -40,7 +46,8 @@ enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
         switch self {
         case .previousWindow, .nextWindow, .windows, .panes, .attachments:
             true
-        case .previousSession, .nextSession, .home, .commandPalette:
+        case .previousSession, .nextSession, .home, .commandPalette,
+             .increaseFontSize, .decreaseFontSize:
             false
         }
     }

--- a/RemuxApp/Sources/Domain/KeyboardSettings.swift
+++ b/RemuxApp/Sources/Domain/KeyboardSettings.swift
@@ -24,6 +24,7 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
         case missingKey
         case missingModifier
         case unsupportedModifiers
+        case reservedSystemShortcut
         case duplicateBinding(command: AppKeyboardCommand)
     }
 
@@ -45,7 +46,7 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
                 input: UIKeyCommand.inputRightArrow,
                 modifiers: [.command, .shift]
             ),
-            .home: KeyboardKeyBinding(input: "h", modifiers: [.command]),
+            .home: KeyboardKeyBinding(input: "h", modifiers: [.command, .shift]),
             .windows: KeyboardKeyBinding(input: "o", modifiers: [.command]),
             .panes: KeyboardKeyBinding(input: "p", modifiers: [.command]),
             .attachments: KeyboardKeyBinding(input: "a", modifiers: [.command]),
@@ -131,11 +132,18 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
         guard binding.modifiers.subtracting(supportedModifiers).isEmpty else {
             throw ValidationError.unsupportedModifiers
         }
-        return KeyboardKeyBinding(
+        let canonicalBinding = KeyboardKeyBinding(
             input: binding.input.count == 1
                 ? binding.input.lowercased()
                 : binding.input,
             modifiers: binding.modifiers
         )
+        guard canonicalBinding != KeyboardKeyBinding(
+            input: "h",
+            modifiers: [.command]
+        ) else {
+            throw ValidationError.reservedSystemShortcut
+        }
+        return canonicalBinding
     }
 }

--- a/RemuxApp/Sources/Domain/KeyboardSettings.swift
+++ b/RemuxApp/Sources/Domain/KeyboardSettings.swift
@@ -51,6 +51,8 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
             .panes: KeyboardKeyBinding(input: "p", modifiers: [.command]),
             .attachments: KeyboardKeyBinding(input: "a", modifiers: [.command]),
             .commandPalette: KeyboardKeyBinding(input: "k", modifiers: [.command]),
+            .increaseFontSize: KeyboardKeyBinding(input: "+", modifiers: [.command]),
+            .decreaseFontSize: KeyboardKeyBinding(input: "-", modifiers: [.command]),
         ],
         hideButtonBarWhenPhysicalKeyboardConnected: true
     )

--- a/RemuxApp/Sources/Domain/KeyboardSettings.swift
+++ b/RemuxApp/Sources/Domain/KeyboardSettings.swift
@@ -21,7 +21,9 @@ struct KeyboardKeyBinding: Codable, Equatable, Hashable, Sendable {
 
 struct KeyboardSettings: Codable, Equatable, Sendable {
     enum ValidationError: Error, Equatable {
+        case missingKey
         case missingModifier
+        case unsupportedModifiers
         case duplicateBinding(command: AppKeyboardCommand)
     }
 
@@ -72,44 +74,68 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
         updating command: AppKeyboardCommand,
         to binding: KeyboardKeyBinding?
     ) throws -> KeyboardSettings {
-        if let binding {
-            guard !binding.modifiers.isEmpty else {
-                throw ValidationError.missingModifier
-            }
-            if let existingCommand = AppKeyboardCommand.allCases.first(where: {
-                $0 != command && bindings[$0] == binding
-            }) {
-                throw ValidationError.duplicateBinding(command: existingCommand)
-            }
-        }
-
         var updatedBindings = bindings
-        updatedBindings[command] = binding
-        let updated = KeyboardSettings(
+        if let binding {
+            let canonicalBinding = try Self.canonicalized(binding)
+            for existingCommand in AppKeyboardCommand.allCases where existingCommand != command {
+                guard let existingBinding = bindings[existingCommand] else { continue }
+                if try Self.canonicalized(existingBinding) == canonicalBinding {
+                    throw ValidationError.duplicateBinding(command: existingCommand)
+                }
+            }
+            updatedBindings[command] = canonicalBinding
+        } else {
+            updatedBindings[command] = nil
+        }
+        return try KeyboardSettings(
             bindings: updatedBindings,
             hideButtonBarWhenPhysicalKeyboardConnected:
                 hideButtonBarWhenPhysicalKeyboardConnected
-        )
-        try updated.validate()
-        return updated
+        ).validated()
     }
 
     func validated() throws -> KeyboardSettings {
-        try validate()
-        return self
-    }
-
-    private func validate() throws {
+        var canonicalBindings: [AppKeyboardCommand: KeyboardKeyBinding] = [:]
         var commandsByBinding: [KeyboardKeyBinding: AppKeyboardCommand] = [:]
         for command in AppKeyboardCommand.allCases {
             guard let binding = bindings[command] else { continue }
-            guard !binding.modifiers.isEmpty else {
-                throw ValidationError.missingModifier
-            }
-            if let existingCommand = commandsByBinding[binding] {
+            let canonicalBinding = try Self.canonicalized(binding)
+            if let existingCommand = commandsByBinding[canonicalBinding] {
                 throw ValidationError.duplicateBinding(command: existingCommand)
             }
-            commandsByBinding[binding] = command
+            commandsByBinding[canonicalBinding] = command
+            canonicalBindings[command] = canonicalBinding
         }
+        return KeyboardSettings(
+            bindings: canonicalBindings,
+            hideButtonBarWhenPhysicalKeyboardConnected:
+                hideButtonBarWhenPhysicalKeyboardConnected
+        )
+    }
+
+    private static func canonicalized(
+        _ binding: KeyboardKeyBinding
+    ) throws -> KeyboardKeyBinding {
+        guard !binding.input.isEmpty else {
+            throw ValidationError.missingKey
+        }
+        guard !binding.modifiers.isEmpty else {
+            throw ValidationError.missingModifier
+        }
+        let supportedModifiers: KeyboardKeyModifiers = [
+            .command,
+            .shift,
+            .option,
+            .control,
+        ]
+        guard binding.modifiers.subtracting(supportedModifiers).isEmpty else {
+            throw ValidationError.unsupportedModifiers
+        }
+        return KeyboardKeyBinding(
+            input: binding.input.count == 1
+                ? binding.input.lowercased()
+                : binding.input,
+            modifiers: binding.modifiers
+        )
     }
 }

--- a/RemuxApp/Sources/Domain/KeyboardSettings.swift
+++ b/RemuxApp/Sources/Domain/KeyboardSettings.swift
@@ -48,6 +48,7 @@ struct KeyboardSettings: Codable, Equatable, Sendable {
             ),
             .home: KeyboardKeyBinding(input: "h", modifiers: [.command, .shift]),
             .windows: KeyboardKeyBinding(input: "o", modifiers: [.command]),
+            .newWindow: KeyboardKeyBinding(input: "n", modifiers: [.command]),
             .panes: KeyboardKeyBinding(input: "p", modifiers: [.command]),
             .attachments: KeyboardKeyBinding(input: "a", modifiers: [.command]),
             .commandPalette: KeyboardKeyBinding(input: "k", modifiers: [.command]),

--- a/RemuxApp/Sources/Domain/KeyboardSettings.swift
+++ b/RemuxApp/Sources/Domain/KeyboardSettings.swift
@@ -1,0 +1,115 @@
+import Foundation
+import UIKit
+
+struct KeyboardKeyModifiers: OptionSet, Codable, Equatable, Hashable, Sendable {
+    let rawValue: Int
+
+    static let command = KeyboardKeyModifiers(rawValue: 1 << 0)
+    static let shift = KeyboardKeyModifiers(rawValue: 1 << 1)
+    static let option = KeyboardKeyModifiers(rawValue: 1 << 2)
+    static let control = KeyboardKeyModifiers(rawValue: 1 << 3)
+
+    init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}
+
+struct KeyboardKeyBinding: Codable, Equatable, Hashable, Sendable {
+    var input: String
+    var modifiers: KeyboardKeyModifiers
+}
+
+struct KeyboardSettings: Codable, Equatable, Sendable {
+    enum ValidationError: Error, Equatable {
+        case missingModifier
+        case duplicateBinding(command: AppKeyboardCommand)
+    }
+
+    static let `default` = KeyboardSettings(
+        bindings: [
+            .previousWindow: KeyboardKeyBinding(
+                input: UIKeyCommand.inputLeftArrow,
+                modifiers: [.command]
+            ),
+            .nextWindow: KeyboardKeyBinding(
+                input: UIKeyCommand.inputRightArrow,
+                modifiers: [.command]
+            ),
+            .previousSession: KeyboardKeyBinding(
+                input: UIKeyCommand.inputLeftArrow,
+                modifiers: [.command, .shift]
+            ),
+            .nextSession: KeyboardKeyBinding(
+                input: UIKeyCommand.inputRightArrow,
+                modifiers: [.command, .shift]
+            ),
+            .home: KeyboardKeyBinding(input: "h", modifiers: [.command]),
+            .windows: KeyboardKeyBinding(input: "o", modifiers: [.command]),
+            .panes: KeyboardKeyBinding(input: "p", modifiers: [.command]),
+            .attachments: KeyboardKeyBinding(input: "a", modifiers: [.command]),
+            .commandPalette: KeyboardKeyBinding(input: "k", modifiers: [.command]),
+        ],
+        hideButtonBarWhenPhysicalKeyboardConnected: true
+    )
+
+    private(set) var bindings: [AppKeyboardCommand: KeyboardKeyBinding]
+    var hideButtonBarWhenPhysicalKeyboardConnected: Bool
+
+    init(
+        bindings: [AppKeyboardCommand: KeyboardKeyBinding],
+        hideButtonBarWhenPhysicalKeyboardConnected: Bool
+    ) {
+        self.bindings = bindings
+        self.hideButtonBarWhenPhysicalKeyboardConnected =
+            hideButtonBarWhenPhysicalKeyboardConnected
+    }
+
+    func binding(for command: AppKeyboardCommand) -> KeyboardKeyBinding? {
+        bindings[command]
+    }
+
+    func validated(
+        updating command: AppKeyboardCommand,
+        to binding: KeyboardKeyBinding?
+    ) throws -> KeyboardSettings {
+        if let binding {
+            guard !binding.modifiers.isEmpty else {
+                throw ValidationError.missingModifier
+            }
+            if let existingCommand = AppKeyboardCommand.allCases.first(where: {
+                $0 != command && bindings[$0] == binding
+            }) {
+                throw ValidationError.duplicateBinding(command: existingCommand)
+            }
+        }
+
+        var updatedBindings = bindings
+        updatedBindings[command] = binding
+        let updated = KeyboardSettings(
+            bindings: updatedBindings,
+            hideButtonBarWhenPhysicalKeyboardConnected:
+                hideButtonBarWhenPhysicalKeyboardConnected
+        )
+        try updated.validate()
+        return updated
+    }
+
+    func validated() throws -> KeyboardSettings {
+        try validate()
+        return self
+    }
+
+    private func validate() throws {
+        var commandsByBinding: [KeyboardKeyBinding: AppKeyboardCommand] = [:]
+        for command in AppKeyboardCommand.allCases {
+            guard let binding = bindings[command] else { continue }
+            guard !binding.modifiers.isEmpty else {
+                throw ValidationError.missingModifier
+            }
+            if let existingCommand = commandsByBinding[binding] {
+                throw ValidationError.duplicateBinding(command: existingCommand)
+            }
+            commandsByBinding[binding] = command
+        }
+    }
+}

--- a/RemuxApp/Sources/Domain/TerminalSettings.swift
+++ b/RemuxApp/Sources/Domain/TerminalSettings.swift
@@ -142,6 +142,15 @@ struct TerminalSettings: Equatable, Codable, Sendable {
         return lines.joined(separator: "\n") + "\n"
     }
 
+    mutating func adjustFontSize(
+        by delta: Float32,
+        effectiveDefault: Float32
+    ) {
+        fontSize = Self.normalizedFontSize(
+            (fontSize ?? effectiveDefault) + delta
+        )
+    }
+
     private static func normalizedFontSize(_ value: Float32?) -> Float32? {
         guard let value, value.isFinite else { return nil }
         return min(max(value, minimumFontSize), maximumFontSize)

--- a/RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift
+++ b/RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift
@@ -7,5 +7,6 @@ struct TerminalViewportSnapshot: Equatable, Sendable {
     let windowID: UUID
     let windowName: String
     let paneID: UUID
+    let paneIndex: Int
     let text: String
 }

--- a/RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift
+++ b/RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct TerminalViewportSnapshot: Equatable, Sendable {
+    let workspaceID: SavedWorkspace.ID
+    let serverName: String
+    let sessionName: String
+    let windowID: UUID
+    let windowName: String
+    let paneID: UUID
+    let text: String
+}

--- a/RemuxApp/Sources/Ghostty/GhosttyKitControlSurface.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKitControlSurface.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Darwin
 import Foundation
 import GhosttyKit
 
@@ -180,6 +181,11 @@ extension TmuxControlViewport {
 /// this wrapper adds no lock, ownership mode, or alternate backend.
 @MainActor
 final class GhosttyKitControlSurface {
+    private typealias ReadViewportFunction = @convention(c) (
+        ghostty_terminal_surface_t?,
+        UnsafeMutablePointer<ghostty_text_s>?
+    ) -> ghostty_terminal_surface_input_result_e
+
     enum Failure: Equatable {
         case native(ghostty_terminal_surface_result_e)
         case scaleChanged
@@ -204,9 +210,33 @@ final class GhosttyKitControlSurface {
 
     var isInvalidated: Bool { invalidated }
 
+    func visibleText() -> String? {
+        guard !invalidated, let readViewport = Self.readViewport else { return nil }
+        var text = ghostty_text_s()
+        guard readViewport(handle, &text) == GHOSTTY_TERMINAL_SURFACE_INPUT_SENT else {
+            return nil
+        }
+        defer { _ = ghostty_terminal_surface_free_text(handle, &text) }
+        guard let bytes = text.text else { return "" }
+        return String(
+            decoding: UnsafeBufferPointer(
+                start: UnsafeRawPointer(bytes).assumingMemoryBound(to: UInt8.self),
+                count: Int(text.text_len)
+            ),
+            as: UTF8.self
+        )
+    }
+
     func invalidate() {
         invalidated = true
     }
+
+    private static let readViewport: ReadViewportFunction? = {
+        guard let symbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "ghostty_terminal_surface_read_viewport") else {
+            return nil
+        }
+        return unsafeBitCast(symbol, to: ReadViewportFunction.self)
+    }()
 
     @discardableResult
     func sendInput(_ text: String) -> Bool {

--- a/RemuxApp/Sources/Ghostty/GhosttyKitControlSurface.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKitControlSurface.swift
@@ -1,5 +1,4 @@
 import CoreGraphics
-import Darwin
 import Foundation
 import GhosttyKit
 
@@ -181,11 +180,6 @@ extension TmuxControlViewport {
 /// this wrapper adds no lock, ownership mode, or alternate backend.
 @MainActor
 final class GhosttyKitControlSurface {
-    private typealias ReadViewportFunction = @convention(c) (
-        ghostty_terminal_surface_t?,
-        UnsafeMutablePointer<ghostty_text_s>?
-    ) -> ghostty_terminal_surface_input_result_e
-
     enum Failure: Equatable {
         case native(ghostty_terminal_surface_result_e)
         case scaleChanged
@@ -211,9 +205,11 @@ final class GhosttyKitControlSurface {
     var isInvalidated: Bool { invalidated }
 
     func visibleText() -> String? {
-        guard !invalidated, let readViewport = Self.readViewport else { return nil }
+        guard !invalidated else { return nil }
         var text = ghostty_text_s()
-        guard readViewport(handle, &text) == GHOSTTY_TERMINAL_SURFACE_INPUT_SENT else {
+        guard ghostty_terminal_surface_read_viewport(handle, &text)
+            == GHOSTTY_TERMINAL_SURFACE_INPUT_SENT
+        else {
             return nil
         }
         defer { _ = ghostty_terminal_surface_free_text(handle, &text) }
@@ -230,13 +226,6 @@ final class GhosttyKitControlSurface {
     func invalidate() {
         invalidated = true
     }
-
-    private static let readViewport: ReadViewportFunction? = {
-        guard let symbol = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "ghostty_terminal_surface_read_viewport") else {
-            return nil
-        }
-        return unsafeBitCast(symbol, to: ReadViewportFunction.self)
-    }()
 
     @discardableResult
     func sendInput(_ text: String) -> Bool {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -108,6 +108,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private let isPhysicalKeyboardConnected: Bool
     private let isAppInputOwnerPresented: Bool
     private let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
+    private let onTerminalInputAvailabilityChange: (Bool) -> Void
     @State private var inputCoordinator = GhosttyTerminalInputCoordinator()
     @State private var terminalInputController = GhosttyTerminalInputController()
     @State private var selectionSheet: GhosttySurfaceSelectionSheet?
@@ -158,6 +159,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         isPhysicalKeyboardConnected: Bool = false,
         isAppInputOwnerPresented: Bool = false,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in },
+        onTerminalInputAvailabilityChange: @escaping (Bool) -> Void = { _ in },
         attachmentTransferServiceFactory: @escaping @Sendable () -> any GhosttyAttachmentTransferService,
         onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)? = nil,
         onReconnect: @escaping () -> Void,
@@ -175,6 +177,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
         self.isAppInputOwnerPresented = isAppInputOwnerPresented
         self.onAppKeyboardCommand = onAppKeyboardCommand
+        self.onTerminalInputAvailabilityChange = onTerminalInputAvailabilityChange
         _physicalKeyboardChromeState = State(
             initialValue: PhysicalKeyboardChromeState(
                 isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
@@ -570,6 +573,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 handleActiveLeafChange(activeLeafID)
             }
             .onChange(of: interactionProjection.isInputAvailable) { _, isInputAvailable in
+                onTerminalInputAvailabilityChange(isInputAvailable)
                 handleTerminalCoverInputAvailabilityChange(isInputAvailable)
             }
             .onChange(of: inputCoordinator.keyboardMode) { _, mode in
@@ -611,6 +615,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         .preferredColorScheme(presentation.terminalTheme.terminalChromeColorScheme)
         .environment(\.ghosttyTerminalChromeStyle, presentation.terminalTheme.terminalChromeStyle)
         .onAppear {
+            onTerminalInputAvailabilityChange(
+                model.terminalInteractionProjection.isInputAvailable
+            )
             GhosttyRuntimeTrace.flowEvent(
                 sessionOpenFlowID,
                 event: "ui.terminalScreen.appear",

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -57,6 +57,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private let isSelected: Bool
     private let isTerminalCovered: Bool
     private let shortcutStore: ShortcutStore
+    private let keyboardSettings: KeyboardSettings
+    private let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     @State private var inputCoordinator = GhosttyTerminalInputCoordinator()
     @State private var terminalInputController = GhosttyTerminalInputController()
     @State private var selectionSheet: GhosttySurfaceSelectionSheet?
@@ -102,6 +104,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         isSelected: Bool,
         isTerminalCovered: Bool = false,
         shortcutStore: ShortcutStore,
+        keyboardSettings: KeyboardSettings = .default,
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in },
         attachmentTransferServiceFactory: @escaping @Sendable () -> any GhosttyAttachmentTransferService,
         onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)? = nil,
         onReconnect: @escaping () -> Void,
@@ -115,6 +119,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         self.isSelected = isSelected
         self.isTerminalCovered = isTerminalCovered
         self.shortcutStore = shortcutStore
+        self.keyboardSettings = keyboardSettings
+        self.onAppKeyboardCommand = onAppKeyboardCommand
         self.attachmentTransferServiceFactory = attachmentTransferServiceFactory
         self.onPreviewSelection = onPreviewSelection
         self.onReconnect = onReconnect
@@ -215,11 +221,13 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             activationToken: inputCoordinator.terminalActivationToken,
                             trackpadDriver: trackpadDriver,
                             keyboardAppearance: presentation.terminalTheme.terminalKeyboardAppearance,
+                            keyboardSettings: keyboardSettings,
                             sendText: sendTerminalText,
                             sendPaste: sendTerminalPaste,
                             sendKeyEvent: sendTerminalKeyEvent,
                             onTrackpadFeedbackChange: { trackpadFeedback = $0 },
-                            onFirstResponderChange: { isTerminalResponderFirstResponder = $0 }
+                            onFirstResponderChange: { isTerminalResponderFirstResponder = $0 },
+                            onAppKeyboardCommand: performAppKeyboardCommand
                         )
                         .frame(
                             width: terminalViewportSize.width,
@@ -649,6 +657,23 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             )
         }
         inputCoordinator.handleSelectionChange(isInputAvailable: isTerminalInputAvailable)
+    }
+
+    private func performAppKeyboardCommand(_ command: AppKeyboardCommand) {
+        switch command {
+        case .previousWindow:
+            handleWindowSwipe(.previous)
+        case .nextWindow:
+            handleWindowSwipe(.next)
+        case .windows:
+            showWindows()
+        case .panes:
+            showPanes()
+        case .attachments:
+            toggleAttachmentTray()
+        case .previousSession, .nextSession, .home, .commandPalette:
+            onAppKeyboardCommand(command)
+        }
     }
 
     private func toggleKeyboardChrome() {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -98,6 +98,7 @@ enum GhosttySurfaceKeyboardCommandRouter {
 struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.displayScale) private var displayScale
+    @Environment(\.appKeyboardCommandCenter) private var appKeyboardCommandCenter
     @ObservedObject private var model: Model
     private let presentation: GhosttySurfaceScreenPresentation
     private let isSelected: Bool
@@ -598,6 +599,14 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 }
             }
 #endif
+        }
+        .background {
+            SelectedTerminalKeyboardCommandRegistrationView(
+                commandCenter: appKeyboardCommandCenter,
+                isSelected: isSelected,
+                onCommand: performAppKeyboardCommand
+            )
+            .frame(width: 0, height: 0)
         }
         .preferredColorScheme(presentation.terminalTheme.terminalChromeColorScheme)
         .environment(\.ghosttyTerminalChromeStyle, presentation.terminalTheme.terminalChromeStyle)

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -163,6 +163,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             let terminalResponderFocusPolicy = GhosttyTerminalResponderFocusPolicy(
                 isSelected: isSelected,
                 keyboardMode: inputCoordinator.keyboardMode,
+                isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
                 isInputAvailable: interactionProjection.isInputAvailable,
                 isTransientInputOwnerPresented: isTransientInputOwnerPresented
             )

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -61,6 +61,40 @@ enum GhosttyTerminalCoverPhase: Equatable {
     }
 }
 
+enum GhosttySurfaceKeyboardCommandRoute: Equatable {
+    case previousWindow
+    case nextWindow
+    case showWindows
+    case createWindow
+    case showPanes
+    case toggleAttachments
+    case forward(AppKeyboardCommand)
+}
+
+enum GhosttySurfaceKeyboardCommandRouter {
+    static func route(
+        _ command: AppKeyboardCommand
+    ) -> GhosttySurfaceKeyboardCommandRoute {
+        switch command {
+        case .previousWindow:
+            .previousWindow
+        case .nextWindow:
+            .nextWindow
+        case .windows:
+            .showWindows
+        case .newWindow:
+            .createWindow
+        case .panes:
+            .showPanes
+        case .attachments:
+            .toggleAttachments
+        case .previousSession, .nextSession, .home, .commandPalette,
+             .increaseFontSize, .decreaseFontSize:
+            .forward(command)
+        }
+    }
+}
+
 struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.displayScale) private var displayScale
@@ -717,19 +751,20 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func performAppKeyboardCommand(_ command: AppKeyboardCommand) {
-        switch command {
+        switch GhosttySurfaceKeyboardCommandRouter.route(command) {
         case .previousWindow:
             handleWindowSwipe(.previous)
         case .nextWindow:
             handleWindowSwipe(.next)
-        case .windows:
+        case .showWindows:
             showWindows()
-        case .panes:
+        case .createWindow:
+            createTmuxWindow(event: "ui.keyCommand.newWindow")
+        case .showPanes:
             showPanes()
-        case .attachments:
+        case .toggleAttachments:
             toggleAttachmentTray()
-        case .previousSession, .nextSession, .home, .commandPalette,
-             .increaseFontSize, .decreaseFontSize:
+        case .forward(let command):
             onAppKeyboardCommand(command)
         }
     }
@@ -2117,10 +2152,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         return fields
     }
 
-    private func createTmuxWindowFromSelectionSheet() {
+    private func createTmuxWindow(event: String) {
         GhosttyRuntimeTrace.flowBegin(
             "tmux.newWindow",
-            event: "ui.tap.newWindow",
+            event: event,
             fields: [
                 "topLevelsBefore": "\(model.terminalInteractionProjection.windowCount)",
                 "workspaceID": presentation.workspaceID.uuidString,
@@ -2130,6 +2165,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         performTopologyActionInteraction(effect) {
             model.createTmuxWindow()
         }
+    }
+
+    private func createTmuxWindowFromSelectionSheet() {
+        createTmuxWindow(event: "ui.tap.newWindow")
     }
 
     private func selectTmuxWindowFromSelectionSheet(_ id: UUID) {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -25,6 +25,18 @@ struct GhosttyAttachmentInputOwnerProjection: Equatable {
     }
 }
 
+struct GhosttyTerminalInputOwnerProjection: Equatable {
+    let isAppInputOwnerPresented: Bool
+    let isAttachmentInputOwnerPresented: Bool
+    let terminalCoverOwnsInput: Bool
+
+    var isTransientInputOwnerPresented: Bool {
+        isAppInputOwnerPresented
+            || isAttachmentInputOwnerPresented
+            || terminalCoverOwnsInput
+    }
+}
+
 struct GhosttyPendingAttachmentInteractionProjection: Equatable {
     let hasPreviewableAttachments: Bool
     let isTransferInProgress: Bool
@@ -59,6 +71,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private let shortcutStore: ShortcutStore
     private let keyboardSettings: KeyboardSettings
     private let isPhysicalKeyboardConnected: Bool
+    private let isAppInputOwnerPresented: Bool
     private let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     @State private var inputCoordinator = GhosttyTerminalInputCoordinator()
     @State private var terminalInputController = GhosttyTerminalInputController()
@@ -108,6 +121,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         shortcutStore: ShortcutStore,
         keyboardSettings: KeyboardSettings = .default,
         isPhysicalKeyboardConnected: Bool = false,
+        isAppInputOwnerPresented: Bool = false,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in },
         attachmentTransferServiceFactory: @escaping @Sendable () -> any GhosttyAttachmentTransferService,
         onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)? = nil,
@@ -124,6 +138,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         self.shortcutStore = shortcutStore
         self.keyboardSettings = keyboardSettings
         self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
+        self.isAppInputOwnerPresented = isAppInputOwnerPresented
         self.onAppKeyboardCommand = onAppKeyboardCommand
         _physicalKeyboardChromeState = State(
             initialValue: PhysicalKeyboardChromeState(
@@ -588,7 +603,11 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private var isTransientInputOwnerPresented: Bool {
-        isAttachmentInputOwnerPresented || terminalCoverPhase.ownsTerminalInput
+        GhosttyTerminalInputOwnerProjection(
+            isAppInputOwnerPresented: isAppInputOwnerPresented,
+            isAttachmentInputOwnerPresented: isAttachmentInputOwnerPresented,
+            terminalCoverOwnsInput: terminalCoverPhase.ownsTerminalInput
+        ).isTransientInputOwnerPresented
     }
 
     private var selectionSheetBinding: Binding<GhosttySurfaceSelectionSheet?> {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -293,7 +293,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             sendKeyEvent: sendTerminalKeyEvent,
                             onTrackpadFeedbackChange: { trackpadFeedback = $0 },
                             onFirstResponderChange: { isTerminalResponderFirstResponder = $0 },
-                            onAppKeyboardCommand: performAppKeyboardCommand
+                            onAppKeyboardCommand: {
+                                appKeyboardCommandCenter?
+                                    .performIfAvailable($0) ?? false
+                            }
                         )
                         .frame(
                             width: terminalViewportSize.width,

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -728,7 +728,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             showPanes()
         case .attachments:
             toggleAttachmentTray()
-        case .previousSession, .nextSession, .home, .commandPalette:
+        case .previousSession, .nextSession, .home, .commandPalette,
+             .increaseFontSize, .decreaseFontSize:
             onAppKeyboardCommand(command)
         }
     }

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -58,6 +58,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private let isTerminalCovered: Bool
     private let shortcutStore: ShortcutStore
     private let keyboardSettings: KeyboardSettings
+    private let isPhysicalKeyboardConnected: Bool
     private let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
     @State private var inputCoordinator = GhosttyTerminalInputCoordinator()
     @State private var terminalInputController = GhosttyTerminalInputController()
@@ -87,6 +88,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     @State private var attachmentTransferUploadCount = 0
     @State private var attachmentTransferProgress: GhosttyAttachmentTransferProgress?
     @State private var attachmentNotice: GhosttyAttachmentNotice?
+    @State private var physicalKeyboardChromeState: PhysicalKeyboardChromeState
 
     private let onReconnect: () -> Void
     private let onEditConnection: () -> Void
@@ -105,6 +107,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         isTerminalCovered: Bool = false,
         shortcutStore: ShortcutStore,
         keyboardSettings: KeyboardSettings = .default,
+        isPhysicalKeyboardConnected: Bool = false,
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in },
         attachmentTransferServiceFactory: @escaping @Sendable () -> any GhosttyAttachmentTransferService,
         onPreviewSelection: ((UUID, TerminalPreviewCandidate) -> Void)? = nil,
@@ -120,7 +123,14 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         self.isTerminalCovered = isTerminalCovered
         self.shortcutStore = shortcutStore
         self.keyboardSettings = keyboardSettings
+        self.isPhysicalKeyboardConnected = isPhysicalKeyboardConnected
         self.onAppKeyboardCommand = onAppKeyboardCommand
+        _physicalKeyboardChromeState = State(
+            initialValue: PhysicalKeyboardChromeState(
+                isPhysicalKeyboardConnected: isPhysicalKeyboardConnected,
+                hidesChrome: keyboardSettings.hideButtonBarWhenPhysicalKeyboardConnected
+            )
+        )
         self.attachmentTransferServiceFactory = attachmentTransferServiceFactory
         self.onPreviewSelection = onPreviewSelection
         self.onReconnect = onReconnect
@@ -344,38 +354,31 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             .overlay(alignment: .bottom) {
                 attachmentNoticeLayer()
             }
+            .overlay(alignment: .bottom) {
+                if physicalKeyboardChromeState.usesFloatingChrome,
+                   physicalKeyboardChromeState.isChromeVisible {
+                    keyboardChrome(
+                        renderedKeyboardMode: renderedKeyboardMode,
+                        interactionProjection: interactionProjection,
+                        chrome: chrome
+                    )
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+            }
             .safeAreaInset(edge: .bottom, spacing: 0) {
-                GhosttyKeyboardChrome(
-                    keyboardMode: renderedKeyboardMode,
-                    isEnabled: interactionProjection.isInputAvailable,
-                    isCompact: chrome.isCompact,
-                    isControlArmed: terminalInputController.isControlArmed,
-                    selectedWindowIndex: interactionProjection.selectedWindowIndex,
-                    windowCount: interactionProjection.windowCount,
-                    selectedPaneIndex: interactionProjection.selectedPaneIndex,
-                    paneCount: interactionProjection.paneCount,
-                    isAttachmentControlActive: isAttachmentTrayPresented,
-                    isAttachmentControlEnabled: !hasPendingAttachments,
-                    pendingAttachmentCount: pendingAttachments.count,
-                    onShowHome: onEditConnection,
-                    onShowWindows: showWindows,
-                    onShowPanes: showPanes,
-                    onShowAttachments: toggleAttachmentTray,
-                    onToggleKeyboard: toggleKeyboardChrome,
-                    onToggleControl: toggleControlModifier,
-                    onShowShortcuts: showShortcutPalette,
-                    sendKey: sendTerminalKeyEvent
-                )
-                .padding(.horizontal, chrome.surfaceHorizontalPadding)
-                .padding(.top, 4)
-                .padding(.bottom, chrome.bottomPadding)
-                .frame(maxWidth: .infinity, alignment: .bottom)
-                .background {
-                    GeometryReader { chromeProxy in
-                        Color.clear.preference(
-                            key: GhosttyBottomChromeHeightPreferenceKey.self,
-                            value: chromeProxy.size.height
-                        )
+                if !physicalKeyboardChromeState.usesFloatingChrome {
+                    keyboardChrome(
+                        renderedKeyboardMode: renderedKeyboardMode,
+                        interactionProjection: interactionProjection,
+                        chrome: chrome
+                    )
+                    .background {
+                        GeometryReader { chromeProxy in
+                            Color.clear.preference(
+                                key: GhosttyBottomChromeHeightPreferenceKey.self,
+                                value: chromeProxy.size.height
+                            )
+                        }
                     }
                 }
             }
@@ -386,6 +389,27 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                     "viewport.bottomChrome old=\(bottomChromeHeight.traceLabel) new=\(normalizedHeight.traceLabel) keyboardMode=\(inputCoordinator.keyboardMode.traceLabel) renderedMode=\(renderedKeyboardMode.traceLabel) softwareKeyboardVisible=\(inputCoordinator.isSoftwareKeyboardVisible) overlap=\(softwareKeyboardOverlapHeight.traceLabel)"
                 )
                 bottomChromeHeight = normalizedHeight
+            }
+            .onChange(of: isPhysicalKeyboardConnected) { _, connected in
+                physicalKeyboardChromeState.keyboardConnectionChanged(
+                    isConnected: connected,
+                    hidesChrome: keyboardSettings.hideButtonBarWhenPhysicalKeyboardConnected
+                )
+                if connected {
+                    bottomChromeHeight = 0
+                }
+            }
+            .onChange(of: keyboardSettings.hideButtonBarWhenPhysicalKeyboardConnected) { _, hides in
+                physicalKeyboardChromeState.keyboardConnectionChanged(
+                    isConnected: isPhysicalKeyboardConnected,
+                    hidesChrome: hides
+                )
+            }
+            .task(id: physicalKeyboardChromeState.autoHideToken) {
+                guard let token = physicalKeyboardChromeState.autoHideToken else { return }
+                try? await Task.sleep(for: .seconds(3))
+                guard !Task.isCancelled else { return }
+                physicalKeyboardChromeState.autoHideElapsed(token: token)
             }
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) {
                 guard shouldHandleTerminalKeyboardNotification else { return }
@@ -627,6 +651,17 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             ]
         )
         let isInputAvailable = isTerminalInputAvailable
+        if physicalKeyboardChromeState.usesFloatingChrome {
+            withAnimation(.easeOut(duration: 0.18)) {
+                physicalKeyboardChromeState.terminalTapped()
+            }
+            GhosttyRuntimeTrace.flowEvent(
+                "terminal.input",
+                event: "ui.tap.surface.end",
+                fields: ["activated": "\(isInputAvailable)"]
+            )
+            return
+        }
         showSystemKeyboard()
         GhosttyRuntimeTrace.flowEvent(
             "terminal.input",
@@ -674,6 +709,46 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         case .previousSession, .nextSession, .home, .commandPalette:
             onAppKeyboardCommand(command)
         }
+    }
+
+    private func keyboardChrome(
+        renderedKeyboardMode: GhosttyKeyboardChromeMode,
+        interactionProjection: GhosttyTerminalInteractionProjection,
+        chrome: GhosttyPhoneChromeLayout
+    ) -> some View {
+        GhosttyKeyboardChrome(
+            keyboardMode: renderedKeyboardMode,
+            isEnabled: interactionProjection.isInputAvailable,
+            isCompact: chrome.isCompact,
+            isControlArmed: terminalInputController.isControlArmed,
+            selectedWindowIndex: interactionProjection.selectedWindowIndex,
+            windowCount: interactionProjection.windowCount,
+            selectedPaneIndex: interactionProjection.selectedPaneIndex,
+            paneCount: interactionProjection.paneCount,
+            isAttachmentControlActive: isAttachmentTrayPresented,
+            isAttachmentControlEnabled: !hasPendingAttachments,
+            pendingAttachmentCount: pendingAttachments.count,
+            onShowHome: { performChromeInteraction(onEditConnection) },
+            onShowWindows: { performChromeInteraction(showWindows) },
+            onShowPanes: { performChromeInteraction(showPanes) },
+            onShowAttachments: { performChromeInteraction(toggleAttachmentTray) },
+            onToggleKeyboard: { performChromeInteraction(toggleKeyboardChrome) },
+            onToggleControl: { performChromeInteraction(toggleControlModifier) },
+            onShowShortcuts: { performChromeInteraction(showShortcutPalette) },
+            sendKey: { event in
+                physicalKeyboardChromeState.chromeInteracted()
+                return sendTerminalKeyEvent(event)
+            }
+        )
+        .padding(.horizontal, chrome.surfaceHorizontalPadding)
+        .padding(.top, 4)
+        .padding(.bottom, chrome.bottomPadding)
+        .frame(maxWidth: .infinity, alignment: .bottom)
+    }
+
+    private func performChromeInteraction(_ action: () -> Void) {
+        physicalKeyboardChromeState.chromeInteracted()
+        action()
     }
 
     private func toggleKeyboardChrome() {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -228,6 +228,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
 
                         GhosttyTerminalResponderRepresentable(
                             isEnabled: terminalResponderFocusPolicy.isResponderEnabled,
+                            areAppKeyboardCommandsEnabled:
+                                terminalResponderFocusPolicy.areAppKeyboardCommandsEnabled,
                             wantsFirstResponder: terminalResponderFocusPolicy.wantsFirstResponder,
                             activationToken: inputCoordinator.terminalActivationToken,
                             trackpadDriver: trackpadDriver,

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
@@ -19,6 +19,6 @@ struct GhosttyTerminalResponderFocusPolicy: Equatable {
     var wantsFirstResponder: Bool {
         isSelected
             && (keyboardMode.enablesSystemKeyboard || isPhysicalKeyboardConnected)
-            && (isResponderEnabled || areAppKeyboardCommandsEnabled)
+            && areAppKeyboardCommandsEnabled
     }
 }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
@@ -11,9 +11,14 @@ struct GhosttyTerminalResponderFocusPolicy: Equatable {
         isInputAvailable && !isTransientInputOwnerPresented
     }
 
+    var areAppKeyboardCommandsEnabled: Bool {
+        !isTransientInputOwnerPresented
+            && (isInputAvailable || isPhysicalKeyboardConnected)
+    }
+
     var wantsFirstResponder: Bool {
         isSelected
             && (keyboardMode.enablesSystemKeyboard || isPhysicalKeyboardConnected)
-            && isResponderEnabled
+            && (isResponderEnabled || areAppKeyboardCommandsEnabled)
     }
 }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderFocusPolicy.swift
@@ -3,6 +3,7 @@ import Foundation
 struct GhosttyTerminalResponderFocusPolicy: Equatable {
     let isSelected: Bool
     let keyboardMode: GhosttyKeyboardChromeMode
+    let isPhysicalKeyboardConnected: Bool
     let isInputAvailable: Bool
     let isTransientInputOwnerPresented: Bool
 
@@ -12,7 +13,7 @@ struct GhosttyTerminalResponderFocusPolicy: Equatable {
 
     var wantsFirstResponder: Bool {
         isSelected
-            && keyboardMode.enablesSystemKeyboard
+            && (keyboardMode.enablesSystemKeyboard || isPhysicalKeyboardConnected)
             && isResponderEnabled
     }
 }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -14,7 +14,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     let sendKeyEvent: (GhosttySurfaceKeyEvent) -> Bool
     let onTrackpadFeedbackChange: (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     let onFirstResponderChange: (Bool) -> Void
-    let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
+    let onAppKeyboardCommand: (AppKeyboardCommand) -> Bool
 
     init(
         isEnabled: Bool,
@@ -29,7 +29,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
         onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void,
         onFirstResponderChange: @escaping (Bool) -> Void = { _ in },
-        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Bool = { _ in false }
     ) {
         self.isEnabled = isEnabled
         self.areAppKeyboardCommandsEnabled = areAppKeyboardCommandsEnabled
@@ -83,6 +83,12 @@ enum GhosttyTerminalInputNormalizer {
     }
 }
 
+enum GhosttyTerminalAppKeyboardCommandResult: Equatable {
+    case notConfigured
+    case deferred
+    case handled
+}
+
 @MainActor
 final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTraits {
     override var canBecomeFirstResponder: Bool {
@@ -110,7 +116,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     private var sendTextHandler: ((String) -> Bool)?
     private var sendPasteHandler: ((String) -> Bool)?
     private var sendKeyEventHandler: ((GhosttySurfaceKeyEvent) -> Bool)?
-    private var appKeyboardCommandHandler: ((AppKeyboardCommand) -> Void)?
+    private var appKeyboardCommandHandler: ((AppKeyboardCommand) -> Bool)?
     private var appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: .default)
     private var trackpadFeedbackHandler: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var firstResponderStateHandler: ((Bool) -> Void)?
@@ -146,7 +152,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
         onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void = { _ in },
         onFirstResponderChange: @escaping (Bool) -> Void = { _ in },
-        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Bool = { _ in false }
     ) {
         let wasInputEnabled = self.isInputEnabled
         let wasResponderEnabled = wasInputEnabled || self.areAppKeyboardCommandsEnabled
@@ -401,12 +407,17 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
                 continue
             }
 
-            if let command = appKeyboardCommandResolver.command(
+            switch routeAppKeyboardCommand(
                 input: key.charactersIgnoringModifiers,
                 modifierFlags: key.modifierFlags
             ) {
-                appKeyboardCommandHandler?(command)
+            case .handled:
                 continue
+            case .deferred:
+                unhandledPresses.insert(press)
+                continue
+            case .notConfigured:
+                break
             }
 
             guard let action = GhosttyTerminalHardwareCommandMapping.resolveHardwarePress(
@@ -441,6 +452,29 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             )
             super.pressesBegan(unhandledPresses, with: event)
         }
+    }
+
+    func routeAppKeyboardCommand(
+        input: String,
+        modifierFlags: UIKeyModifierFlags
+    ) -> GhosttyTerminalAppKeyboardCommandResult {
+        guard
+            let command = appKeyboardCommandResolver.command(
+                input: input,
+                modifierFlags: modifierFlags
+            )
+        else {
+            return .notConfigured
+        }
+        guard
+            isInputEnabled,
+            areAppKeyboardCommandsEnabled,
+            wantsFirstResponder,
+            appKeyboardCommandHandler?(command) == true
+        else {
+            return .deferred
+        }
+        return .handled
     }
 
     private func handleHardwareCommandAction(_ action: GhosttyTerminalHardwareCommandAction) {

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -112,7 +112,6 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     private var sendKeyEventHandler: ((GhosttySurfaceKeyEvent) -> Bool)?
     private var appKeyboardCommandHandler: ((AppKeyboardCommand) -> Void)?
     private var appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: .default)
-    private var appKeyCommands: [UIKeyCommand] = []
     private var trackpadFeedbackHandler: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var firstResponderStateHandler: ((Bool) -> Void)?
     private var lastReportedFirstResponderState: Bool?
@@ -132,7 +131,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        areAppKeyboardCommandsEnabled ? appKeyCommands : nil
+        nil
     }
 
     func update(
@@ -180,7 +179,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         self.appKeyboardCommandHandler = onAppKeyboardCommand
         self.trackpadFeedbackHandler = onTrackpadFeedbackChange
         self.firstResponderStateHandler = onFirstResponderChange
-        updateAppKeyCommands(settings: keyboardSettings)
+        updateAppKeyboardCommandResolver(settings: keyboardSettings)
 
         if isFirstResponder, previousKeyboardAppearance != keyboardAppearance {
             reloadInputViews()
@@ -453,24 +452,8 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         }
     }
 
-    private func updateAppKeyCommands(settings: KeyboardSettings) {
+    private func updateAppKeyboardCommandResolver(settings: KeyboardSettings) {
         appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: settings)
-        appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
-            settings: settings,
-            commands: AppKeyboardCommand.allCases.filter(\.requiresTerminal),
-            action: #selector(performTerminalAppKeyboardCommand(_:))
-        )
-    }
-
-    @objc
-    private func performTerminalAppKeyboardCommand(_ sender: UIKeyCommand) {
-        guard
-            let rawValue = sender.propertyList as? String,
-            let command = AppKeyboardCommand(rawValue: rawValue)
-        else {
-            return
-        }
-        appKeyboardCommandHandler?(command)
     }
 
     private func scheduleResponderReconciliationIfNeeded(reason: String) {

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -457,13 +457,13 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: settings)
         appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
             settings: settings,
-            commands: AppKeyboardCommand.allCases,
-            action: #selector(performAppKeyboardCommand(_:))
+            commands: AppKeyboardCommand.allCases.filter(\.requiresTerminal),
+            action: #selector(performTerminalAppKeyboardCommand(_:))
         )
     }
 
     @objc
-    private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
+    private func performTerminalAppKeyboardCommand(_ sender: UIKeyCommand) {
         guard
             let rawValue = sender.propertyList as? String,
             let command = AppKeyboardCommand(rawValue: rawValue)

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     let isEnabled: Bool
+    let areAppKeyboardCommandsEnabled: Bool
     let wantsFirstResponder: Bool
     let activationToken: Int
     let trackpadDriver: GhosttyKeyboardCursorTrackpadDriver
@@ -17,6 +18,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
 
     init(
         isEnabled: Bool,
+        areAppKeyboardCommandsEnabled: Bool,
         wantsFirstResponder: Bool,
         activationToken: Int,
         trackpadDriver: GhosttyKeyboardCursorTrackpadDriver,
@@ -30,6 +32,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
     ) {
         self.isEnabled = isEnabled
+        self.areAppKeyboardCommandsEnabled = areAppKeyboardCommandsEnabled
         self.wantsFirstResponder = wantsFirstResponder
         self.activationToken = activationToken
         self.trackpadDriver = trackpadDriver
@@ -53,6 +56,7 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     func updateUIView(_ uiView: GhosttyTerminalResponderUIView, context: Context) {
         uiView.update(
             isEnabled: isEnabled,
+            areAppKeyboardCommandsEnabled: areAppKeyboardCommandsEnabled,
             wantsFirstResponder: wantsFirstResponder,
             activationToken: activationToken,
             keyboardAppearance: keyboardAppearance,
@@ -81,7 +85,9 @@ enum GhosttyTerminalInputNormalizer {
 
 @MainActor
 final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTraits {
-    override var canBecomeFirstResponder: Bool { isInputEnabled }
+    override var canBecomeFirstResponder: Bool {
+        isInputEnabled || areAppKeyboardCommandsEnabled
+    }
 
     var hasText: Bool { isInputEnabled }
     var keyboardAppearance: UIKeyboardAppearance = .dark
@@ -96,6 +102,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     var enablesReturnKeyAutomatically = false
 
     private var isInputEnabled = false
+    private var areAppKeyboardCommandsEnabled = false
     private var wantsFirstResponder = false
     private var activationToken = -1
     private var pendingFirstResponderRequest = false
@@ -125,11 +132,12 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     }
 
     override var keyCommands: [UIKeyCommand]? {
-        isInputEnabled ? appKeyCommands : nil
+        areAppKeyboardCommandsEnabled ? appKeyCommands : nil
     }
 
     func update(
         isEnabled: Bool,
+        areAppKeyboardCommandsEnabled: Bool? = nil,
         wantsFirstResponder: Bool,
         activationToken: Int,
         keyboardAppearance: UIKeyboardAppearance = .dark,
@@ -142,6 +150,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
     ) {
         let wasInputEnabled = self.isInputEnabled
+        let wasResponderEnabled = wasInputEnabled || self.areAppKeyboardCommandsEnabled
         let previouslyWantedFirstResponder = self.wantsFirstResponder
         let previousActivationToken = self.activationToken
         let previousKeyboardAppearance = self.keyboardAppearance
@@ -162,6 +171,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             ]
         )
         self.isInputEnabled = isEnabled
+        self.areAppKeyboardCommandsEnabled = areAppKeyboardCommandsEnabled ?? isEnabled
         self.wantsFirstResponder = wantsFirstResponder
         self.keyboardAppearance = keyboardAppearance
         self.sendTextHandler = sendText
@@ -178,6 +188,10 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
         if !isEnabled {
             cancelTrackpadGestureIfActive(reason: "disabled")
+        }
+
+        let isResponderEnabled = isInputEnabled || self.areAppKeyboardCommandsEnabled
+        if !isResponderEnabled {
             pendingFirstResponderRequest = false
             self.activationToken = activationToken
             scheduleResponderReconciliationIfNeeded(reason: "disabled")
@@ -192,7 +206,7 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         }
 
         let activationChanged = activationToken != self.activationToken
-        let enabledChanged = !wasInputEnabled
+        let enabledChanged = !wasResponderEnabled
         let wantsFirstResponderChanged = wantsFirstResponder != previouslyWantedFirstResponder
         let needsFirstResponderRecovery = !isFirstResponder && !pendingFirstResponderRequest
         guard activationChanged || enabledChanged || wantsFirstResponderChanged || needsFirstResponderRecovery else { return }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -7,11 +7,13 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
     let activationToken: Int
     let trackpadDriver: GhosttyKeyboardCursorTrackpadDriver
     let keyboardAppearance: UIKeyboardAppearance
+    let keyboardSettings: KeyboardSettings
     let sendText: (String) -> Bool
     let sendPaste: (String) -> Bool
     let sendKeyEvent: (GhosttySurfaceKeyEvent) -> Bool
     let onTrackpadFeedbackChange: (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void
     let onFirstResponderChange: (Bool) -> Void
+    let onAppKeyboardCommand: (AppKeyboardCommand) -> Void
 
     init(
         isEnabled: Bool,
@@ -19,22 +21,26 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
         activationToken: Int,
         trackpadDriver: GhosttyKeyboardCursorTrackpadDriver,
         keyboardAppearance: UIKeyboardAppearance = .dark,
+        keyboardSettings: KeyboardSettings = .default,
         sendText: @escaping (String) -> Bool,
         sendPaste: @escaping (String) -> Bool,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
         onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void,
-        onFirstResponderChange: @escaping (Bool) -> Void = { _ in }
+        onFirstResponderChange: @escaping (Bool) -> Void = { _ in },
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
     ) {
         self.isEnabled = isEnabled
         self.wantsFirstResponder = wantsFirstResponder
         self.activationToken = activationToken
         self.trackpadDriver = trackpadDriver
         self.keyboardAppearance = keyboardAppearance
+        self.keyboardSettings = keyboardSettings
         self.sendText = sendText
         self.sendPaste = sendPaste
         self.sendKeyEvent = sendKeyEvent
         self.onTrackpadFeedbackChange = onTrackpadFeedbackChange
         self.onFirstResponderChange = onFirstResponderChange
+        self.onAppKeyboardCommand = onAppKeyboardCommand
     }
 
     func makeUIView(context: Context) -> GhosttyTerminalResponderUIView {
@@ -50,11 +56,13 @@ struct GhosttyTerminalResponderRepresentable: UIViewRepresentable {
             wantsFirstResponder: wantsFirstResponder,
             activationToken: activationToken,
             keyboardAppearance: keyboardAppearance,
+            keyboardSettings: keyboardSettings,
             sendText: { sendText(GhosttyTerminalInputNormalizer.normalize($0)) },
             sendPaste: sendPaste,
             sendKeyEvent: sendKeyEvent,
             onTrackpadFeedbackChange: onTrackpadFeedbackChange,
-            onFirstResponderChange: onFirstResponderChange
+            onFirstResponderChange: onFirstResponderChange,
+            onAppKeyboardCommand: onAppKeyboardCommand
         )
     }
 
@@ -95,6 +103,9 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
     private var sendTextHandler: ((String) -> Bool)?
     private var sendPasteHandler: ((String) -> Bool)?
     private var sendKeyEventHandler: ((GhosttySurfaceKeyEvent) -> Bool)?
+    private var appKeyboardCommandHandler: ((AppKeyboardCommand) -> Void)?
+    private var appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: .default)
+    private var appKeyCommands: [UIKeyCommand] = []
     private var trackpadFeedbackHandler: ((GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void)?
     private var firstResponderStateHandler: ((Bool) -> Void)?
     private var lastReportedFirstResponderState: Bool?
@@ -113,16 +124,22 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         fatalError("init(coder:) is unavailable")
     }
 
+    override var keyCommands: [UIKeyCommand]? {
+        isInputEnabled ? appKeyCommands : nil
+    }
+
     func update(
         isEnabled: Bool,
         wantsFirstResponder: Bool,
         activationToken: Int,
         keyboardAppearance: UIKeyboardAppearance = .dark,
+        keyboardSettings: KeyboardSettings = .default,
         sendText: @escaping (String) -> Bool,
         sendPaste: @escaping (String) -> Bool,
         sendKeyEvent: @escaping (GhosttySurfaceKeyEvent) -> Bool,
         onTrackpadFeedbackChange: @escaping (GhosttyKeyboardCursorTrackpad.FeedbackState) -> Void = { _ in },
-        onFirstResponderChange: @escaping (Bool) -> Void = { _ in }
+        onFirstResponderChange: @escaping (Bool) -> Void = { _ in },
+        onAppKeyboardCommand: @escaping (AppKeyboardCommand) -> Void = { _ in }
     ) {
         let wasInputEnabled = self.isInputEnabled
         let previouslyWantedFirstResponder = self.wantsFirstResponder
@@ -150,8 +167,10 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         self.sendTextHandler = sendText
         self.sendPasteHandler = sendPaste
         self.sendKeyEventHandler = sendKeyEvent
+        self.appKeyboardCommandHandler = onAppKeyboardCommand
         self.trackpadFeedbackHandler = onTrackpadFeedbackChange
         self.firstResponderStateHandler = onFirstResponderChange
+        updateAppKeyCommands(settings: keyboardSettings)
 
         if isFirstResponder, previousKeyboardAppearance != keyboardAppearance {
             reloadInputViews()
@@ -366,6 +385,14 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
                 continue
             }
 
+            if let command = appKeyboardCommandResolver.command(
+                input: key.charactersIgnoringModifiers,
+                modifierFlags: key.modifierFlags
+            ) {
+                appKeyboardCommandHandler?(command)
+                continue
+            }
+
             guard let action = GhosttyTerminalHardwareCommandMapping.resolveHardwarePress(
                 keyCode: key.keyCode,
                 modifiers: key.modifierFlags,
@@ -407,6 +434,34 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         case .text(let text):
             _ = sendTextHandler?(text)
         }
+    }
+
+    private func updateAppKeyCommands(settings: KeyboardSettings) {
+        appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: settings)
+        appKeyCommands = AppKeyboardCommand.allCases.compactMap { command -> UIKeyCommand? in
+            guard let binding = settings.binding(for: command) else { return nil }
+            let keyCommand = UIKeyCommand(
+                title: command.displayTitle,
+                image: nil,
+                action: #selector(performAppKeyboardCommand(_:)),
+                input: binding.input,
+                modifierFlags: binding.modifiers.uiKeyModifierFlags,
+                propertyList: command.rawValue
+            )
+            keyCommand.wantsPriorityOverSystemBehavior = true
+            return keyCommand
+        }
+    }
+
+    @objc
+    private func performAppKeyboardCommand(_ sender: UIKeyCommand) {
+        guard
+            let rawValue = sender.propertyList as? String,
+            let command = AppKeyboardCommand(rawValue: rawValue)
+        else {
+            return
+        }
+        appKeyboardCommandHandler?(command)
     }
 
     private func scheduleResponderReconciliationIfNeeded(reason: String) {

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -86,7 +86,7 @@ enum GhosttyTerminalInputNormalizer {
 @MainActor
 final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTraits {
     override var canBecomeFirstResponder: Bool {
-        isInputEnabled || areAppKeyboardCommandsEnabled
+        isResponderEnabled
     }
 
     var hasText: Bool { isInputEnabled }
@@ -190,7 +190,6 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             cancelTrackpadGestureIfActive(reason: "disabled")
         }
 
-        let isResponderEnabled = isInputEnabled || self.areAppKeyboardCommandsEnabled
         if !isResponderEnabled {
             pendingFirstResponderRequest = false
             self.activationToken = activationToken
@@ -499,16 +498,16 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
     private var needsResponderReconciliation: Bool {
         if isFirstResponder {
-            return !isInputEnabled || !wantsFirstResponder || pendingFirstResponderRequest
+            return !isResponderEnabled || !wantsFirstResponder || pendingFirstResponderRequest
         }
 
-        return isInputEnabled && wantsFirstResponder && pendingFirstResponderRequest
+        return isResponderEnabled && wantsFirstResponder && pendingFirstResponderRequest
     }
 
     private func reconcileResponderState() {
         responderReconciliationScheduled = false
 
-        guard isInputEnabled else {
+        guard isResponderEnabled else {
             pendingFirstResponderRequest = false
             guard isFirstResponder else { return }
             GhosttyRuntimeTrace.diagnostics("responder.reconcile resign disabled token=\(activationToken)")
@@ -542,6 +541,10 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             ]
         )
         _ = attemptFirstResponderRequest(route: "reconcile")
+    }
+
+    private var isResponderEnabled: Bool {
+        isInputEnabled || areAppKeyboardCommandsEnabled
     }
 
     @discardableResult

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalResponderView.swift
@@ -270,6 +270,10 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
         cancelTrackpadGestureIfActive(reason: "resignFirstResponder")
         let didResignFirstResponder = super.resignFirstResponder()
         reportFirstResponderStateIfChanged()
+        if didResignFirstResponder, isResponderEnabled, wantsFirstResponder {
+            pendingFirstResponderRequest = true
+            scheduleResponderReconciliationIfNeeded(reason: "unexpected-resign")
+        }
         GhosttyRuntimeTrace.flowEventIfActive(
             "terminal.input",
             event: "responder.resignFirstResponder.result",
@@ -451,19 +455,11 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
     private func updateAppKeyCommands(settings: KeyboardSettings) {
         appKeyboardCommandResolver = AppKeyboardCommandResolver(settings: settings)
-        appKeyCommands = AppKeyboardCommand.allCases.compactMap { command -> UIKeyCommand? in
-            guard let binding = settings.binding(for: command) else { return nil }
-            let keyCommand = UIKeyCommand(
-                title: command.displayTitle,
-                image: nil,
-                action: #selector(performAppKeyboardCommand(_:)),
-                input: binding.input,
-                modifierFlags: binding.modifiers.uiKeyModifierFlags,
-                propertyList: command.rawValue
-            )
-            keyCommand.wantsPriorityOverSystemBehavior = true
-            return keyCommand
-        }
+        appKeyCommands = AppKeyboardKeyCommandBuilder.commands(
+            settings: settings,
+            commands: AppKeyboardCommand.allCases,
+            action: #selector(performAppKeyboardCommand(_:))
+        )
     }
 
     @objc
@@ -528,6 +524,10 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
             GhosttyRuntimeTrace.perf("responder.requestFirstResponder skip-no-window token=\(activationToken)")
             return
         }
+        guard !hasExternalFirstResponder else {
+            pendingFirstResponderRequest = false
+            return
+        }
 
         GhosttyRuntimeTrace.perf(
             "responder.requestFirstResponder deferred token=\(activationToken) firstResponder=\(isFirstResponder)"
@@ -545,6 +545,25 @@ final class GhosttyTerminalResponderUIView: UIView, UIKeyInput, UITextInputTrait
 
     private var isResponderEnabled: Bool {
         isInputEnabled || areAppKeyboardCommandsEnabled
+    }
+
+    private var hasExternalFirstResponder: Bool {
+        guard let window, let responder = firstResponder(in: window) else {
+            return false
+        }
+        return responder !== self
+    }
+
+    private func firstResponder(in view: UIView) -> UIView? {
+        if view.isFirstResponder {
+            return view
+        }
+        for subview in view.subviews {
+            if let responder = firstResponder(in: subview) {
+                return responder
+            }
+        }
+        return nil
     }
 
     @discardableResult

--- a/RemuxApp/Sources/Ghostty/PhysicalKeyboardChromeState.swift
+++ b/RemuxApp/Sources/Ghostty/PhysicalKeyboardChromeState.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct PhysicalKeyboardChromeState: Equatable {
+    private(set) var usesFloatingChrome: Bool
+    private(set) var isChromeVisible: Bool
+    private(set) var autoHideToken: Int?
+    private var nextToken = 0
+    private var hidesChrome: Bool
+
+    init(isPhysicalKeyboardConnected: Bool, hidesChrome: Bool) {
+        self.usesFloatingChrome = isPhysicalKeyboardConnected
+        self.isChromeVisible = !isPhysicalKeyboardConnected || !hidesChrome
+        self.autoHideToken = nil
+        self.hidesChrome = hidesChrome
+    }
+
+    mutating func keyboardConnectionChanged(
+        isConnected: Bool,
+        hidesChrome: Bool
+    ) {
+        usesFloatingChrome = isConnected
+        self.hidesChrome = hidesChrome
+        autoHideToken = nil
+        isChromeVisible = !isConnected || !hidesChrome
+    }
+
+    mutating func terminalTapped() {
+        revealIfAutoHidden()
+    }
+
+    mutating func chromeInteracted() {
+        revealIfAutoHidden()
+    }
+
+    mutating func autoHideElapsed(token: Int) {
+        guard autoHideToken == token else { return }
+        autoHideToken = nil
+        isChromeVisible = false
+    }
+
+    private mutating func revealIfAutoHidden() {
+        guard usesFloatingChrome, hidesChrome else { return }
+        isChromeVisible = true
+        nextToken += 1
+        autoHideToken = nextToken
+    }
+}

--- a/RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift
+++ b/RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+protocol KeyboardSettingsRepository: Sendable {
+    func loadSettings() async throws -> KeyboardSettings
+    func saveSettings(_ settings: KeyboardSettings) async throws
+}
+
+actor FileBackedKeyboardSettingsRepository: KeyboardSettingsRepository {
+    private let store: JSONFileStore<KeyboardSettings>
+
+    init(rootURL: URL) {
+        self.store = JSONFileStore(fileURL: rootURL.appendingPathComponent("keyboard-settings.json"))
+    }
+
+    func loadSettings() async throws -> KeyboardSettings {
+        let settings = try await store.load(defaultValue: [.default]).first ?? .default
+        return try settings.validated()
+    }
+
+    func saveSettings(_ settings: KeyboardSettings) async throws {
+        try settings.validated()
+        try await store.save([settings])
+    }
+}

--- a/RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift
+++ b/RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift
@@ -18,7 +18,7 @@ actor FileBackedKeyboardSettingsRepository: KeyboardSettingsRepository {
     }
 
     func saveSettings(_ settings: KeyboardSettings) async throws {
-        try settings.validated()
-        try await store.save([settings])
+        let validatedSettings = try settings.validated()
+        try await store.save([validatedSettings])
     }
 }

--- a/RemuxApp/Sources/Tmux/TmuxPaneSurface.swift
+++ b/RemuxApp/Sources/Tmux/TmuxPaneSurface.swift
@@ -60,6 +60,10 @@ final class TmuxPaneSurface {
         case failed
     }
 
+    func visibleText() -> String? {
+        renderer?.control.visibleText()
+    }
+
     private final class FailureRelay {
         weak var pane: TmuxPaneSurface?
     }

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -143,8 +143,7 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
             let windowName = window.name.isEmpty
                 ? "Window \(windowIndex + 1)"
                 : window.name
-            return topology.panes
-                .filter { $0.windowID == window.id }
+            return Self.orderedPanes(in: window.id, topology: topology)
                 .enumerated()
                 .compactMap { paneIndex, pane -> TerminalViewportSnapshot? in
                     guard let text = textByPaneID[pane.id] else { return nil }
@@ -160,6 +159,17 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
                     )
                 }
         }
+    }
+
+    static func orderedPanes(
+        in windowID: TmuxWindowID,
+        topology: TmuxSessionController.TopologySnapshot
+    ) -> [TmuxSessionController.PaneInfo] {
+        topology.panes
+            .filter { $0.windowID == windowID }
+            .sorted { lhs, rhs in
+                (lhs.y, lhs.x, lhs.id) < (rhs.y, rhs.x, rhs.id)
+            }
     }
 
     // MARK: Topology synthesis
@@ -179,11 +189,7 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
         }
 
         let topLevels = topology.windows.map { window in
-            let paneIDs = topology.panes
-                .filter { $0.windowID == window.id }
-                .sorted { lhs, rhs in
-                    (lhs.y, lhs.x, lhs.id) < (rhs.y, rhs.x, rhs.id)
-                }
+            let paneIDs = Self.orderedPanes(in: window.id, topology: topology)
                 .map { identities.surfaceID(for: $0.id) }
             return GhosttyTopLevelSurface(
                 id: identities.surfaceID(for: window.id),

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -139,22 +139,26 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
         let textByPaneID = Dictionary(
             uniqueKeysWithValues: session.visiblePaneTexts().map { ($0.paneID, $0.text) }
         )
-        return topology.panes.compactMap { pane in
-            guard
-                let text = textByPaneID[pane.id],
-                let window = topology.windows.first(where: { $0.id == pane.windowID })
-            else {
-                return nil
-            }
-            return TerminalViewportSnapshot(
-                workspaceID: workspaceID,
-                serverName: serverName,
-                sessionName: sessionName,
-                windowID: identities.surfaceID(for: window.id),
-                windowName: window.name,
-                paneID: identities.surfaceID(for: pane.id),
-                text: text
-            )
+        return topology.windows.enumerated().flatMap { windowIndex, window in
+            let windowName = window.name.isEmpty
+                ? "Window \(windowIndex + 1)"
+                : window.name
+            return topology.panes
+                .filter { $0.windowID == window.id }
+                .enumerated()
+                .compactMap { paneIndex, pane -> TerminalViewportSnapshot? in
+                    guard let text = textByPaneID[pane.id] else { return nil }
+                    return TerminalViewportSnapshot(
+                        workspaceID: workspaceID,
+                        serverName: serverName,
+                        sessionName: sessionName,
+                        windowID: identities.surfaceID(for: window.id),
+                        windowName: windowName,
+                        paneID: identities.surfaceID(for: pane.id),
+                        paneIndex: paneIndex + 1,
+                        text: text
+                    )
+                }
         }
     }
 

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -135,9 +135,24 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
         serverName: String,
         sessionName: String
     ) -> [TerminalViewportSnapshot] {
-        guard let session, let topology = latestTopology else { return [] }
+        guard let session else { return [] }
+        return viewportSnapshots(
+            workspaceID: workspaceID,
+            serverName: serverName,
+            sessionName: sessionName,
+            visiblePaneTexts: session.visiblePaneTexts()
+        )
+    }
+
+    func viewportSnapshots(
+        workspaceID: SavedWorkspace.ID,
+        serverName: String,
+        sessionName: String,
+        visiblePaneTexts: [(paneID: TmuxPaneID, text: String)]
+    ) -> [TerminalViewportSnapshot] {
+        guard let topology = latestTopology else { return [] }
         let textByPaneID = Dictionary(
-            uniqueKeysWithValues: session.visiblePaneTexts().map { ($0.paneID, $0.text) }
+            uniqueKeysWithValues: visiblePaneTexts.map { ($0.paneID, $0.text) }
         )
         return topology.windows.enumerated().flatMap { windowIndex, window in
             let windowName = window.name.isEmpty

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -130,6 +130,34 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
         return paneID
     }
 
+    func viewportSnapshots(
+        workspaceID: SavedWorkspace.ID,
+        serverName: String,
+        sessionName: String
+    ) -> [TerminalViewportSnapshot] {
+        guard let session, let topology = latestTopology else { return [] }
+        let textByPaneID = Dictionary(
+            uniqueKeysWithValues: session.visiblePaneTexts().map { ($0.paneID, $0.text) }
+        )
+        return topology.panes.compactMap { pane in
+            guard
+                let text = textByPaneID[pane.id],
+                let window = topology.windows.first(where: { $0.id == pane.windowID })
+            else {
+                return nil
+            }
+            return TerminalViewportSnapshot(
+                workspaceID: workspaceID,
+                serverName: serverName,
+                sessionName: sessionName,
+                windowID: identities.surfaceID(for: window.id),
+                windowName: window.name,
+                paneID: identities.surfaceID(for: pane.id),
+                text: text
+            )
+        }
+    }
+
     // MARK: Topology synthesis
 
     private static var emptyTopologySnapshot: GhosttyRuntimeSurfaceTopologySnapshot {

--- a/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
@@ -441,9 +441,23 @@ final class TmuxTerminalSession: ObservableObject {
     }
 
     func visiblePaneTexts() -> [(paneID: TmuxPaneID, text: String)] {
-        surfacesByPaneID.compactMap { paneID, surface in
-            surface.visibleText().map { (paneID, $0) }
+        guard Self.isViewportSearchAvailable(state: state, isShutDown: isShutDown) else {
+            return []
         }
+        return surfacesByPaneID.compactMap { paneID, surface -> (
+            paneID: TmuxPaneID,
+            text: String
+        )? in
+            guard livePaneIDs.contains(paneID), !surface.isClosing else { return nil }
+            return surface.visibleText().map { (paneID, $0) }
+        }
+    }
+
+    static func isViewportSearchAvailable(
+        state: TmuxSessionController.SessionState,
+        isShutDown: Bool
+    ) -> Bool {
+        !isShutDown && state == .ready
     }
 
     private func presentActivePane(from snapshot: TmuxSessionController.TopologySnapshot) {

--- a/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
@@ -440,6 +440,12 @@ final class TmuxTerminalSession: ObservableObject {
         surfacesByPaneID[paneID]?.cancelPickerCaptureForPresentation()
     }
 
+    func visiblePaneTexts() -> [(paneID: TmuxPaneID, text: String)] {
+        surfacesByPaneID.compactMap { paneID, surface in
+            surface.visibleText().map { (paneID, $0) }
+        }
+    }
+
     private func presentActivePane(from snapshot: TmuxSessionController.TopologySnapshot) {
         guard !isShutDown, isAppActive, state == .ready,
               let paneID = activePaneID(in: snapshot)

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import XCTest
 @testable import Remux
@@ -136,5 +137,151 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         )
         XCTAssertNil(resolver.command(input: "g", modifierFlags: [.control]))
         XCTAssertNil(resolver.command(input: "h", modifierFlags: [.command]))
+    }
+}
+
+final class AppKeyboardCommandResponderTests: XCTestCase {
+    @MainActor
+    func testHostingControllerExposesGlobalCommands() throws {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+
+        controller.update(settings: .default, commandCenter: center)
+
+        let commands = try XCTUnwrap(controller.keyCommands)
+        XCTAssertEqual(
+            Set(commands.compactMap { $0.propertyList as? String }),
+            Set(
+                AppKeyboardCommand.allCases
+                    .filter { !$0.requiresTerminal }
+                    .map(\.rawValue)
+            )
+        )
+        XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
+    }
+
+    @MainActor
+    func testTextFieldResponderChainReachesGlobalCommandTarget() throws {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+        controller.loadViewIfNeeded()
+
+        let contentController = try XCTUnwrap(controller.children.first)
+        let textField = UITextField()
+        contentController.view.addSubview(textField)
+        let command = try XCTUnwrap(
+            controller.keyCommands?.first(where: {
+                $0.propertyList as? String
+                    == AppKeyboardCommand.commandPalette.rawValue
+            })
+        )
+        let action = try XCTUnwrap(command.action)
+
+        let target = textField.target(
+            forAction: action,
+            withSender: command
+        ) as? AppKeyboardCommandHostingController
+        XCTAssertTrue(target === controller)
+    }
+
+    @MainActor
+    func testShortcutCaptureSuspendsAndRestoresGlobalCommands() {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+        center.register(controller)
+
+        center.setShortcutCaptureActive(true)
+        XCTAssertTrue((controller.keyCommands ?? []).isEmpty)
+
+        center.setShortcutCaptureActive(false)
+        XCTAssertFalse((controller.keyCommands ?? []).isEmpty)
+    }
+}
+
+final class AppKeyboardCommandCenterTests: XCTestCase {
+    @MainActor
+    func testDispatchesCommandsThroughCurrentHandler() {
+        let center = AppKeyboardCommandCenter()
+        var receivedCommands: [AppKeyboardCommand] = []
+
+        center.update(settings: .default) {
+            receivedCommands.append($0)
+        }
+        center.perform(.commandPalette)
+
+        XCTAssertEqual(receivedCommands, [.commandPalette])
+    }
+}
+
+final class AppKeyboardCommandResponderActionTests: XCTestCase {
+    @MainActor
+    func testDispatchesRegisteredCommandThroughCurrentCenter() throws {
+        let center = AppKeyboardCommandCenter()
+        var receivedCommands: [AppKeyboardCommand] = []
+        center.update(settings: .default) {
+            receivedCommands.append($0)
+        }
+
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+        let registeredCommand = try XCTUnwrap(
+            controller.keyCommands?.first(where: {
+                $0.propertyList as? String == AppKeyboardCommand.commandPalette.rawValue
+            })
+        )
+        let action = try XCTUnwrap(registeredCommand.action)
+        XCTAssertTrue(controller.responds(to: action))
+        XCTAssertTrue(
+            controller.canPerformAction(action, withSender: registeredCommand)
+        )
+        XCTAssertTrue(
+            UIApplication.shared.sendAction(
+                action,
+                to: controller,
+                from: registeredCommand,
+                for: nil
+            )
+        )
+
+        XCTAssertEqual(receivedCommands, [.commandPalette])
+    }
+
+    @MainActor
+    func testHandlesConfiguredRawGlobalChordAndIgnoresPlainText() {
+        let center = AppKeyboardCommandCenter()
+        var receivedCommands: [AppKeyboardCommand] = []
+        center.update(settings: .default) {
+            receivedCommands.append($0)
+        }
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+
+        XCTAssertTrue(
+            controller.handleKeyPress(
+                input: "h",
+                modifierFlags: [.command, .shift]
+            )
+        )
+        XCTAssertFalse(
+            controller.handleKeyPress(input: "h", modifierFlags: [])
+        )
+        XCTAssertEqual(receivedCommands, [.home])
     }
 }

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -158,19 +158,36 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
 
 final class AppKeyboardCommandResponderTests: XCTestCase {
     @MainActor
-    func testHostingControllerExposesAllAppCommands() throws {
+    func testHostingControllerExposesOnlyAvailableAppCommands() throws {
         let center = AppKeyboardCommandCenter()
         let controller = AppKeyboardCommandHostingController(
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
+        let availableCommands = AppKeyboardCommandRouter.availableCommands(
+            in: AppKeyboardCommandRouteContext(
+                selectedSessionID: nil,
+                isSelectedTerminalReady: false,
+                orderedActiveSessionIDs: []
+            )
+        )
+        XCTAssertEqual(availableCommands, [
+            .home,
+            .increaseFontSize,
+            .decreaseFontSize,
+            .commandPalette,
+        ])
 
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: availableCommands,
+            commandCenter: center
+        )
 
         let commands = try XCTUnwrap(controller.keyCommands)
         XCTAssertEqual(
             Set(commands.compactMap { $0.propertyList as? String }),
-            Set(AppKeyboardCommand.allCases.map(\.rawValue))
+            Set(availableCommands.map(\.rawValue))
         )
         XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
     }
@@ -182,7 +199,11 @@ final class AppKeyboardCommandResponderTests: XCTestCase {
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases,
+            commandCenter: center
+        )
         controller.loadViewIfNeeded()
 
         let contentController = try XCTUnwrap(controller.children.first)
@@ -210,7 +231,11 @@ final class AppKeyboardCommandResponderTests: XCTestCase {
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases,
+            commandCenter: center
+        )
         center.register(controller)
 
         center.setShortcutCaptureActive(true)
@@ -227,7 +252,10 @@ final class AppKeyboardCommandCenterTests: XCTestCase {
         let center = AppKeyboardCommandCenter()
         var receivedCommands: [AppKeyboardCommand] = []
 
-        center.update(settings: .default) {
+        center.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases
+        ) {
             receivedCommands.append($0)
         }
         center.perform(.commandPalette)
@@ -241,7 +269,10 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
     func testDispatchesRegisteredCommandThroughCurrentCenter() throws {
         let center = AppKeyboardCommandCenter()
         var receivedCommands: [AppKeyboardCommand] = []
-        center.update(settings: .default) {
+        center.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases
+        ) {
             receivedCommands.append($0)
         }
 
@@ -249,7 +280,11 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases,
+            commandCenter: center
+        )
         let registeredCommand = try XCTUnwrap(
             controller.keyCommands?.first(where: {
                 $0.propertyList as? String == AppKeyboardCommand.commandPalette.rawValue
@@ -276,14 +311,21 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
     func testHandlesConfiguredRawAppChordsAndIgnoresPlainText() {
         let center = AppKeyboardCommandCenter()
         var receivedCommands: [AppKeyboardCommand] = []
-        center.update(settings: .default) {
+        center.update(
+            settings: .default,
+            availableCommands: [.home]
+        ) {
             receivedCommands.append($0)
         }
         let controller = AppKeyboardCommandHostingController(
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: [.home],
+            commandCenter: center
+        )
 
         XCTAssertTrue(
             controller.handleKeyPress(
@@ -294,13 +336,13 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
         XCTAssertFalse(
             controller.handleKeyPress(input: "h", modifierFlags: [])
         )
-        XCTAssertTrue(
+        XCTAssertFalse(
             controller.handleKeyPress(
                 input: "n",
                 modifierFlags: [.command]
             )
         )
-        XCTAssertEqual(receivedCommands, [.home, .newWindow])
+        XCTAssertEqual(receivedCommands, [.home])
     }
 
     @MainActor
@@ -310,7 +352,11 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases,
+            commandCenter: center
+        )
         center.register(controller)
         controller.loadViewIfNeeded()
         let contentController = try XCTUnwrap(controller.children.first)

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -22,6 +22,23 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         XCTAssertEqual(AppKeyboardCommandRouter.route(.windows, in: context), .unavailable)
     }
 
+    func testFontSizeCommandsAreGlobalAdjustments() {
+        let context = AppKeyboardCommandRouteContext(
+            selectedSessionID: nil,
+            isSelectedTerminalReady: false,
+            orderedActiveSessionIDs: []
+        )
+
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.increaseFontSize, in: context),
+            .adjustFontSize(by: 1)
+        )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.decreaseFontSize, in: context),
+            .adjustFontSize(by: -1)
+        )
+    }
+
     func testSelectedTerminalCommandsRouteLocally() {
         let selectedID = UUID()
         let context = AppKeyboardCommandRouteContext(

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -1,0 +1,104 @@
+import UIKit
+import XCTest
+@testable import Remux
+
+final class AppKeyboardCommandRouterTests: XCTestCase {
+    func testHomeRouteKeepsGlobalCommandsAndDisablesTerminalCommands() {
+        let context = AppKeyboardCommandRouteContext(
+            selectedSessionID: nil,
+            orderedActiveSessionIDs: []
+        )
+
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.home, in: context), .showHome)
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.commandPalette, in: context),
+            .showCommandPalette
+        )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.previousWindow, in: context),
+            .unavailable
+        )
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.windows, in: context), .unavailable)
+    }
+
+    func testSelectedTerminalCommandsRouteLocally() {
+        let selectedID = UUID()
+        let context = AppKeyboardCommandRouteContext(
+            selectedSessionID: selectedID,
+            orderedActiveSessionIDs: [selectedID]
+        )
+
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.previousWindow, in: context),
+            .terminal(.previousWindow)
+        )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.windows, in: context),
+            .terminal(.windows)
+        )
+    }
+
+    func testSessionNavigationWrapsInSuppliedHomeOrder() {
+        let first = UUID()
+        let second = UUID()
+        let third = UUID()
+        let ordered = [first, second, third]
+
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(
+                .previousSession,
+                in: AppKeyboardCommandRouteContext(
+                    selectedSessionID: first,
+                    orderedActiveSessionIDs: ordered
+                )
+            ),
+            .showSession(third)
+        )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(
+                .nextSession,
+                in: AppKeyboardCommandRouteContext(
+                    selectedSessionID: third,
+                    orderedActiveSessionIDs: ordered
+                )
+            ),
+            .showSession(first)
+        )
+    }
+
+    func testSessionNavigationFromHomeChoosesNearestEnd() {
+        let first = UUID()
+        let last = UUID()
+        let context = AppKeyboardCommandRouteContext(
+            selectedSessionID: nil,
+            orderedActiveSessionIDs: [first, last]
+        )
+
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.nextSession, in: context),
+            .showSession(first)
+        )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.previousSession, in: context),
+            .showSession(last)
+        )
+    }
+
+    func testConfiguredChordResolverMatchesOnlyAssignedModifiedChord() throws {
+        let settings = try KeyboardSettings.default.validated(
+            updating: .home,
+            to: KeyboardKeyBinding(input: "g", modifiers: [.control, .option])
+        )
+        let resolver = AppKeyboardCommandResolver(settings: settings)
+
+        XCTAssertEqual(
+            resolver.command(
+                input: "G",
+                modifierFlags: [.control, .alternate, .alphaShift]
+            ),
+            .home
+        )
+        XCTAssertNil(resolver.command(input: "g", modifierFlags: [.control]))
+        XCTAssertNil(resolver.command(input: "h", modifierFlags: [.command]))
+    }
+}

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -300,4 +300,82 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
         )
         XCTAssertEqual(receivedCommands, [.home])
     }
+
+    @MainActor
+    func testPaletteCommandsDispatchThroughGlobalResponderWhileTextOwnsFocus() throws {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+        center.register(controller)
+        controller.loadViewIfNeeded()
+        let contentController = try XCTUnwrap(controller.children.first)
+        let textField = UITextField()
+        contentController.view.addSubview(textField)
+
+        let owner = NSObject()
+        var actions: [String] = []
+        center.registerCommandPalette(
+            owner: owner,
+            onMoveSelection: {
+                switch $0 {
+                case .previous:
+                    actions.append("previous")
+                case .next:
+                    actions.append("next")
+                }
+            },
+            onActivateSelection: {
+                actions.append("activate")
+            },
+            onDismiss: {
+                actions.append("dismiss")
+            }
+        )
+
+        let expectedInputs = [
+            UIKeyCommand.inputUpArrow,
+            UIKeyCommand.inputDownArrow,
+            "\r",
+            UIKeyCommand.inputEscape,
+        ]
+        let commands = try XCTUnwrap(controller.keyCommands)
+        for input in expectedInputs {
+            let command = try XCTUnwrap(
+                commands.first {
+                    $0.input == input && $0.modifierFlags.isEmpty
+                }
+            )
+            XCTAssertTrue(command.wantsPriorityOverSystemBehavior)
+            let action = try XCTUnwrap(command.action)
+            let target = textField.target(
+                forAction: action,
+                withSender: command
+            ) as? AppKeyboardCommandHostingController
+            XCTAssertTrue(target === controller)
+            XCTAssertTrue(
+                UIApplication.shared.sendAction(
+                    action,
+                    to: controller,
+                    from: command,
+                    for: nil
+                )
+            )
+        }
+
+        XCTAssertEqual(
+            actions,
+            ["previous", "next", "activate", "dismiss"]
+        )
+
+        center.unregisterCommandPalette(owner: owner)
+        XCTAssertFalse(
+            (controller.keyCommands ?? []).contains {
+                expectedInputs.contains($0.input ?? "")
+                    && $0.modifierFlags.isEmpty
+            }
+        )
+    }
 }

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -3,6 +3,20 @@ import UIKit
 import XCTest
 @testable import Remux
 
+private struct AppKeyboardCommandHostContentProbe: UIViewRepresentable {
+    let text: String
+
+    func makeUIView(context: Context) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        return label
+    }
+
+    func updateUIView(_ uiView: UILabel, context: Context) {
+        uiView.text = text
+    }
+}
+
 final class AppKeyboardCommandRouterTests: XCTestCase {
     func testHomeRouteKeepsGlobalCommandsAndDisablesTerminalCommands() {
         let context = AppKeyboardCommandRouteContext(
@@ -203,6 +217,39 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
 
 final class AppKeyboardCommandResponderTests: XCTestCase {
     @MainActor
+    func testHostingControllerUpdatesRenderedContent() async throws {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(AppKeyboardCommandHostContentProbe(text: "Initial")),
+            commandCenter: center
+        )
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer {
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        let contentController = try XCTUnwrap(controller.children.first)
+        let renderedLabel = await waitForSubview(
+            of: UILabel.self,
+            in: contentController.view
+        )
+        let label = try XCTUnwrap(renderedLabel)
+        XCTAssertEqual(label.text, "Initial")
+
+        controller.updateContent(
+            AnyView(AppKeyboardCommandHostContentProbe(text: "Updated"))
+        )
+
+        let didRenderUpdate = await waitUntil {
+            label.text == "Updated"
+        }
+        XCTAssertTrue(didRenderUpdate)
+    }
+
+    @MainActor
     func testHostingControllerExposesOnlyAvailableAppCommands() throws {
         let center = AppKeyboardCommandCenter()
         let controller = AppKeyboardCommandHostingController(
@@ -289,6 +336,50 @@ final class AppKeyboardCommandResponderTests: XCTestCase {
         center.setShortcutCaptureActive(false)
         XCTAssertFalse((controller.keyCommands ?? []).isEmpty)
     }
+
+    @MainActor
+    private func firstSubview<View: UIView>(
+        of type: View.Type,
+        in rootView: UIView
+    ) -> View? {
+        if let rootView = rootView as? View {
+            return rootView
+        }
+        for subview in rootView.subviews {
+            if let match = firstSubview(of: type, in: subview) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    @MainActor
+    private func waitForSubview<View: UIView>(
+        of type: View.Type,
+        in rootView: UIView,
+        timeout: TimeInterval = 1
+    ) async -> View? {
+        var match: View?
+        _ = await waitUntil(timeout: timeout) {
+            rootView.layoutIfNeeded()
+            match = self.firstSubview(of: type, in: rootView)
+            return match != nil
+        }
+        return match
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return condition()
+    }
 }
 
 final class AppKeyboardCommandCenterTests: XCTestCase {
@@ -306,6 +397,26 @@ final class AppKeyboardCommandCenterTests: XCTestCase {
         center.perform(.commandPalette)
 
         XCTAssertEqual(receivedCommands, [.commandPalette])
+    }
+
+    @MainActor
+    func testPerformsOnlyCurrentlyAvailableCommands() {
+        let center = AppKeyboardCommandCenter()
+        var receivedCommands: [AppKeyboardCommand] = []
+
+        center.update(
+            settings: .default,
+            availableCommands: [.home]
+        ) {
+            receivedCommands.append($0)
+        }
+
+        XCTAssertFalse(center.performIfAvailable(.newWindow))
+        XCTAssertTrue(center.performIfAvailable(.home))
+
+        center.setShortcutCaptureActive(true)
+        XCTAssertFalse(center.performIfAvailable(.home))
+        XCTAssertEqual(receivedCommands, [.home])
     }
 }
 

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -6,6 +6,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
     func testHomeRouteKeepsGlobalCommandsAndDisablesTerminalCommands() {
         let context = AppKeyboardCommandRouteContext(
             selectedSessionID: nil,
+            isSelectedTerminalReady: false,
             orderedActiveSessionIDs: []
         )
 
@@ -25,6 +26,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         let selectedID = UUID()
         let context = AppKeyboardCommandRouteContext(
             selectedSessionID: selectedID,
+            isSelectedTerminalReady: true,
             orderedActiveSessionIDs: [selectedID]
         )
 
@@ -49,6 +51,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
                 .previousSession,
                 in: AppKeyboardCommandRouteContext(
                     selectedSessionID: first,
+                    isSelectedTerminalReady: true,
                     orderedActiveSessionIDs: ordered
                 )
             ),
@@ -59,6 +62,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
                 .nextSession,
                 in: AppKeyboardCommandRouteContext(
                     selectedSessionID: third,
+                    isSelectedTerminalReady: true,
                     orderedActiveSessionIDs: ordered
                 )
             ),
@@ -71,6 +75,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         let last = UUID()
         let context = AppKeyboardCommandRouteContext(
             selectedSessionID: nil,
+            isSelectedTerminalReady: false,
             orderedActiveSessionIDs: [first, last]
         )
 
@@ -82,6 +87,20 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
             AppKeyboardCommandRouter.route(.previousSession, in: context),
             .showSession(last)
         )
+    }
+
+    func testDisconnectedSelectedTerminalDisablesTerminalCommands() {
+        let selectedID = UUID()
+        let context = AppKeyboardCommandRouteContext(
+            selectedSessionID: selectedID,
+            isSelectedTerminalReady: false,
+            orderedActiveSessionIDs: [selectedID]
+        )
+
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.windows, in: context), .unavailable)
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.panes, in: context), .unavailable)
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.attachments, in: context), .unavailable)
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.home, in: context), .showHome)
     }
 
     func testConfiguredChordResolverMatchesOnlyAssignedModifiedChord() throws {

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -126,6 +126,51 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         XCTAssertEqual(AppKeyboardCommandRouter.route(.home, in: context), .showHome)
     }
 
+    func testTerminalReadinessTransitionsDriveCommandAvailability() {
+        let workspaceID = UUID()
+        let attempt = TerminalRuntimeAttemptKey(
+            workspaceID: workspaceID,
+            instanceID: UUID()
+        )
+        var readiness = TerminalKeyboardReadiness()
+
+        func availableCommands() -> [AppKeyboardCommand] {
+            AppKeyboardCommandRouter.availableCommands(
+                in: AppKeyboardCommandRouteContext(
+                    selectedSessionID: workspaceID,
+                    isSelectedTerminalReady: readiness.isReady(for: attempt),
+                    orderedActiveSessionIDs: [workspaceID]
+                )
+            )
+        }
+
+        XCTAssertFalse(availableCommands().contains(.newWindow))
+
+        readiness.update(isReady: true, for: attempt)
+        XCTAssertTrue(availableCommands().contains(.newWindow))
+
+        readiness.update(isReady: false, for: attempt)
+        XCTAssertFalse(availableCommands().contains(.newWindow))
+    }
+
+    func testTerminalReadinessDoesNotCarryAcrossReconnectAttempt() {
+        let workspaceID = UUID()
+        let oldAttempt = TerminalRuntimeAttemptKey(
+            workspaceID: workspaceID,
+            instanceID: UUID()
+        )
+        let replacementAttempt = TerminalRuntimeAttemptKey(
+            workspaceID: workspaceID,
+            instanceID: UUID()
+        )
+        var readiness = TerminalKeyboardReadiness()
+
+        readiness.update(isReady: true, for: oldAttempt)
+
+        XCTAssertTrue(readiness.isReady(for: oldAttempt))
+        XCTAssertFalse(readiness.isReady(for: replacementAttempt))
+    }
+
     func testTerminalSurfaceMapsNewWindowToTopologyCreation() {
         XCTAssertEqual(
             GhosttySurfaceKeyboardCommandRouter.route(.newWindow),

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -56,6 +56,10 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
             AppKeyboardCommandRouter.route(.windows, in: context),
             .terminal(.windows)
         )
+        XCTAssertEqual(
+            AppKeyboardCommandRouter.route(.newWindow, in: context),
+            .terminal(.newWindow)
+        )
     }
 
     func testSessionNavigationWrapsInSuppliedHomeOrder() {
@@ -116,9 +120,21 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
         )
 
         XCTAssertEqual(AppKeyboardCommandRouter.route(.windows, in: context), .unavailable)
+        XCTAssertEqual(AppKeyboardCommandRouter.route(.newWindow, in: context), .unavailable)
         XCTAssertEqual(AppKeyboardCommandRouter.route(.panes, in: context), .unavailable)
         XCTAssertEqual(AppKeyboardCommandRouter.route(.attachments, in: context), .unavailable)
         XCTAssertEqual(AppKeyboardCommandRouter.route(.home, in: context), .showHome)
+    }
+
+    func testTerminalSurfaceMapsNewWindowToTopologyCreation() {
+        XCTAssertEqual(
+            GhosttySurfaceKeyboardCommandRouter.route(.newWindow),
+            .createWindow
+        )
+        XCTAssertEqual(
+            GhosttySurfaceKeyboardCommandRouter.route(.commandPalette),
+            .forward(.commandPalette)
+        )
     }
 
     func testConfiguredChordResolverMatchesOnlyAssignedModifiedChord() throws {

--- a/RemuxAppTests/AppKeyboardCommandRouterTests.swift
+++ b/RemuxAppTests/AppKeyboardCommandRouterTests.swift
@@ -158,7 +158,7 @@ final class AppKeyboardCommandRouterTests: XCTestCase {
 
 final class AppKeyboardCommandResponderTests: XCTestCase {
     @MainActor
-    func testHostingControllerExposesGlobalCommands() throws {
+    func testHostingControllerExposesAllAppCommands() throws {
         let center = AppKeyboardCommandCenter()
         let controller = AppKeyboardCommandHostingController(
             rootView: AnyView(EmptyView()),
@@ -170,11 +170,7 @@ final class AppKeyboardCommandResponderTests: XCTestCase {
         let commands = try XCTUnwrap(controller.keyCommands)
         XCTAssertEqual(
             Set(commands.compactMap { $0.propertyList as? String }),
-            Set(
-                AppKeyboardCommand.allCases
-                    .filter { !$0.requiresTerminal }
-                    .map(\.rawValue)
-            )
+            Set(AppKeyboardCommand.allCases.map(\.rawValue))
         )
         XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
     }
@@ -277,7 +273,7 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
     }
 
     @MainActor
-    func testHandlesConfiguredRawGlobalChordAndIgnoresPlainText() {
+    func testHandlesConfiguredRawAppChordsAndIgnoresPlainText() {
         let center = AppKeyboardCommandCenter()
         var receivedCommands: [AppKeyboardCommand] = []
         center.update(settings: .default) {
@@ -298,7 +294,13 @@ final class AppKeyboardCommandResponderActionTests: XCTestCase {
         XCTAssertFalse(
             controller.handleKeyPress(input: "h", modifierFlags: [])
         )
-        XCTAssertEqual(receivedCommands, [.home])
+        XCTAssertTrue(
+            controller.handleKeyPress(
+                input: "n",
+                modifierFlags: [.command]
+            )
+        )
+        XCTAssertEqual(receivedCommands, [.home, .newWindow])
     }
 
     @MainActor

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -132,7 +132,7 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(state.selectedResult, first)
     }
 
-    func testStateCanMoveBeforeAQueryAndResetsWhenResultsChange() {
+    func testQueryResultReplacementResetsSelectionToFirstEnabled() {
         let first = item(id: "first")
         let second = item(id: "second")
         var state = CommandPaletteState(results: [first, second])
@@ -144,6 +144,31 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(state.selectedResultID, first.id)
     }
 
+    func testAvailabilityRefreshResetsSelectionWhenQueryReplacementIsPending() {
+        let first = CommandPaletteItem(
+            id: "first",
+            title: "Target First",
+            subtitle: nil,
+            action: .appCommand(.panes)
+        )
+        let second = CommandPaletteItem(
+            id: "second",
+            title: "Target Second",
+            subtitle: nil,
+            action: .appCommand(.home)
+        )
+        var state = CommandPaletteState(results: [first, second])
+        state.moveSelection(.next)
+
+        state.refreshAvailability(
+            query: "target",
+            commands: [first, second],
+            snapshots: []
+        )
+
+        XCTAssertEqual(state.selectedResultID, first.id)
+    }
+
     func testStateRefreshesReadyCommandToDisconnectedWhileKeepingQueryFiltering() {
         let available = CommandPaletteItem(
             id: "panes",
@@ -152,7 +177,10 @@ final class CommandPaletteSearchTests: XCTestCase {
             action: .appCommand(.panes)
         )
         let unrelated = item(id: "unrelated")
-        var state = CommandPaletteState(results: [available])
+        var state = CommandPaletteState(
+            results: [available],
+            appliedQuery: "panes"
+        )
 
         state.refreshAvailability(
             query: "panes",
@@ -188,7 +216,10 @@ final class CommandPaletteSearchTests: XCTestCase {
             subtitle: nil,
             action: .appCommand(.home)
         )
-        var state = CommandPaletteState(results: [newlyAvailable, selected])
+        var state = CommandPaletteState(
+            results: [newlyAvailable, selected],
+            appliedQuery: "target"
+        )
 
         state.refreshAvailability(
             query: "target",

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -140,9 +140,8 @@ final class CommandPaletteSearchTests: XCTestCase {
         state.moveSelection(.next)
         XCTAssertEqual(state.selectedResultID, second.id)
 
-        let replacement = item(id: "replacement")
-        state.replaceResults([replacement])
-        XCTAssertEqual(state.selectedResultID, replacement.id)
+        state.replaceResults([first, second])
+        XCTAssertEqual(state.selectedResultID, first.id)
     }
 
     func testStateRefreshesReadyCommandToDisconnectedWhileKeepingQueryFiltering() {
@@ -155,7 +154,7 @@ final class CommandPaletteSearchTests: XCTestCase {
         let unrelated = item(id: "unrelated")
         var state = CommandPaletteState(results: [available])
 
-        state.refresh(
+        state.refreshAvailability(
             query: "panes",
             commands: [
                 CommandPaletteItem(
@@ -191,7 +190,7 @@ final class CommandPaletteSearchTests: XCTestCase {
         )
         var state = CommandPaletteState(results: [newlyAvailable, selected])
 
-        state.refresh(
+        state.refreshAvailability(
             query: "target",
             commands: [
                 CommandPaletteItem(

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -122,6 +122,37 @@ final class CommandPaletteSearchTests: XCTestCase {
         )
     }
 
+    func testStateStartsWithCommandsAndFirstEnabledSelection() {
+        let disabled = item(id: "disabled", isEnabled: false)
+        let first = item(id: "first")
+        let state = CommandPaletteState(results: [disabled, first])
+
+        XCTAssertEqual(state.results, [disabled, first])
+        XCTAssertEqual(state.selectedResultID, first.id)
+        XCTAssertEqual(state.selectedResult, first)
+    }
+
+    func testStateCanMoveBeforeAQueryAndResetsWhenResultsChange() {
+        let first = item(id: "first")
+        let second = item(id: "second")
+        var state = CommandPaletteState(results: [first, second])
+
+        state.moveSelection(.next)
+        XCTAssertEqual(state.selectedResultID, second.id)
+
+        let replacement = item(id: "replacement")
+        state.replaceResults([replacement])
+        XCTAssertEqual(state.selectedResultID, replacement.id)
+    }
+
+    func testFloatingLayoutCapsAtSixRowsAndKeepsEmptyStateCompact() {
+        XCTAssertEqual(CommandPaletteLayout.inputRowHeight, 44)
+        XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 0), 120)
+        XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 1), 56)
+        XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 6), 336)
+        XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 9), 336)
+    }
+
     @MainActor
     func testSearchFieldRoutesNavigationAndActivationKeysWithoutModifiers() {
         let field = CommandPaletteTextField()
@@ -170,11 +201,53 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(actions, ["previous", "next", "activate", "dismiss"])
         XCTAssertEqual(
             field.keyCommands?.compactMap(\.input),
-            ["\r", UIKeyCommand.inputEscape]
+            [
+                UIKeyCommand.inputUpArrow,
+                UIKeyCommand.inputDownArrow,
+                "\r",
+                UIKeyCommand.inputEscape,
+            ]
         )
         XCTAssertTrue(
             field.keyCommands?.allSatisfy(\.wantsPriorityOverSystemBehavior)
                 == true
+        )
+    }
+
+    @MainActor
+    func testPriorityKeyCommandsMoveActivateAndDismiss() throws {
+        let field = CommandPaletteTextField()
+        var actions: [String] = []
+        field.onMoveSelection = {
+            switch $0 {
+            case .previous:
+                actions.append("previous")
+            case .next:
+                actions.append("next")
+            }
+        }
+        field.onActivateSelection = {
+            actions.append("activate")
+        }
+        field.onDismiss = {
+            actions.append("dismiss")
+        }
+
+        for input in [
+            UIKeyCommand.inputUpArrow,
+            UIKeyCommand.inputDownArrow,
+            "\r",
+            UIKeyCommand.inputEscape,
+        ] {
+            let command = try XCTUnwrap(
+                field.keyCommands?.first(where: { $0.input == input })
+            )
+            field.perform(command.action, with: command)
+        }
+
+        XCTAssertEqual(
+            actions,
+            ["previous", "next", "activate", "dismiss"]
         )
     }
 

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Remux
+
+final class CommandPaletteSearchTests: XCTestCase {
+    func testMatchesCommandsAndVisibleLinesCaseInsensitively() {
+        let snapshot = TerminalViewportSnapshot(
+            workspaceID: UUID(),
+            serverName: "Build Host",
+            sessionName: "deploy",
+            windowID: UUID(),
+            windowName: "logs",
+            paneID: UUID(),
+            text: "ready\nFATAL: disk full\nretrying"
+        )
+        let commands = [
+            CommandPaletteItem(
+                id: "add",
+                title: "Add Connection",
+                subtitle: nil,
+                action: .addConnection
+            ),
+        ]
+
+        XCTAssertEqual(
+            CommandPaletteSearch.results(
+                query: "connection",
+                commands: commands,
+                snapshots: [snapshot]
+            ).map(\.title),
+            ["Add Connection"]
+        )
+        let textResult = CommandPaletteSearch.results(
+            query: "fatal",
+            commands: commands,
+            snapshots: [snapshot]
+        )
+        XCTAssertEqual(textResult.map(\.title), ["FATAL: disk full"])
+        XCTAssertEqual(textResult.first?.subtitle, "Build Host · deploy · logs")
+    }
+
+    func testEmptyQueryReturnsOnlyCommands() {
+        let command = CommandPaletteItem(
+            id: "home",
+            title: "Home",
+            subtitle: nil,
+            action: .appCommand(.home)
+        )
+
+        XCTAssertEqual(
+            CommandPaletteSearch.results(query: "", commands: [command], snapshots: []),
+            [command]
+        )
+    }
+}

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -153,6 +153,25 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 9), 336)
     }
 
+    func testFloatingLayoutUsesBalancedSpacing() {
+        XCTAssertEqual(CommandPaletteLayout.screenMargin, 20)
+        XCTAssertEqual(CommandPaletteLayout.cardInset, 10)
+        XCTAssertEqual(CommandPaletteLayout.innerCornerRadius, 12)
+    }
+
+    @MainActor
+    func testSearchFieldUsesCompactDynamicTypeFont() {
+        let field = CommandPaletteTextField()
+        let expected = UIFont.preferredFont(forTextStyle: .footnote)
+
+        XCTAssertEqual(field.font?.pointSize, expected.pointSize)
+        XCTAssertEqual(
+            field.font?.fontDescriptor.object(forKey: .textStyle) as? String,
+            UIFont.TextStyle.footnote.rawValue
+        )
+        XCTAssertTrue(field.adjustsFontForContentSizeCategory)
+    }
+
     @MainActor
     func testSearchFieldRoutesNavigationAndActivationKeysWithoutModifiers() {
         let field = CommandPaletteTextField()

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -145,6 +145,72 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(state.selectedResultID, replacement.id)
     }
 
+    func testStateRefreshesReadyCommandToDisconnectedWhileKeepingQueryFiltering() {
+        let available = CommandPaletteItem(
+            id: "panes",
+            title: "Show Panes",
+            subtitle: nil,
+            action: .appCommand(.panes)
+        )
+        let unrelated = item(id: "unrelated")
+        var state = CommandPaletteState(results: [available])
+
+        state.refresh(
+            query: "panes",
+            commands: [
+                CommandPaletteItem(
+                    id: available.id,
+                    title: available.title,
+                    subtitle: available.subtitle,
+                    action: available.action,
+                    isEnabled: false
+                ),
+                unrelated,
+            ],
+            snapshots: []
+        )
+
+        XCTAssertEqual(state.results.map(\.id), [available.id])
+        XCTAssertFalse(state.results[0].isEnabled)
+        XCTAssertNil(state.selectedResultID)
+    }
+
+    func testStateRefreshesDisconnectedCommandToReadyWithoutReplacingValidSelection() {
+        let newlyAvailable = CommandPaletteItem(
+            id: "first",
+            title: "Target First",
+            subtitle: nil,
+            action: .appCommand(.panes),
+            isEnabled: false
+        )
+        let selected = CommandPaletteItem(
+            id: "second",
+            title: "Target Second",
+            subtitle: nil,
+            action: .appCommand(.home)
+        )
+        var state = CommandPaletteState(results: [newlyAvailable, selected])
+
+        state.refresh(
+            query: "target",
+            commands: [
+                CommandPaletteItem(
+                    id: newlyAvailable.id,
+                    title: newlyAvailable.title,
+                    subtitle: newlyAvailable.subtitle,
+                    action: newlyAvailable.action
+                ),
+                selected,
+                item(id: "unrelated"),
+            ],
+            snapshots: []
+        )
+
+        XCTAssertEqual(state.results.map(\.id), ["first", "second"])
+        XCTAssertTrue(state.results[0].isEnabled)
+        XCTAssertEqual(state.selectedResultID, selected.id)
+    }
+
     func testFloatingLayoutCapsAtSixRowsAndKeepsEmptyStateCompact() {
         XCTAssertEqual(CommandPaletteLayout.inputRowHeight, 44)
         XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 0), 120)

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import Remux
 
 final class CommandPaletteSearchTests: XCTestCase {
@@ -67,6 +68,126 @@ final class CommandPaletteSearchTests: XCTestCase {
                 .first?
                 .isEnabled,
             false
+        )
+    }
+
+    func testSelectionStartsAtFirstEnabledResult() {
+        let disabled = item(id: "disabled", isEnabled: false)
+        let first = item(id: "first")
+        let second = item(id: "second")
+
+        XCTAssertEqual(
+            CommandPaletteSelection.initialID(in: [disabled, first, second]),
+            first.id
+        )
+    }
+
+    func testSelectionMovesPastDisabledResultsAndStopsAtEnds() {
+        let first = item(id: "first")
+        let disabled = item(id: "disabled", isEnabled: false)
+        let last = item(id: "last")
+        let results = [first, disabled, last]
+
+        XCTAssertEqual(
+            CommandPaletteSelection.moving(
+                from: first.id,
+                direction: .next,
+                in: results
+            ),
+            last.id
+        )
+        XCTAssertEqual(
+            CommandPaletteSelection.moving(
+                from: last.id,
+                direction: .next,
+                in: results
+            ),
+            last.id
+        )
+        XCTAssertEqual(
+            CommandPaletteSelection.moving(
+                from: last.id,
+                direction: .previous,
+                in: results
+            ),
+            first.id
+        )
+        XCTAssertEqual(
+            CommandPaletteSelection.moving(
+                from: first.id,
+                direction: .previous,
+                in: results
+            ),
+            first.id
+        )
+    }
+
+    @MainActor
+    func testSearchFieldRoutesNavigationAndActivationKeysWithoutModifiers() {
+        let field = CommandPaletteTextField()
+        var actions: [String] = []
+        field.onMoveSelection = {
+            switch $0 {
+            case .previous:
+                actions.append("previous")
+            case .next:
+                actions.append("next")
+            }
+        }
+        field.onActivateSelection = {
+            actions.append("activate")
+        }
+        field.onDismiss = {
+            actions.append("dismiss")
+        }
+
+        XCTAssertTrue(
+            field.handleKeyPress(
+                input: UIKeyCommand.inputUpArrow,
+                modifierFlags: []
+            )
+        )
+        XCTAssertTrue(
+            field.handleKeyPress(
+                input: UIKeyCommand.inputDownArrow,
+                modifierFlags: []
+            )
+        )
+        XCTAssertTrue(field.handleKeyPress(input: "\r", modifierFlags: []))
+        XCTAssertTrue(
+            field.handleKeyPress(
+                input: UIKeyCommand.inputEscape,
+                modifierFlags: []
+            )
+        )
+        XCTAssertFalse(
+            field.handleKeyPress(
+                input: UIKeyCommand.inputDownArrow,
+                modifierFlags: .command
+            )
+        )
+        XCTAssertFalse(field.handleKeyPress(input: "a", modifierFlags: []))
+        XCTAssertEqual(actions, ["previous", "next", "activate", "dismiss"])
+        XCTAssertEqual(
+            field.keyCommands?.compactMap(\.input),
+            ["\r", UIKeyCommand.inputEscape]
+        )
+        XCTAssertTrue(
+            field.keyCommands?.allSatisfy(\.wantsPriorityOverSystemBehavior)
+                == true
+        )
+    }
+
+    private func item(
+        id: String,
+        isEnabled: Bool = true
+    ) -> CommandPaletteItem {
+        CommandPaletteItem(
+            id: id,
+            title: id,
+            subtitle: nil,
+            action: .addConnection,
+            isEnabled: isEnabled
         )
     }
 }

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -199,56 +199,6 @@ final class CommandPaletteSearchTests: XCTestCase {
         )
         XCTAssertFalse(field.handleKeyPress(input: "a", modifierFlags: []))
         XCTAssertEqual(actions, ["previous", "next", "activate", "dismiss"])
-        XCTAssertEqual(
-            field.keyCommands?.compactMap(\.input),
-            [
-                UIKeyCommand.inputUpArrow,
-                UIKeyCommand.inputDownArrow,
-                "\r",
-                UIKeyCommand.inputEscape,
-            ]
-        )
-        XCTAssertTrue(
-            field.keyCommands?.allSatisfy(\.wantsPriorityOverSystemBehavior)
-                == true
-        )
-    }
-
-    @MainActor
-    func testPriorityKeyCommandsMoveActivateAndDismiss() throws {
-        let field = CommandPaletteTextField()
-        var actions: [String] = []
-        field.onMoveSelection = {
-            switch $0 {
-            case .previous:
-                actions.append("previous")
-            case .next:
-                actions.append("next")
-            }
-        }
-        field.onActivateSelection = {
-            actions.append("activate")
-        }
-        field.onDismiss = {
-            actions.append("dismiss")
-        }
-
-        for input in [
-            UIKeyCommand.inputUpArrow,
-            UIKeyCommand.inputDownArrow,
-            "\r",
-            UIKeyCommand.inputEscape,
-        ] {
-            let command = try XCTUnwrap(
-                field.keyCommands?.first(where: { $0.input == input })
-            )
-            field.perform(command.action, with: command)
-        }
-
-        XCTAssertEqual(
-            actions,
-            ["previous", "next", "activate", "dismiss"]
-        )
     }
 
     private func item(

--- a/RemuxAppTests/CommandPaletteSearchTests.swift
+++ b/RemuxAppTests/CommandPaletteSearchTests.swift
@@ -10,6 +10,7 @@ final class CommandPaletteSearchTests: XCTestCase {
             windowID: UUID(),
             windowName: "logs",
             paneID: UUID(),
+            paneIndex: 2,
             text: "ready\nFATAL: disk full\nretrying"
         )
         let commands = [
@@ -35,7 +36,7 @@ final class CommandPaletteSearchTests: XCTestCase {
             snapshots: [snapshot]
         )
         XCTAssertEqual(textResult.map(\.title), ["FATAL: disk full"])
-        XCTAssertEqual(textResult.first?.subtitle, "Build Host · deploy · logs")
+        XCTAssertEqual(textResult.first?.subtitle, "Build Host · deploy · logs · Pane 2")
     }
 
     func testEmptyQueryReturnsOnlyCommands() {
@@ -49,6 +50,23 @@ final class CommandPaletteSearchTests: XCTestCase {
         XCTAssertEqual(
             CommandPaletteSearch.results(query: "", commands: [command], snapshots: []),
             [command]
+        )
+    }
+
+    func testEmptyQueryKeepsUnavailableCommandDisabled() {
+        let command = CommandPaletteItem(
+            id: "panes",
+            title: "Show Panes",
+            subtitle: nil,
+            action: .appCommand(.panes),
+            isEnabled: false
+        )
+
+        XCTAssertEqual(
+            CommandPaletteSearch.results(query: "", commands: [command], snapshots: [])
+                .first?
+                .isEnabled,
+            false
         )
     }
 }

--- a/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
@@ -65,6 +65,7 @@ final class GhosttyTerminalResponderFocusPolicyTests: XCTestCase {
         let policy = GhosttyTerminalResponderFocusPolicy(
             isSelected: true,
             keyboardMode: .system,
+            isPhysicalKeyboardConnected: false,
             isInputAvailable: true,
             isTransientInputOwnerPresented: false
         )
@@ -77,6 +78,7 @@ final class GhosttyTerminalResponderFocusPolicyTests: XCTestCase {
         let policy = GhosttyTerminalResponderFocusPolicy(
             isSelected: true,
             keyboardMode: .system,
+            isPhysicalKeyboardConnected: false,
             isInputAvailable: true,
             isTransientInputOwnerPresented: true
         )
@@ -89,12 +91,26 @@ final class GhosttyTerminalResponderFocusPolicyTests: XCTestCase {
         let policy = GhosttyTerminalResponderFocusPolicy(
             isSelected: true,
             keyboardMode: .hidden,
+            isPhysicalKeyboardConnected: false,
             isInputAvailable: true,
             isTransientInputOwnerPresented: false
         )
 
         XCTAssertTrue(policy.isResponderEnabled)
         XCTAssertFalse(policy.wantsFirstResponder)
+    }
+
+    func testPhysicalKeyboardRequestsResponderWhileSoftwareKeyboardIsHidden() {
+        let policy = GhosttyTerminalResponderFocusPolicy(
+            isSelected: true,
+            keyboardMode: .hidden,
+            isPhysicalKeyboardConnected: true,
+            isInputAvailable: true,
+            isTransientInputOwnerPresented: false
+        )
+
+        XCTAssertTrue(policy.isResponderEnabled)
+        XCTAssertTrue(policy.wantsFirstResponder)
     }
 
     func testCoveredPresentationOwnsInputOnlyUntilKeyboardRestorationBegins() {

--- a/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
@@ -113,6 +113,20 @@ final class GhosttyTerminalResponderFocusPolicyTests: XCTestCase {
         XCTAssertTrue(policy.wantsFirstResponder)
     }
 
+    func testPhysicalKeyboardKeepsAppCommandsAvailableWhileTerminalInputIsUnavailable() {
+        let policy = GhosttyTerminalResponderFocusPolicy(
+            isSelected: true,
+            keyboardMode: .hidden,
+            isPhysicalKeyboardConnected: true,
+            isInputAvailable: false,
+            isTransientInputOwnerPresented: false
+        )
+
+        XCTAssertFalse(policy.isResponderEnabled)
+        XCTAssertTrue(policy.areAppKeyboardCommandsEnabled)
+        XCTAssertTrue(policy.wantsFirstResponder)
+    }
+
     func testCoveredPresentationOwnsInputOnlyUntilKeyboardRestorationBegins() {
         XCTAssertFalse(GhosttyTerminalCoverPhase.visible.ownsTerminalInput)
         XCTAssertTrue(

--- a/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderFocusPolicyTests.swift
@@ -87,6 +87,26 @@ final class GhosttyTerminalResponderFocusPolicyTests: XCTestCase {
         XCTAssertFalse(policy.wantsFirstResponder)
     }
 
+    func testAppInputOwnerSuspendsTerminalResponder() {
+        let projection = GhosttyTerminalInputOwnerProjection(
+            isAppInputOwnerPresented: true,
+            isAttachmentInputOwnerPresented: false,
+            terminalCoverOwnsInput: false
+        )
+        let policy = GhosttyTerminalResponderFocusPolicy(
+            isSelected: true,
+            keyboardMode: .hidden,
+            isPhysicalKeyboardConnected: true,
+            isInputAvailable: true,
+            isTransientInputOwnerPresented:
+                projection.isTransientInputOwnerPresented
+        )
+
+        XCTAssertFalse(policy.isResponderEnabled)
+        XCTAssertFalse(policy.areAppKeyboardCommandsEnabled)
+        XCTAssertFalse(policy.wantsFirstResponder)
+    }
+
     func testHiddenKeyboardDoesNotRequestFirstResponder() {
         let policy = GhosttyTerminalResponderFocusPolicy(
             isSelected: true,

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -4,6 +4,67 @@ import XCTest
 
 final class GhosttyTerminalResponderViewTests: XCTestCase {
     @MainActor
+    func testSelectedResponderRecoversAfterUnexpectedFocusLoss() {
+        let view = GhosttyTerminalResponderUIView(
+            trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
+        )
+        let viewController = UIViewController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        viewController.view.addSubview(view)
+        defer { window.isHidden = true }
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true }
+        )
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        XCTAssertTrue(view.isFirstResponder)
+
+        XCTAssertTrue(view.resignFirstResponder())
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+
+        XCTAssertTrue(view.isFirstResponder)
+    }
+
+    @MainActor
+    func testSelectedResponderDoesNotDisplaceExternalTextInput() {
+        let view = GhosttyTerminalResponderUIView(
+            trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
+        )
+        let textField = UITextField()
+        let viewController = UIViewController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+        viewController.view.addSubview(view)
+        viewController.view.addSubview(textField)
+        defer { window.isHidden = true }
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true }
+        )
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+        XCTAssertTrue(view.isFirstResponder)
+
+        XCTAssertTrue(textField.becomeFirstResponder())
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+
+        XCTAssertTrue(textField.isFirstResponder)
+        XCTAssertFalse(view.isFirstResponder)
+    }
+
+    @MainActor
     func testResponderPublishesPriorityAppKeyCommandsAndDispatchesSelection() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
         var receivedCommands: [AppKeyboardCommand] = []

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import XCTest
 @testable import Remux
@@ -65,7 +66,7 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
     }
 
     @MainActor
-    func testResponderPublishesPriorityAppKeyCommandsAndDispatchesSelection() {
+    func testResponderPublishesPriorityTerminalKeyCommandsAndDispatchesSelection() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
         var receivedCommands: [AppKeyboardCommand] = []
 
@@ -83,16 +84,15 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         )
 
         let commands = view.keyCommands ?? []
-        XCTAssertEqual(commands.count, AppKeyboardCommand.allCases.count)
-        XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
-
-        let home = try! XCTUnwrap(
-            commands.first {
-                $0.input == "h"
-                    && $0.modifierFlags == [.command, .shift]
-            }
+        XCTAssertEqual(
+            Set(commands.compactMap { $0.propertyList as? String }),
+            Set(
+                AppKeyboardCommand.allCases
+                    .filter(\.requiresTerminal)
+                    .map(\.rawValue)
+            )
         )
-        view.perform(home.action, with: home)
+        XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
 
         let newWindow = try! XCTUnwrap(
             commands.first {
@@ -101,11 +101,11 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             }
         )
         view.perform(newWindow.action, with: newWindow)
-        XCTAssertEqual(receivedCommands, [.home, .newWindow])
+        XCTAssertEqual(receivedCommands, [.newWindow])
     }
 
     @MainActor
-    func testResponderPublishesAppCommandsWithoutAcceptingTerminalText() {
+    func testResponderPublishesTerminalCommandsWithoutAcceptingTerminalText() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
 
         view.update(
@@ -120,7 +120,57 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         )
 
         XCTAssertFalse(view.hasText)
-        XCTAssertEqual(view.keyCommands?.count, AppKeyboardCommand.allCases.count)
+        XCTAssertEqual(
+            view.keyCommands?.count,
+            AppKeyboardCommand.allCases.filter(\.requiresTerminal).count
+        )
+    }
+
+    @MainActor
+    func testResponderLeavesGlobalCommandsToHostingController() throws {
+        let center = AppKeyboardCommandCenter()
+        let controller = AppKeyboardCommandHostingController(
+            rootView: AnyView(EmptyView()),
+            commandCenter: center
+        )
+        controller.update(settings: .default, commandCenter: center)
+        controller.loadViewIfNeeded()
+
+        let contentController = try XCTUnwrap(controller.children.first)
+        let view = GhosttyTerminalResponderUIView(
+            trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
+        )
+        contentController.view.addSubview(view)
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true }
+        )
+
+        let terminalCommands = try XCTUnwrap(view.keyCommands)
+        XCTAssertFalse(
+            terminalCommands.contains {
+                $0.propertyList as? String
+                    == AppKeyboardCommand.commandPalette.rawValue
+            }
+        )
+
+        let command = try XCTUnwrap(
+            controller.keyCommands?.first {
+                $0.propertyList as? String
+                    == AppKeyboardCommand.commandPalette.rawValue
+            }
+        )
+        let action = try XCTUnwrap(command.action)
+        let target = view.target(
+            forAction: action,
+            withSender: command
+        ) as? AppKeyboardCommandHostingController
+        XCTAssertTrue(target === controller)
     }
 
     @MainActor

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -4,6 +4,33 @@ import XCTest
 
 final class GhosttyTerminalResponderViewTests: XCTestCase {
     @MainActor
+    func testResponderPublishesPriorityAppKeyCommandsAndDispatchesSelection() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        var receivedCommands: [AppKeyboardCommand] = []
+
+        view.update(
+            isEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onAppKeyboardCommand: {
+                receivedCommands.append($0)
+            }
+        )
+
+        let commands = view.keyCommands ?? []
+        XCTAssertEqual(commands.count, AppKeyboardCommand.allCases.count)
+        XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
+
+        let home = try! XCTUnwrap(commands.first { $0.input == "h" })
+        view.perform(home.action, with: home)
+        XCTAssertEqual(receivedCommands, [.home])
+    }
+
+    @MainActor
     func testResponderReportsTextWhenEnabled() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
 

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -108,7 +108,11 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             rootView: AnyView(EmptyView()),
             commandCenter: center
         )
-        controller.update(settings: .default, commandCenter: center)
+        controller.update(
+            settings: .default,
+            availableCommands: AppKeyboardCommand.allCases,
+            commandCenter: center
+        )
         controller.loadViewIfNeeded()
 
         let contentController = try XCTUnwrap(controller.children.first)

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -93,7 +93,15 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             }
         )
         view.perform(home.action, with: home)
-        XCTAssertEqual(receivedCommands, [.home])
+
+        let newWindow = try! XCTUnwrap(
+            commands.first {
+                $0.input == "n"
+                    && $0.modifierFlags == [.command]
+            }
+        )
+        view.perform(newWindow.action, with: newWindow)
+        XCTAssertEqual(receivedCommands, [.home, .newWindow])
     }
 
     @MainActor

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -66,9 +66,8 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
     }
 
     @MainActor
-    func testResponderPublishesPriorityTerminalKeyCommandsAndDispatchesSelection() {
+    func testResponderLeavesAppKeyCommandsToHostingController() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
-        var receivedCommands: [AppKeyboardCommand] = []
 
         view.update(
             isEnabled: true,
@@ -77,35 +76,14 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             keyboardSettings: .default,
             sendText: { _ in true },
             sendPaste: { _ in true },
-            sendKeyEvent: { _ in true },
-            onAppKeyboardCommand: {
-                receivedCommands.append($0)
-            }
+            sendKeyEvent: { _ in true }
         )
 
-        let commands = view.keyCommands ?? []
-        XCTAssertEqual(
-            Set(commands.compactMap { $0.propertyList as? String }),
-            Set(
-                AppKeyboardCommand.allCases
-                    .filter(\.requiresTerminal)
-                    .map(\.rawValue)
-            )
-        )
-        XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
-
-        let newWindow = try! XCTUnwrap(
-            commands.first {
-                $0.input == "n"
-                    && $0.modifierFlags == [.command]
-            }
-        )
-        view.perform(newWindow.action, with: newWindow)
-        XCTAssertEqual(receivedCommands, [.newWindow])
+        XCTAssertTrue((view.keyCommands ?? []).isEmpty)
     }
 
     @MainActor
-    func testResponderPublishesTerminalCommandsWithoutAcceptingTerminalText() {
+    func testResponderDoesNotPublishAppCommandsWithoutAcceptingTerminalText() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
 
         view.update(
@@ -120,14 +98,11 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         )
 
         XCTAssertFalse(view.hasText)
-        XCTAssertEqual(
-            view.keyCommands?.count,
-            AppKeyboardCommand.allCases.filter(\.requiresTerminal).count
-        )
+        XCTAssertTrue((view.keyCommands ?? []).isEmpty)
     }
 
     @MainActor
-    func testResponderLeavesGlobalCommandsToHostingController() throws {
+    func testFocusedTerminalResponderChainReachesAppCommandTarget() throws {
         let center = AppKeyboardCommandCenter()
         let controller = AppKeyboardCommandHostingController(
             rootView: AnyView(EmptyView()),
@@ -151,18 +126,10 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendKeyEvent: { _ in true }
         )
 
-        let terminalCommands = try XCTUnwrap(view.keyCommands)
-        XCTAssertFalse(
-            terminalCommands.contains {
-                $0.propertyList as? String
-                    == AppKeyboardCommand.commandPalette.rawValue
-            }
-        )
-
         let command = try XCTUnwrap(
             controller.keyCommands?.first {
                 $0.propertyList as? String
-                    == AppKeyboardCommand.commandPalette.rawValue
+                    == AppKeyboardCommand.newWindow.rawValue
             }
         )
         let action = try XCTUnwrap(command.action)

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -25,7 +25,12 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         XCTAssertEqual(commands.count, AppKeyboardCommand.allCases.count)
         XCTAssertTrue(commands.allSatisfy(\.wantsPriorityOverSystemBehavior))
 
-        let home = try! XCTUnwrap(commands.first { $0.input == "h" })
+        let home = try! XCTUnwrap(
+            commands.first {
+                $0.input == "h"
+                    && $0.modifierFlags == [.command, .shift]
+            }
+        )
         view.perform(home.action, with: home)
         XCTAssertEqual(receivedCommands, [.home])
     }

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -31,6 +31,25 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
     }
 
     @MainActor
+    func testResponderPublishesAppCommandsWithoutAcceptingTerminalText() {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+
+        view.update(
+            isEnabled: false,
+            areAppKeyboardCommandsEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true }
+        )
+
+        XCTAssertFalse(view.hasText)
+        XCTAssertEqual(view.keyCommands?.count, AppKeyboardCommand.allCases.count)
+    }
+
+    @MainActor
     func testResponderReportsTextWhenEnabled() {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
 

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -590,6 +590,36 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
     }
 
     @MainActor
+    func testCommandOnlyResponderBecomesFirstResponderWithoutAcceptingText() async {
+        let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        window.rootViewController = UIViewController()
+        window.rootViewController?.view.addSubview(view)
+        window.makeKeyAndVisible()
+        defer {
+            _ = view.resignFirstResponder()
+            view.removeFromSuperview()
+            window.isHidden = true
+            window.rootViewController = nil
+        }
+
+        view.update(
+            isEnabled: false,
+            areAppKeyboardCommandsEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 7,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true }
+        )
+
+        let becameFirstResponder = await waitUntil { view.isFirstResponder }
+        XCTAssertTrue(becameFirstResponder)
+        XCTAssertFalse(view.hasText)
+    }
+
+    @MainActor
     func testResponderDefersBecomeWhenWanted() async {
         let view = GhosttyTerminalResponderUIView(trackpadDriver: GhosttyKeyboardCursorTrackpadDriver())
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))

--- a/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+++ b/RemuxAppTests/GhosttyTerminalResponderViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class GhosttyTerminalResponderViewTests: XCTestCase {
     @MainActor
-    func testSelectedResponderRecoversAfterUnexpectedFocusLoss() {
+    func testSelectedResponderRecoversAfterUnexpectedFocusLoss() async {
         let view = GhosttyTerminalResponderUIView(
             trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
         )
@@ -14,7 +14,12 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         window.rootViewController = viewController
         window.makeKeyAndVisible()
         viewController.view.addSubview(view)
-        defer { window.isHidden = true }
+        defer {
+            _ = view.resignFirstResponder()
+            view.removeFromSuperview()
+            window.isHidden = true
+            window.rootViewController = nil
+        }
 
         view.update(
             isEnabled: true,
@@ -24,17 +29,17 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendPaste: { _ in true },
             sendKeyEvent: { _ in true }
         )
-        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
-        XCTAssertTrue(view.isFirstResponder)
+        let becameFirstResponder = await waitUntil { view.isFirstResponder }
+        XCTAssertTrue(becameFirstResponder)
 
         XCTAssertTrue(view.resignFirstResponder())
-        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
 
-        XCTAssertTrue(view.isFirstResponder)
+        let recoveredFirstResponder = await waitUntil { view.isFirstResponder }
+        XCTAssertTrue(recoveredFirstResponder)
     }
 
     @MainActor
-    func testSelectedResponderDoesNotDisplaceExternalTextInput() {
+    func testSelectedResponderDoesNotDisplaceExternalTextInput() async {
         let view = GhosttyTerminalResponderUIView(
             trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
         )
@@ -45,7 +50,14 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
         window.makeKeyAndVisible()
         viewController.view.addSubview(view)
         viewController.view.addSubview(textField)
-        defer { window.isHidden = true }
+        defer {
+            _ = textField.resignFirstResponder()
+            _ = view.resignFirstResponder()
+            textField.removeFromSuperview()
+            view.removeFromSuperview()
+            window.isHidden = true
+            window.rootViewController = nil
+        }
 
         view.update(
             isEnabled: true,
@@ -55,14 +67,15 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
             sendPaste: { _ in true },
             sendKeyEvent: { _ in true }
         )
-        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
-        XCTAssertTrue(view.isFirstResponder)
+        let becameFirstResponder = await waitUntil { view.isFirstResponder }
+        XCTAssertTrue(becameFirstResponder)
 
         XCTAssertTrue(textField.becomeFirstResponder())
-        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
 
-        XCTAssertTrue(textField.isFirstResponder)
-        XCTAssertFalse(view.isFirstResponder)
+        let externalInputRetainedFocus = await waitUntil {
+            textField.isFirstResponder && !view.isFirstResponder
+        }
+        XCTAssertTrue(externalInputRetainedFocus)
     }
 
     @MainActor
@@ -99,6 +112,92 @@ final class GhosttyTerminalResponderViewTests: XCTestCase {
 
         XCTAssertFalse(view.hasText)
         XCTAssertTrue((view.keyCommands ?? []).isEmpty)
+    }
+
+    @MainActor
+    func testRawAppChordIsClaimedOnlyByCurrentAcceptingOwner() {
+        let view = GhosttyTerminalResponderUIView(
+            trackpadDriver: GhosttyKeyboardCursorTrackpadDriver()
+        )
+        var receivedCommands: [AppKeyboardCommand] = []
+
+        view.update(
+            isEnabled: true,
+            areAppKeyboardCommandsEnabled: true,
+            wantsFirstResponder: false,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onAppKeyboardCommand: {
+                receivedCommands.append($0)
+                return true
+            }
+        )
+
+        XCTAssertEqual(
+            view.routeAppKeyboardCommand(
+                input: "k",
+                modifierFlags: [.command]
+            ),
+            .deferred
+        )
+        XCTAssertTrue(receivedCommands.isEmpty)
+
+        view.update(
+            isEnabled: true,
+            areAppKeyboardCommandsEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onAppKeyboardCommand: {
+                receivedCommands.append($0)
+                return false
+            }
+        )
+
+        XCTAssertEqual(
+            view.routeAppKeyboardCommand(
+                input: "k",
+                modifierFlags: [.command]
+            ),
+            .deferred
+        )
+
+        view.update(
+            isEnabled: true,
+            areAppKeyboardCommandsEnabled: true,
+            wantsFirstResponder: true,
+            activationToken: 1,
+            keyboardSettings: .default,
+            sendText: { _ in true },
+            sendPaste: { _ in true },
+            sendKeyEvent: { _ in true },
+            onAppKeyboardCommand: {
+                receivedCommands.append($0)
+                return true
+            }
+        )
+
+        XCTAssertEqual(
+            view.routeAppKeyboardCommand(
+                input: "k",
+                modifierFlags: [.command]
+            ),
+            .handled
+        )
+        XCTAssertEqual(
+            view.routeAppKeyboardCommand(
+                input: "k",
+                modifierFlags: []
+            ),
+            .notConfigured
+        )
+        XCTAssertEqual(receivedCommands, [.commandPalette, .commandPalette])
     }
 
     @MainActor

--- a/RemuxAppTests/KeyboardSettingsRepositoryTests.swift
+++ b/RemuxAppTests/KeyboardSettingsRepositoryTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import Remux
+
+final class KeyboardSettingsRepositoryTests: XCTestCase {
+    func testFileBackedRepositoryLoadsDefaultWhenNoFileExists() async throws {
+        let repository = FileBackedKeyboardSettingsRepository(rootURL: temporaryRoot())
+
+        let settings = try await repository.loadSettings()
+
+        XCTAssertEqual(settings, .default)
+    }
+
+    func testFileBackedRepositoryPersistsSettings() async throws {
+        let root = temporaryRoot()
+        let repository = FileBackedKeyboardSettingsRepository(rootURL: root)
+        var saved = try KeyboardSettings.default.validated(updating: .home, to: nil)
+        saved.hideButtonBarWhenPhysicalKeyboardConnected = false
+
+        try await repository.saveSettings(saved)
+
+        let reloaded = try await FileBackedKeyboardSettingsRepository(rootURL: root).loadSettings()
+        XCTAssertEqual(reloaded, saved)
+    }
+
+    func testFileBackedRepositoryRejectsDecodedDuplicateBindings() async throws {
+        let root = temporaryRoot()
+        let duplicate = KeyboardKeyBinding(input: "x", modifiers: [.command])
+        let invalid = KeyboardSettings(
+            bindings: [
+                .home: duplicate,
+                .commandPalette: duplicate,
+            ],
+            hideButtonBarWhenPhysicalKeyboardConnected: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try JSONEncoder().encode([invalid]).write(
+            to: root.appendingPathComponent("keyboard-settings.json"),
+            options: .atomic
+        )
+        let repository = FileBackedKeyboardSettingsRepository(rootURL: root)
+
+        await XCTAssertThrowsErrorAsync(try await repository.loadSettings()) { error in
+            guard case KeyboardSettings.ValidationError.duplicateBinding = error else {
+                return XCTFail("Expected duplicate binding, got \(error)")
+            }
+        }
+    }
+
+    private func temporaryRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw")
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/RemuxAppTests/KeyboardSettingsTests.swift
+++ b/RemuxAppTests/KeyboardSettingsTests.swift
@@ -31,6 +31,10 @@ final class KeyboardSettingsTests: XCTestCase {
             KeyboardKeyBinding(input: "o", modifiers: [.command])
         )
         XCTAssertEqual(
+            settings.binding(for: .newWindow),
+            KeyboardKeyBinding(input: "n", modifiers: [.command])
+        )
+        XCTAssertEqual(
             settings.binding(for: .panes),
             KeyboardKeyBinding(input: "p", modifiers: [.command])
         )

--- a/RemuxAppTests/KeyboardSettingsTests.swift
+++ b/RemuxAppTests/KeyboardSettingsTests.swift
@@ -78,4 +78,53 @@ final class KeyboardSettingsTests: XCTestCase {
             )
         }
     }
+
+    func testValidationCanonicalizesPrintableKeysBeforeDuplicateDetection() {
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardKeyBinding(input: "K", modifiers: [.command])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KeyboardSettings.ValidationError,
+                .duplicateBinding(command: .commandPalette)
+            )
+        }
+    }
+
+    func testValidationRejectsMissingKeyAndUnsupportedModifiers() {
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardKeyBinding(input: "", modifiers: [.command])
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeyboardSettings.ValidationError, .missingKey)
+        }
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardKeyBinding(
+                    input: "g",
+                    modifiers: KeyboardKeyModifiers(rawValue: 1 << 8)
+                )
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeyboardSettings.ValidationError, .unsupportedModifiers)
+        }
+    }
+
+    func testBindingDescriptionSpacesEveryKeyToken() {
+        XCTAssertEqual(
+            KeyboardBindingDescription.text(
+                KeyboardKeyBinding(
+                    input: "g",
+                    modifiers: [.control, .option, .shift, .command]
+                )
+            ),
+            "⌃ ⌥ ⇧ ⌘ G"
+        )
+        XCTAssertEqual(KeyboardBindingDescription.text(nil), "Unassigned")
+    }
 }

--- a/RemuxAppTests/KeyboardSettingsTests.swift
+++ b/RemuxAppTests/KeyboardSettingsTests.swift
@@ -24,7 +24,7 @@ final class KeyboardSettingsTests: XCTestCase {
         )
         XCTAssertEqual(
             settings.binding(for: .home),
-            KeyboardKeyBinding(input: "h", modifiers: [.command])
+            KeyboardKeyBinding(input: "h", modifiers: [.command, .shift])
         )
         XCTAssertEqual(
             settings.binding(for: .windows),
@@ -62,6 +62,20 @@ final class KeyboardSettingsTests: XCTestCase {
             )
         ) { error in
             XCTAssertEqual(error as? KeyboardSettings.ValidationError, .missingModifier)
+        }
+    }
+
+    func testUpdatingBindingRejectsSystemHomeShortcut() {
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardKeyBinding(input: "h", modifiers: [.command])
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KeyboardSettings.ValidationError,
+                .reservedSystemShortcut
+            )
         }
     }
 

--- a/RemuxAppTests/KeyboardSettingsTests.swift
+++ b/RemuxAppTests/KeyboardSettingsTests.swift
@@ -42,6 +42,14 @@ final class KeyboardSettingsTests: XCTestCase {
             settings.binding(for: .commandPalette),
             KeyboardKeyBinding(input: "k", modifiers: [.command])
         )
+        XCTAssertEqual(
+            settings.binding(for: .increaseFontSize),
+            KeyboardKeyBinding(input: "+", modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .decreaseFontSize),
+            KeyboardKeyBinding(input: "-", modifiers: [.command])
+        )
         XCTAssertTrue(settings.hideButtonBarWhenPhysicalKeyboardConnected)
     }
 

--- a/RemuxAppTests/KeyboardSettingsTests.swift
+++ b/RemuxAppTests/KeyboardSettingsTests.swift
@@ -1,0 +1,81 @@
+import UIKit
+import XCTest
+@testable import Remux
+
+final class KeyboardSettingsTests: XCTestCase {
+    func testDefaultsAssignEveryDocumentedCommand() {
+        let settings = KeyboardSettings.default
+
+        XCTAssertEqual(
+            settings.binding(for: .previousWindow),
+            KeyboardKeyBinding(input: UIKeyCommand.inputLeftArrow, modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .nextWindow),
+            KeyboardKeyBinding(input: UIKeyCommand.inputRightArrow, modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .previousSession),
+            KeyboardKeyBinding(input: UIKeyCommand.inputLeftArrow, modifiers: [.command, .shift])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .nextSession),
+            KeyboardKeyBinding(input: UIKeyCommand.inputRightArrow, modifiers: [.command, .shift])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .home),
+            KeyboardKeyBinding(input: "h", modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .windows),
+            KeyboardKeyBinding(input: "o", modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .panes),
+            KeyboardKeyBinding(input: "p", modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .attachments),
+            KeyboardKeyBinding(input: "a", modifiers: [.command])
+        )
+        XCTAssertEqual(
+            settings.binding(for: .commandPalette),
+            KeyboardKeyBinding(input: "k", modifiers: [.command])
+        )
+        XCTAssertTrue(settings.hideButtonBarWhenPhysicalKeyboardConnected)
+    }
+
+    func testUpdatingBindingCanClearOrAssignCustomChord() throws {
+        let cleared = try KeyboardSettings.default.validated(updating: .home, to: nil)
+        let custom = KeyboardKeyBinding(input: "g", modifiers: [.control, .option])
+        let reassigned = try cleared.validated(updating: .home, to: custom)
+
+        XCTAssertNil(cleared.binding(for: .home))
+        XCTAssertEqual(reassigned.binding(for: .home), custom)
+    }
+
+    func testUpdatingBindingRejectsBareKey() {
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardKeyBinding(input: "g", modifiers: [])
+            )
+        ) { error in
+            XCTAssertEqual(error as? KeyboardSettings.ValidationError, .missingModifier)
+        }
+    }
+
+    func testUpdatingBindingRejectsChordAlreadyAssignedToAnotherCommand() {
+        XCTAssertThrowsError(
+            try KeyboardSettings.default.validated(
+                updating: .home,
+                to: KeyboardSettings.default.binding(for: .commandPalette)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? KeyboardSettings.ValidationError,
+                .duplicateBinding(command: .commandPalette)
+            )
+        }
+    }
+}

--- a/RemuxAppTests/KeyboardShortcutCaptureTests.swift
+++ b/RemuxAppTests/KeyboardShortcutCaptureTests.swift
@@ -37,8 +37,4 @@ final class KeyboardShortcutCaptureTests: XCTestCase {
             try KeyboardShortcutCapture.binding(input: "", modifierFlags: [.command])
         )
     }
-
-    func testClearProducesUnassignedBinding() {
-        XCTAssertNil(KeyboardShortcutCapture.clearedBinding())
-    }
 }

--- a/RemuxAppTests/KeyboardShortcutCaptureTests.swift
+++ b/RemuxAppTests/KeyboardShortcutCaptureTests.swift
@@ -1,0 +1,44 @@
+import UIKit
+import XCTest
+@testable import Remux
+
+final class KeyboardShortcutCaptureTests: XCTestCase {
+    func testNormalizesPrintableInputAndCombinedModifiers() throws {
+        XCTAssertEqual(
+            try KeyboardShortcutCapture.binding(
+                input: "G",
+                modifierFlags: [.command, .shift, .alternate]
+            ),
+            KeyboardKeyBinding(
+                input: "g",
+                modifiers: [.command, .shift, .option]
+            )
+        )
+    }
+
+    func testPreservesArrowInput() throws {
+        XCTAssertEqual(
+            try KeyboardShortcutCapture.binding(
+                input: UIKeyCommand.inputLeftArrow,
+                modifierFlags: [.control]
+            ),
+            KeyboardKeyBinding(
+                input: UIKeyCommand.inputLeftArrow,
+                modifiers: [.control]
+            )
+        )
+    }
+
+    func testRejectsBareAndModifierOnlyKeys() {
+        XCTAssertThrowsError(
+            try KeyboardShortcutCapture.binding(input: "x", modifierFlags: [])
+        )
+        XCTAssertThrowsError(
+            try KeyboardShortcutCapture.binding(input: "", modifierFlags: [.command])
+        )
+    }
+
+    func testClearProducesUnassignedBinding() {
+        XCTAssertNil(KeyboardShortcutCapture.clearedBinding())
+    }
+}

--- a/RemuxAppTests/PhysicalKeyboardChromeStateTests.swift
+++ b/RemuxAppTests/PhysicalKeyboardChromeStateTests.swift
@@ -2,6 +2,39 @@ import XCTest
 @testable import Remux
 
 final class PhysicalKeyboardChromeStateTests: XCTestCase {
+    func testUITestingIgnoresSimulatorKeyboardUnlessExplicitlyEnabled() {
+        XCTAssertFalse(
+            PhysicalKeyboardConnectionProjection.isConnected(
+                environment: ["REMUX_UI_TESTING": "1"],
+                isSystemKeyboardConnected: true
+            )
+        )
+        XCTAssertTrue(
+            PhysicalKeyboardConnectionProjection.isConnected(
+                environment: [
+                    "REMUX_UI_TESTING": "1",
+                    "REMUX_UI_TEST_PHYSICAL_KEYBOARD": "1",
+                ],
+                isSystemKeyboardConnected: false
+            )
+        )
+    }
+
+    func testProductionUsesSystemKeyboardConnection() {
+        XCTAssertTrue(
+            PhysicalKeyboardConnectionProjection.isConnected(
+                environment: [:],
+                isSystemKeyboardConnected: true
+            )
+        )
+        XCTAssertFalse(
+            PhysicalKeyboardConnectionProjection.isConnected(
+                environment: [:],
+                isSystemKeyboardConnected: false
+            )
+        )
+    }
+
     func testConnectedHideEnabledStartsFloatingAndHidden() {
         let state = PhysicalKeyboardChromeState(
             isPhysicalKeyboardConnected: true,

--- a/RemuxAppTests/PhysicalKeyboardChromeStateTests.swift
+++ b/RemuxAppTests/PhysicalKeyboardChromeStateTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import Remux
+
+final class PhysicalKeyboardChromeStateTests: XCTestCase {
+    func testConnectedHideEnabledStartsFloatingAndHidden() {
+        let state = PhysicalKeyboardChromeState(
+            isPhysicalKeyboardConnected: true,
+            hidesChrome: true
+        )
+
+        XCTAssertTrue(state.usesFloatingChrome)
+        XCTAssertFalse(state.isChromeVisible)
+        XCTAssertNil(state.autoHideToken)
+    }
+
+    func testTerminalTapRevealsAndSchedulesAutoHide() {
+        var state = PhysicalKeyboardChromeState(
+            isPhysicalKeyboardConnected: true,
+            hidesChrome: true
+        )
+
+        state.terminalTapped()
+
+        XCTAssertTrue(state.isChromeVisible)
+        XCTAssertNotNil(state.autoHideToken)
+        state.autoHideElapsed(token: state.autoHideToken!)
+        XCTAssertFalse(state.isChromeVisible)
+    }
+
+    func testChromeInteractionRestartsTimer() {
+        var state = PhysicalKeyboardChromeState(
+            isPhysicalKeyboardConnected: true,
+            hidesChrome: true
+        )
+        state.terminalTapped()
+        let first = state.autoHideToken
+
+        state.chromeInteracted()
+
+        XCTAssertNotEqual(state.autoHideToken, first)
+        state.autoHideElapsed(token: first!)
+        XCTAssertTrue(state.isChromeVisible)
+    }
+
+    func testHideDisabledKeepsFloatingChromeVisible() {
+        var state = PhysicalKeyboardChromeState(
+            isPhysicalKeyboardConnected: true,
+            hidesChrome: false
+        )
+        state.terminalTapped()
+
+        XCTAssertTrue(state.usesFloatingChrome)
+        XCTAssertTrue(state.isChromeVisible)
+        XCTAssertNil(state.autoHideToken)
+    }
+
+    func testDisconnectRestoresNormalMeasuredChrome() {
+        var state = PhysicalKeyboardChromeState(
+            isPhysicalKeyboardConnected: true,
+            hidesChrome: true
+        )
+
+        state.keyboardConnectionChanged(isConnected: false, hidesChrome: true)
+
+        XCTAssertFalse(state.usesFloatingChrome)
+        XCTAssertTrue(state.isChromeVisible)
+        XCTAssertNil(state.autoHideToken)
+    }
+}

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -32,6 +32,22 @@ final class RemuxRootModelTests: XCTestCase {
         XCTAssertEqual(RemuxAppLifecycleProjection(scenePhase: .background).appLifecyclePhase, .background)
     }
 
+    func testAdjustTerminalFontSizePersistsAppGlobalSetting() async throws {
+        let harness = makeHarness(
+            settings: TerminalSettings(fontSize: nil, theme: .remuxDark)
+        )
+        await harness.model.load()
+
+        await harness.model.adjustTerminalFontSize(
+            by: 1,
+            effectiveDefault: 12
+        )
+
+        XCTAssertEqual(harness.model.terminalSettings.fontSize, 13)
+        let saved = try await harness.settingsRepository.loadSettings()
+        XCTAssertEqual(saved.fontSize, 13)
+    }
+
     func testSaveAndConnectPersistsNewProfileAndUsesCurrentSettings() async throws {
         let settings = TerminalSettings(fontSize: 15, theme: .remuxDark)
         let harness = makeHarness(settings: settings)

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -48,6 +48,38 @@ final class RemuxRootModelTests: XCTestCase {
         XCTAssertEqual(saved.fontSize, 13)
     }
 
+    func testQueuedFontSizeAdjustmentsPreserveDeliveryOrderAtClampBoundary() async throws {
+        let initial = TerminalSettings(
+            fontSize: TerminalSettings.maximumFontSize,
+            theme: .remuxDark
+        )
+        let repository = BlockingFirstSaveTerminalSettingsRepository(settings: initial)
+        let harness = makeHarness(
+            settings: initial,
+            settingsRepository: repository
+        )
+        await harness.model.load()
+
+        harness.model.enqueueTerminalFontSizeAdjustment(
+            by: 1,
+            effectiveDefault: 10
+        )
+        await repository.waitForFirstSaveToStart()
+        harness.model.enqueueTerminalFontSizeAdjustment(
+            by: -1,
+            effectiveDefault: 10
+        )
+        let secondSaveStartedBeforeRelease =
+            await repository.waitForSecondSaveToStart()
+        await repository.releaseFirstSave()
+        await repository.waitForBothSavesToComplete()
+
+        XCTAssertFalse(secondSaveStartedBeforeRelease)
+        XCTAssertEqual(harness.model.terminalSettings.fontSize, 23)
+        let saved = try await repository.loadSettings()
+        XCTAssertEqual(saved.fontSize, 23)
+    }
+
     func testSaveAndConnectPersistsNewProfileAndUsesCurrentSettings() async throws {
         let settings = TerminalSettings(fontSize: 15, theme: .remuxDark)
         let harness = makeHarness(settings: settings)
@@ -2604,6 +2636,67 @@ private actor TestTerminalSettingsRepository: TerminalSettingsRepository {
 
     func saveSettings(_ settings: TerminalSettings) async throws {
         self.settings = settings
+    }
+}
+
+private actor BlockingFirstSaveTerminalSettingsRepository: TerminalSettingsRepository {
+    private var settings: TerminalSettings
+    private var saveCount = 0
+    private var completedSaveCount = 0
+    private var firstSaveStartedContinuation: CheckedContinuation<Void, Never>?
+    private var firstSaveReleaseContinuation: CheckedContinuation<Void, Never>?
+    private var bothSavesCompletedContinuation: CheckedContinuation<Void, Never>?
+
+    init(settings: TerminalSettings) {
+        self.settings = settings
+    }
+
+    func loadSettings() async throws -> TerminalSettings {
+        settings
+    }
+
+    func saveSettings(_ settings: TerminalSettings) async throws {
+        saveCount += 1
+        if saveCount == 1 {
+            firstSaveStartedContinuation?.resume()
+            firstSaveStartedContinuation = nil
+            await withCheckedContinuation { continuation in
+                firstSaveReleaseContinuation = continuation
+            }
+        }
+
+        self.settings = settings
+        completedSaveCount += 1
+        if completedSaveCount == 2 {
+            bothSavesCompletedContinuation?.resume()
+            bothSavesCompletedContinuation = nil
+        }
+    }
+
+    func waitForFirstSaveToStart() async {
+        guard saveCount == 0 else { return }
+        await withCheckedContinuation { continuation in
+            firstSaveStartedContinuation = continuation
+        }
+    }
+
+    func releaseFirstSave() {
+        firstSaveReleaseContinuation?.resume()
+        firstSaveReleaseContinuation = nil
+    }
+
+    func waitForSecondSaveToStart() async -> Bool {
+        for _ in 0..<100 where saveCount < 2 {
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return saveCount == 2
+    }
+
+    func waitForBothSavesToComplete() async {
+        guard completedSaveCount < 2 else { return }
+        await withCheckedContinuation { continuation in
+            bothSavesCompletedContinuation = continuation
+        }
     }
 }
 

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -75,9 +75,10 @@ final class RemuxRootModelTests: XCTestCase {
         await repository.waitForBothSavesToComplete()
 
         XCTAssertFalse(secondSaveStartedBeforeRelease)
-        XCTAssertEqual(harness.model.terminalSettings.fontSize, 23)
+        let expectedFontSize = TerminalSettings.maximumFontSize - 1
+        XCTAssertEqual(harness.model.terminalSettings.fontSize, expectedFontSize)
         let saved = try await repository.loadSettings()
-        XCTAssertEqual(saved.fontSize, 23)
+        XCTAssertEqual(saved.fontSize, expectedFontSize)
     }
 
     func testSaveAndConnectPersistsNewProfileAndUsesCurrentSettings() async throws {

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -2107,6 +2107,7 @@ final class RemuxRootModelTests: XCTestCase {
         let dependencies = RemuxAppDependencies(
             profileRepository: profileRepository,
             settingsRepository: settingsRepository,
+            keyboardSettingsRepository: FileBackedKeyboardSettingsRepository(rootURL: temporaryRoot()),
             shortcutRepository: shortcutRepository,
             credentialStore: credentialStore,
             trustedHostStore: trustedHostStore,

--- a/RemuxAppTests/TerminalSettingsTests.swift
+++ b/RemuxAppTests/TerminalSettingsTests.swift
@@ -18,6 +18,33 @@ final class TerminalSettingsTests: XCTestCase {
         XCTAssertNil(TerminalSettings(fontSize: .nan, theme: .ghosttyDefault).fontSize)
     }
 
+    func testFontSizeAdjustmentStartsFromEffectiveDefaultAndThenUsesExplicitSize() {
+        var settings = TerminalSettings(fontSize: nil, theme: .remuxDark)
+
+        settings.adjustFontSize(by: 1, effectiveDefault: 12)
+        XCTAssertEqual(settings.fontSize, 13)
+
+        settings.adjustFontSize(by: -1, effectiveDefault: 20)
+        XCTAssertEqual(settings.fontSize, 12)
+    }
+
+    func testFontSizeAdjustmentClampsToSupportedRange() {
+        var maximum = TerminalSettings(
+            fontSize: TerminalSettings.maximumFontSize,
+            theme: .remuxDark
+        )
+        var minimum = TerminalSettings(
+            fontSize: TerminalSettings.minimumFontSize,
+            theme: .remuxDark
+        )
+
+        maximum.adjustFontSize(by: 1, effectiveDefault: 10)
+        minimum.adjustFontSize(by: -1, effectiveDefault: 10)
+
+        XCTAssertEqual(maximum.fontSize, TerminalSettings.maximumFontSize)
+        XCTAssertEqual(minimum.fontSize, TerminalSettings.minimumFontSize)
+    }
+
     func testGhosttyConfigIncludesOfficialCatppuccinMochaThemeAndFont() {
         let settings = TerminalSettings(fontSize: 13, theme: .remuxDark)
 

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -61,16 +61,36 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
 
     private func pane(
         id: TmuxPaneID,
-        windowID: TmuxWindowID
+        windowID: TmuxWindowID,
+        x: UInt32 = 0,
+        y: UInt32 = 0
     ) -> TmuxSessionController.PaneInfo {
         TmuxSessionController.PaneInfo(
             id: id,
             windowID: windowID,
-            x: 0,
-            y: 0,
+            x: x,
+            y: y,
             width: 80,
             height: 24,
             phase: .live
+        )
+    }
+
+    func testPaneOrderingMatchesVisibleTopologyOrder() {
+        let topology = TmuxSessionController.TopologySnapshot(
+            sessionName: "pane-order",
+            windows: [window(id: 1, active: true, paneID: 30)],
+            panes: [
+                pane(id: 30, windowID: 1, x: 40, y: 12),
+                pane(id: 20, windowID: 1, x: 40, y: 0),
+                pane(id: 10, windowID: 1, x: 0, y: 0),
+            ],
+            activeWindowID: 1
+        )
+
+        XCTAssertEqual(
+            TmuxTerminalScreenAdapter.orderedPanes(in: 1, topology: topology).map(\.id),
+            [10, 20, 30]
         )
     }
 

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -94,6 +94,133 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         )
     }
 
+    func testViewportSnapshotsJoinMetadataAndOmitUnavailablePaneText() async throws {
+        let runtime = try GhosttyKitRuntime()
+        let session = makeSession(runtime: runtime)
+        let adapter = TmuxTerminalScreenAdapter()
+        adapter.activate(
+            session: session,
+            initialViewportHandler: { _, _ in },
+            clientSizeHandler: { _ in },
+            viewportStabilityHandler: { _ in }
+        )
+        session.handleTopology(
+            TmuxSessionController.TopologySnapshot(
+                sessionName: "adapter-fixture",
+                windows: [
+                    window(id: 1, active: true, paneID: 10, name: "editor"),
+                    window(id: 2, active: false, paneID: 30),
+                ],
+                panes: [
+                    pane(id: 20, windowID: 1, x: 40),
+                    pane(id: 10, windowID: 1),
+                    pane(id: 30, windowID: 2),
+                ],
+                activeWindowID: 1
+            )
+        )
+        let workspaceID = UUID()
+
+        let snapshots = adapter.viewportSnapshots(
+            workspaceID: workspaceID,
+            serverName: "Build Host",
+            sessionName: "deploy",
+            visiblePaneTexts: [
+                (paneID: 10, text: "editor text"),
+                (paneID: 30, text: "logs text"),
+            ]
+        )
+
+        XCTAssertEqual(snapshots.map(\.workspaceID), [workspaceID, workspaceID])
+        XCTAssertEqual(snapshots.map(\.serverName), ["Build Host", "Build Host"])
+        XCTAssertEqual(snapshots.map(\.sessionName), ["deploy", "deploy"])
+        XCTAssertEqual(snapshots.map(\.windowName), ["editor", "Window 2"])
+        XCTAssertEqual(snapshots.map(\.paneIndex), [1, 1])
+        XCTAssertEqual(snapshots.map(\.text), ["editor text", "logs text"])
+        XCTAssertEqual(snapshots.map { adapter.tmuxPaneID(for: $0.paneID) }, [10, 30])
+        XCTAssertEqual(adapter.focusTmuxTopLevel(snapshots[0].windowID), .queued)
+        XCTAssertEqual(adapter.focusTmuxTopLevel(snapshots[1].windowID), .queued)
+
+        await session.shutdown()
+    }
+
+    func testPaletteSearchUsesEveryActiveAdapterAndRoutesExactSelectedResult() async throws {
+        let runtime = try GhosttyKitRuntime()
+        let firstSession = makeSession(runtime: runtime)
+        let secondSession = makeSession(runtime: runtime)
+        let firstAdapter = TmuxTerminalScreenAdapter()
+        let secondAdapter = TmuxTerminalScreenAdapter()
+        for (adapter, session) in [
+            (firstAdapter, firstSession),
+            (secondAdapter, secondSession),
+        ] {
+            adapter.activate(
+                session: session,
+                initialViewportHandler: { _, _ in },
+                clientSizeHandler: { _ in },
+                viewportStabilityHandler: { _ in }
+            )
+        }
+        firstSession.handleTopology(
+            TmuxSessionController.TopologySnapshot(
+                sessionName: "first",
+                windows: [window(id: 1, active: true, paneID: 10, name: "editor")],
+                panes: [pane(id: 10, windowID: 1)],
+                activeWindowID: 1
+            )
+        )
+        secondSession.handleTopology(
+            TmuxSessionController.TopologySnapshot(
+                sessionName: "second",
+                windows: [window(id: 2, active: true, paneID: 20, name: "logs")],
+                panes: [pane(id: 20, windowID: 2)],
+                activeWindowID: 2
+            )
+        )
+        let firstWorkspaceID = UUID()
+        let secondWorkspaceID = UUID()
+        let allSnapshots = firstAdapter.viewportSnapshots(
+            workspaceID: firstWorkspaceID,
+            serverName: "First Host",
+            sessionName: "one",
+            visiblePaneTexts: [(paneID: 10, text: "needle first")]
+        ) + secondAdapter.viewportSnapshots(
+            workspaceID: secondWorkspaceID,
+            serverName: "Second Host",
+            sessionName: "two",
+            visiblePaneTexts: [(paneID: 20, text: "needle second")]
+        )
+
+        let results = CommandPaletteSearch.results(
+            query: "needle",
+            commands: [],
+            snapshots: allSnapshots
+        )
+
+        XCTAssertEqual(results.map(\.title), ["needle first", "needle second"])
+        XCTAssertEqual(
+            results.map(\.subtitle),
+            [
+                "First Host · one · editor · Pane 1",
+                "Second Host · two · logs · Pane 1",
+            ]
+        )
+        guard case .viewport(let selectedSnapshot) = results[1].action else {
+            return XCTFail("Expected a viewport search result")
+        }
+        XCTAssertEqual(selectedSnapshot.workspaceID, secondWorkspaceID)
+        XCTAssertEqual(secondAdapter.tmuxPaneID(for: selectedSnapshot.paneID), 20)
+        XCTAssertEqual(
+            secondAdapter.focusTmuxTopLevel(selectedSnapshot.windowID),
+            .queued
+        )
+        XCTAssertEqual(secondAdapter.focusTmuxPane(selectedSnapshot.paneID), .queued)
+        XCTAssertEqual(firstAdapter.tmuxPaneID(for: selectedSnapshot.paneID), nil)
+
+        await firstSession.shutdown()
+        await secondSession.shutdown()
+    }
+
     func testWindowProjectionReflectsEmittedTopologyImmediately() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)

--- a/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
+++ b/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
@@ -64,6 +64,33 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
         await session.shutdown()
     }
 
+    func testViewportSearchRequiresReadySession() {
+        XCTAssertFalse(
+            TmuxTerminalSession.isViewportSearchAvailable(
+                state: .detached(.transportClosed),
+                isShutDown: false
+            )
+        )
+        XCTAssertFalse(
+            TmuxTerminalSession.isViewportSearchAvailable(
+                state: .closed(.unsupportedVersion("old")),
+                isShutDown: false
+            )
+        )
+        XCTAssertFalse(
+            TmuxTerminalSession.isViewportSearchAvailable(
+                state: .ready,
+                isShutDown: true
+            )
+        )
+        XCTAssertTrue(
+            TmuxTerminalSession.isViewportSearchAvailable(
+                state: .ready,
+                isShutDown: false
+            )
+        )
+    }
+
     func testSameWindowSelectionSuppressesDuplicateZoomForIntermediateTopology() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -143,6 +143,34 @@ final class RemuxAppUITests: XCTestCase {
         openCommandPaletteAndAssertImmediateTyping()
     }
 
+    func testCommandPaletteSupportsKeyboardSelectionAndDismissal() {
+        launchSimulatorApp()
+        XCTAssertTrue(
+            app.buttons["library.empty.add-server"].waitForExistence(timeout: 5)
+        )
+        app.typeKey("k", modifierFlags: .command)
+
+        let palette = app.descendants(matching: .any)["command-palette"]
+        XCTAssertTrue(palette.waitForExistence(timeout: 2))
+
+        let addConnection = app.buttons["command-palette.item.add-connection"]
+        XCTAssertTrue(addConnection.waitForExistence(timeout: 2))
+        XCTAssertTrue(addConnection.isSelected)
+
+        app.typeKey(.downArrow, modifierFlags: [])
+        let home = app.buttons["command-palette.item.command:home"]
+        XCTAssertTrue(home.waitForExistence(timeout: 2))
+        XCTAssertTrue(home.isSelected)
+
+        app.typeText("\n")
+        XCTAssertTrue(palette.waitForNonExistence(timeout: 2))
+
+        app.typeKey("k", modifierFlags: .command)
+        XCTAssertTrue(palette.waitForExistence(timeout: 2))
+        app.buttons["xmark.circle.fill"].tap()
+        XCTAssertTrue(palette.waitForNonExistence(timeout: 2))
+    }
+
     func testPhysicalKeyboardKeepsConnectionFormEditableAndStartsWithHiddenButtonBar() {
         app.launchEnvironment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] = "1"
         launchSimulatorApp()
@@ -2669,6 +2697,7 @@ final class RemuxAppUITests: XCTestCase {
 
         let password = app.secureTextFields["connection.password"]
         XCTAssertTrue(password.waitForExistence(timeout: 2))
+        password.tap()
         password.typeText("demo-password")
 
         app.swipeUp()

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -130,6 +130,11 @@ final class RemuxAppUITests: XCTestCase {
         )
     }
 
+    func testCommandPaletteReceivesImmediateTyping() {
+        launchSimulatorApp()
+        openCommandPaletteAndAssertImmediateTyping()
+    }
+
     func testPhysicalKeyboardKeepsConnectionFormEditableAndStartsWithHiddenButtonBar() {
         app.launchEnvironment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] = "1"
         launchSimulatorApp()
@@ -206,12 +211,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertNotNil(optionalTerminalHomeButton(timeout: 2))
         XCTAssertEqual(terminal.frame, terminalFrame)
 
-        app.typeKey("k", modifierFlags: .command)
-
-        XCTAssertTrue(
-            app.descendants(matching: .any)["command-palette"]
-                .waitForExistence(timeout: 2)
-        )
+        openCommandPaletteAndAssertImmediateTyping()
     }
 
     func testLiveSSHKeyboardResizeTraceWhenConfigured() throws {
@@ -2632,6 +2632,22 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.buttons["library.empty.add-server"].waitForExistence(timeout: 5))
         app.buttons["library.empty.add-server"].tap()
         XCTAssertTrue(app.textFields["connection.name"].waitForExistence(timeout: 2))
+    }
+
+    private func openCommandPaletteAndAssertImmediateTyping() {
+        app.typeKey("k", modifierFlags: .command)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["command-palette"]
+                .waitForExistence(timeout: 2)
+        )
+
+        let searchField = app.descendants(matching: .any)["command-palette.search"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 2))
+
+        app.typeText("palette focus")
+
+        XCTAssertEqual(searchField.value as? String, "palette focus")
     }
 
     private func fillConnectionForm() {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -153,6 +153,15 @@ final class RemuxAppUITests: XCTestCase {
         let palette = app.descendants(matching: .any)["command-palette"]
         XCTAssertTrue(palette.waitForExistence(timeout: 2))
 
+        let search = app.textFields["command-palette.search"]
+        XCTAssertTrue(search.waitForExistence(timeout: 2))
+        XCTAssertLessThanOrEqual(search.frame.height, 44.5)
+        XCTAssertLessThanOrEqual(
+            palette.frame.height,
+            430,
+            "The chooser should remain a compact floating card with six visible rows."
+        )
+
         let addConnection = app.buttons["command-palette.item.add-connection"]
         XCTAssertTrue(addConnection.waitForExistence(timeout: 2))
         XCTAssertTrue(addConnection.isSelected)

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -120,13 +120,11 @@ final class RemuxAppUITests: XCTestCase {
         let homeTitle = app.staticTexts["Home"]
         XCTAssertTrue(homeTitle.waitForExistence(timeout: 2))
         XCTAssertEqual(homeBinding.frame.height, homeTitle.frame.height, accuracy: 2)
-        XCTAssertTrue(app.buttons["Set"].firstMatch.waitForExistence(timeout: 2))
-
-        let setButtons = app.buttons.matching(
-            NSPredicate(format: "label == %@", "Set")
-        )
-        XCTAssertGreaterThan(setButtons.count, 0)
-        setButtons.element(boundBy: setButtons.count - 1).tap()
+        let setCommandPalette = app.buttons[
+            "keyboard-settings.set.commandPalette"
+        ]
+        XCTAssertTrue(setCommandPalette.waitForExistence(timeout: 2))
+        setCommandPalette.tap()
         XCTAssertTrue(
             app.staticTexts["Press the shortcut for Command Palette"]
                 .waitForExistence(timeout: 2)
@@ -151,10 +149,7 @@ final class RemuxAppUITests: XCTestCase {
             app.descendants(matching: .any)["keyboard-settings.form"]
                 .waitForExistence(timeout: 2)
         )
-        let clearHome = app.buttons
-            .matching(identifier: "keyboard-settings.binding.home")
-            .matching(NSPredicate(format: "label == %@", "Clear"))
-            .firstMatch
+        let clearHome = app.buttons["keyboard-settings.clear.home"]
         XCTAssertTrue(clearHome.waitForExistence(timeout: 2))
 
         clearHome.tap()
@@ -2835,7 +2830,9 @@ final class RemuxAppUITests: XCTestCase {
 
         let terminal = app.otherElements["terminal.screen"]
         if terminal.exists {
-            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            terminal.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
+            ).tap()
         }
 
         if let button = optionalTerminalHomeButton(timeout: timeout) {
@@ -3437,6 +3434,7 @@ final class RemuxAppUITests: XCTestCase {
 
         let pwd = app.secureTextFields["connection.password"]
         XCTAssertTrue(pwd.waitForExistence(timeout: 2))
+        pwd.tap()
         pwd.typeText("demo-password")
         sleep(1)
         attach(name: "13-connection-setup-filled")

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -264,14 +264,19 @@ final class RemuxAppUITests: XCTestCase {
             cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
         }
 
+        app.launchEnvironment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] = "1"
         try launchLiveSSHAppIfConfigured(
             traceRuntime: true,
             sessionNameOverride: sessionName
         )
         openFirstSavedSession()
         waitForLiveTerminalReady(timeout: 90)
-        waitForLiveTerminalInputReady(timeout: 10)
 
+        app.typeKey("k", modifierFlags: .command)
+        let palette = app.otherElements["command-palette"]
+        XCTAssertTrue(palette.waitForExistence(timeout: 2))
+        app.buttons["xmark.circle.fill"].tap()
+        XCTAssertTrue(palette.waitForNonExistence(timeout: 2))
         app.typeKey("n", modifierFlags: .command)
         waitForLiveTerminalReady(timeout: 30)
 

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -140,6 +140,9 @@ final class RemuxAppUITests: XCTestCase {
 
     func testCommandPaletteReceivesImmediateTyping() {
         launchSimulatorApp()
+        XCTAssertTrue(
+            app.buttons["library.empty.add-server"].waitForExistence(timeout: 5)
+        )
         openCommandPaletteAndAssertImmediateTyping()
     }
 
@@ -152,6 +155,25 @@ final class RemuxAppUITests: XCTestCase {
 
         let palette = app.descendants(matching: .any)["command-palette"]
         XCTAssertTrue(palette.waitForExistence(timeout: 2))
+
+        let appFrame = app.frame
+        let minimumScreenMargin: CGFloat = 19.5
+        XCTAssertGreaterThanOrEqual(
+            palette.frame.minX - appFrame.minX,
+            minimumScreenMargin
+        )
+        XCTAssertGreaterThanOrEqual(
+            appFrame.maxX - palette.frame.maxX,
+            minimumScreenMargin
+        )
+        XCTAssertGreaterThanOrEqual(
+            palette.frame.minY - appFrame.minY,
+            minimumScreenMargin
+        )
+        XCTAssertGreaterThanOrEqual(
+            appFrame.maxY - palette.frame.maxY,
+            minimumScreenMargin
+        )
 
         let search = app.textFields["command-palette.search"]
         XCTAssertTrue(search.waitForExistence(timeout: 2))

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -117,6 +117,17 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(homeTitle.waitForExistence(timeout: 2))
         XCTAssertEqual(homeBinding.frame.height, homeTitle.frame.height, accuracy: 2)
         XCTAssertTrue(app.buttons["Set"].firstMatch.waitForExistence(timeout: 2))
+
+        let setButtons = app.buttons.matching(
+            NSPredicate(format: "label == %@", "Set")
+        )
+        XCTAssertGreaterThan(setButtons.count, 0)
+        setButtons.element(boundBy: setButtons.count - 1).tap()
+        app.typeKey("h", modifierFlags: .command)
+        XCTAssertTrue(
+            app.staticTexts["keyboard-settings.capture.validation"]
+                .waitForExistence(timeout: 2)
+        )
     }
 
     func testPhysicalKeyboardKeepsConnectionFormEditableAndStartsWithHiddenButtonBar() {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -123,6 +123,10 @@ final class RemuxAppUITests: XCTestCase {
         )
         XCTAssertGreaterThan(setButtons.count, 0)
         setButtons.element(boundBy: setButtons.count - 1).tap()
+        XCTAssertTrue(
+            app.staticTexts["Press the shortcut for Command Palette"]
+                .waitForExistence(timeout: 2)
+        )
         app.typeKey("h", modifierFlags: .command)
         XCTAssertTrue(
             app.staticTexts["keyboard-settings.capture.validation"]
@@ -145,7 +149,6 @@ final class RemuxAppUITests: XCTestCase {
         let terminal = app.otherElements["terminal.screen"]
         XCTAssertTrue(terminal.waitForExistence(timeout: 5))
         XCTAssertNil(optionalTerminalHomeButton(timeout: 0.5))
-        XCTAssertFalse(app.keyboards.firstMatch.exists)
     }
 
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
@@ -2687,9 +2690,19 @@ final class RemuxAppUITests: XCTestCase {
     }
 
     private func waitForTerminalHomeButton(timeout: TimeInterval = 2) -> XCUIElement {
-        if let button = terminalHomeButton(timeout: timeout, allowMissing: false) {
+        if let button = optionalTerminalHomeButton(timeout: timeout) {
             return button
         }
+
+        let terminal = app.otherElements["terminal.screen"]
+        if terminal.exists {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
+
+        if let button = optionalTerminalHomeButton(timeout: timeout) {
+            return button
+        }
+
         XCTFail("Missing terminal Home button.")
         return app.buttons["terminal.home"].firstMatch
     }

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -111,6 +111,10 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(autoHide.waitForExistence(timeout: 2))
         XCTAssertEqual(autoHide.value as? String, "1")
         XCTAssertTrue(app.staticTexts["Command Palette"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Increase Font Size"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Decrease Font Size"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["⌘ +"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["⌘ -"].waitForExistence(timeout: 2))
         let homeBinding = app.staticTexts["⇧ ⌘ H"]
         XCTAssertTrue(homeBinding.waitForExistence(timeout: 2))
         let homeTitle = app.staticTexts["Home"]

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -94,6 +94,26 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Catppuccin Mocha"].waitForExistence(timeout: 2))
     }
 
+    func testSettingsExposePhysicalKeyboardDefaults() {
+        launchSimulatorApp()
+        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
+        app.buttons["library.settings"].tap()
+
+        let physicalKeyboard = app.descendants(matching: .any)["settings.physical-keyboard"]
+        XCTAssertTrue(physicalKeyboard.waitForExistence(timeout: 2))
+        physicalKeyboard.tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["keyboard-settings.form"]
+                .waitForExistence(timeout: 2)
+        )
+        let autoHide = app.switches["keyboard-settings.hide-button-bar"]
+        XCTAssertTrue(autoHide.waitForExistence(timeout: 2))
+        XCTAssertEqual(autoHide.value as? String, "1")
+        XCTAssertTrue(app.staticTexts["Command Palette"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["Set"].firstMatch.waitForExistence(timeout: 2))
+    }
+
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
         launchSimulatorApp()
         openConnectionSetup()

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -111,7 +111,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(autoHide.waitForExistence(timeout: 2))
         XCTAssertEqual(autoHide.value as? String, "1")
         XCTAssertTrue(app.staticTexts["Command Palette"].waitForExistence(timeout: 2))
-        let homeBinding = app.staticTexts["⌘ H"]
+        let homeBinding = app.staticTexts["⇧ ⌘ H"]
         XCTAssertTrue(homeBinding.waitForExistence(timeout: 2))
         let homeTitle = app.staticTexts["Home"]
         XCTAssertTrue(homeTitle.waitForExistence(timeout: 2))
@@ -127,7 +127,7 @@ final class RemuxAppUITests: XCTestCase {
             app.staticTexts["Press the shortcut for Command Palette"]
                 .waitForExistence(timeout: 2)
         )
-        app.typeKey("h", modifierFlags: .command)
+        app.typeKey("h", modifierFlags: [])
         XCTAssertTrue(
             app.staticTexts["keyboard-settings.capture.validation"]
                 .waitForExistence(timeout: 2)

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -138,6 +138,31 @@ final class RemuxAppUITests: XCTestCase {
         )
     }
 
+    func testSettingsClearRemovesBinding() {
+        launchSimulatorApp()
+        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
+        app.buttons["library.settings"].tap()
+
+        let physicalKeyboard = app.descendants(matching: .any)["settings.physical-keyboard"]
+        XCTAssertTrue(physicalKeyboard.waitForExistence(timeout: 2))
+        physicalKeyboard.tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["keyboard-settings.form"]
+                .waitForExistence(timeout: 2)
+        )
+        let clearHome = app.buttons
+            .matching(identifier: "keyboard-settings.binding.home")
+            .matching(NSPredicate(format: "label == %@", "Clear"))
+            .firstMatch
+        XCTAssertTrue(clearHome.waitForExistence(timeout: 2))
+
+        clearHome.tap()
+
+        XCTAssertTrue(app.staticTexts["Unassigned"].waitForExistence(timeout: 2))
+        XCTAssertTrue(clearHome.waitForNonExistence(timeout: 2))
+    }
+
     func testCommandPaletteReceivesImmediateTyping() {
         launchSimulatorApp()
         XCTAssertTrue(

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -114,6 +114,19 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Set"].firstMatch.waitForExistence(timeout: 2))
     }
 
+    func testPhysicalKeyboardKeepsConnectionFormEditableAndStartsWithHiddenButtonBar() {
+        app.launchEnvironment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] = "1"
+        launchSimulatorApp()
+        openConnectionSetup()
+        fillConnectionForm()
+        saveConnectionAndWaitForTerminal()
+
+        let terminal = app.otherElements["terminal.screen"]
+        XCTAssertTrue(terminal.waitForExistence(timeout: 5))
+        XCTAssertNil(optionalTerminalHomeButton(timeout: 0.5))
+        XCTAssertFalse(app.keyboards.firstMatch.exists)
+    }
+
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
         launchSimulatorApp()
         openConnectionSetup()
@@ -152,6 +165,37 @@ final class RemuxAppUITests: XCTestCase {
             "yes 'REMUX_RENDER_CHECK ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789' | head -120"
         )
         assertLiveTerminalScreenshotContainsRenderedContent(minNonBackgroundPixels: 30_000)
+    }
+
+    func testLivePhysicalKeyboardRevealsFloatingButtonBarAndOpensCommandPaletteWhenConfigured() throws {
+        let sessionName = try generatedLiveLatencySessionName("physical-keyboard")
+        defer {
+            cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+        }
+
+        app.launchEnvironment["REMUX_UI_TEST_PHYSICAL_KEYBOARD"] = "1"
+        try launchLiveSSHAppIfConfigured(traceRuntime: true, sessionNameOverride: sessionName)
+        openFirstSavedSession()
+
+        waitForLiveTerminalReady(timeout: 60)
+        waitForLiveTerminalInputReady(timeout: 10)
+
+        let terminal = app.otherElements["terminal.screen"].firstMatch
+        XCTAssertTrue(terminal.waitForExistence(timeout: 5))
+        let terminalFrame = terminal.frame
+        XCTAssertNil(optionalTerminalHomeButton(timeout: 0.5))
+
+        terminal.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
+        XCTAssertNotNil(optionalTerminalHomeButton(timeout: 2))
+        XCTAssertEqual(terminal.frame, terminalFrame)
+
+        app.typeKey("k", modifierFlags: .command)
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)["command-palette"]
+                .waitForExistence(timeout: 2)
+        )
     }
 
     func testLiveSSHKeyboardResizeTraceWhenConfigured() throws {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -258,6 +258,51 @@ final class RemuxAppUITests: XCTestCase {
         openCommandPaletteAndAssertImmediateTyping()
     }
 
+    func testLiveSSHCommandNCreatesRemoteWindowWhenConfigured() throws {
+        let sessionName = try generatedLiveLatencySessionName("command-n")
+        defer {
+            cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+        }
+
+        try launchLiveSSHAppIfConfigured(
+            traceRuntime: true,
+            sessionNameOverride: sessionName
+        )
+        openFirstSavedSession()
+        waitForLiveTerminalReady(timeout: 90)
+        waitForLiveTerminalInputReady(timeout: 10)
+
+        app.typeKey("n", modifierFlags: .command)
+        waitForLiveTerminalReady(timeout: 30)
+
+        app.typeKey("o", modifierFlags: .command)
+        XCTAssertTrue(
+            waitForAnyPickerElement(
+                [
+                    elementWithIdentifier("terminal.windows.sheet"),
+                    app.buttons["terminal.window.new"],
+                    app.buttons["New Window"],
+                ],
+                timeout: 8
+            ),
+            "Command-O should present the current session's window sheet."
+        )
+        XCTAssertTrue(
+            app.buttons["terminal.window.tile.1"].waitForExistence(timeout: 10)
+        )
+        XCTAssertTrue(
+            app.buttons["terminal.window.tile.2"].waitForExistence(timeout: 10)
+        )
+        XCTAssertFalse(
+            app.buttons["terminal.window.tile.3"].waitForExistence(timeout: 2),
+            "Command-N should create exactly one remote tmux window."
+        )
+        recordLiveTmuxWindowCountExpectation(
+            sessionName: sessionName,
+            expectedCount: 2
+        )
+    }
+
     func testLiveSSHKeyboardResizeTraceWhenConfigured() throws {
         let sessionName = try generatedLiveLatencySessionName("keyboard")
         defer {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -111,6 +111,11 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(autoHide.waitForExistence(timeout: 2))
         XCTAssertEqual(autoHide.value as? String, "1")
         XCTAssertTrue(app.staticTexts["Command Palette"].waitForExistence(timeout: 2))
+        let homeBinding = app.staticTexts["⌘ H"]
+        XCTAssertTrue(homeBinding.waitForExistence(timeout: 2))
+        let homeTitle = app.staticTexts["Home"]
+        XCTAssertTrue(homeTitle.waitForExistence(timeout: 2))
+        XCTAssertEqual(homeBinding.frame.height, homeTitle.frame.height, accuracy: 2)
         XCTAssertTrue(app.buttons["Set"].firstMatch.waitForExistence(timeout: 2))
     }
 

--- a/RemuxAppUITests/ShortcutPaletteUITests.swift
+++ b/RemuxAppUITests/ShortcutPaletteUITests.swift
@@ -91,7 +91,9 @@ final class ShortcutPaletteUITests: XCTestCase {
         let terminal = app.otherElements["terminal.screen"]
         XCTAssertTrue(terminal.waitForExistence(timeout: 5))
         if !app.buttons["terminal.ctrl"].waitForExistence(timeout: 0.5) {
-            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            terminal.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
+            ).tap()
         }
 
         XCTAssertTrue(app.buttons["terminal.ctrl"].waitForExistence(timeout: 5))

--- a/RemuxAppUITests/ShortcutPaletteUITests.swift
+++ b/RemuxAppUITests/ShortcutPaletteUITests.swift
@@ -88,6 +88,12 @@ final class ShortcutPaletteUITests: XCTestCase {
         XCTAssertTrue(session.waitForExistence(timeout: 5))
         session.tap()
 
+        let terminal = app.otherElements["terminal.screen"]
+        XCTAssertTrue(terminal.waitForExistence(timeout: 5))
+        if !app.buttons["terminal.ctrl"].waitForExistence(timeout: 0.5) {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
+
         XCTAssertTrue(app.buttons["terminal.ctrl"].waitForExistence(timeout: 5))
     }
 

--- a/docs/superpowers/plans/2026-07-26-command-palette-focus-and-surfaces.md
+++ b/docs/superpowers/plans/2026-07-26-command-palette-focus-and-surfaces.md
@@ -69,15 +69,19 @@ private var isTransientInputOwnerPresented: Bool {
 }
 ```
 
-- [ ] **Step 4: Request search focus after responder reconciliation**
+- [ ] **Step 4: Establish results before requesting search focus**
 
-Replace the immediate `onAppear` focus request with a view task that seeds results, yields once on the main actor, and then focuses the search field:
+Initialize `CommandPaletteState` synchronously from `commands` so selection
+exists before the field can receive a key. Let `CommandPaletteTextField`
+request first responder only after it enters a window; do not populate results
+from an asynchronous view task:
 
 ```swift
-.task {
-    results = commands
-    await Task.yield()
-    isSearchFocused = true
+init(commands: [CommandPaletteItem], ...) {
+    self.commands = commands
+    _paletteState = State(
+        initialValue: CommandPaletteState(results: commands)
+    )
 }
 ```
 
@@ -105,15 +109,16 @@ git commit -m "Keep command palette keyboard focus"
 - Modify: `RemuxApp/Sources/App/CommandPaletteView.swift:14`
 
 **Interfaces:**
-- Consumes: the existing dynamic colors currently exposed privately by `LibraryHomePalette`
-- Produces: shared `RemuxAppPalette.background`, `RemuxAppPalette.rowSurface`, and `RemuxAppPalette.separator` colors
+- Consumes: the existing dynamic colors exposed by `LibraryHomePalette`
+- Produces: shared `LibraryHomePalette.background`, `LibraryHomePalette.rowSurface`, and `LibraryHomePalette.separator` colors
 
-- [ ] **Step 1: Expose the existing palette under an app-wide name**
+- [ ] **Step 1: Expose the existing semantic palette**
 
-Rename `LibraryHomePalette` to internal `RemuxAppPalette` and update its existing references without changing color values:
+Keep the established `LibraryHomePalette` symbol, make it internal rather than
+private, and preserve its color values:
 
 ```swift
-enum RemuxAppPalette {
+enum LibraryHomePalette {
     static let background = Color(uiColor: .libraryHomeBackground)
     static let rowSurface = Color(uiColor: .libraryHomeRowSurface)
     static let separator = Color(uiColor: .libraryHomeSeparator)
@@ -140,21 +145,21 @@ Section {
 
 - [ ] **Step 3: Replace the translucent palette material**
 
-Hide the `List` scroll background, apply `RemuxAppPalette.rowSurface` to result rows, use `RemuxAppPalette.background` for the panel, and draw a subtle separator-colored border:
+Hide the `List` scroll background, apply `LibraryHomePalette.rowSurface` to result rows, use `LibraryHomePalette.background` for the panel, and draw a subtle separator-colored border:
 
 ```swift
-.listRowBackground(RemuxAppPalette.rowSurface)
-.listRowSeparatorTint(RemuxAppPalette.separator)
+.listRowBackground(LibraryHomePalette.rowSurface)
+.listRowSeparatorTint(LibraryHomePalette.separator)
 ```
 
 ```swift
 .background(
-    RemuxAppPalette.background,
+    LibraryHomePalette.background,
     in: RoundedRectangle(cornerRadius: 18)
 )
 .overlay {
     RoundedRectangle(cornerRadius: 18)
-        .stroke(RemuxAppPalette.separator, lineWidth: 1)
+        .stroke(LibraryHomePalette.separator, lineWidth: 1)
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-26-command-palette-focus-and-surfaces.md
+++ b/docs/superpowers/plans/2026-07-26-command-palette-focus-and-surfaces.md
@@ -1,0 +1,227 @@
+# Command Palette Focus and Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Command-K palette own keyboard input immediately and render it and the Physical Keyboard settings row with Remux's established opaque app surfaces.
+
+**Architecture:** Propagate the root palette-presentation state into the selected terminal screen as an app-level transient input owner, then fold it into the existing terminal responder focus policy. Expose the existing app palette under a domain-appropriate shared name and apply its dynamic background, row, and separator colors to the command palette and keyboard settings entry.
+
+**Tech Stack:** Swift 6, SwiftUI, UIKit responder integration, XCTest, XCUITest, Xcode
+
+## Global Constraints
+
+- Preserve touch-first behavior when the command palette is closed.
+- Use Remux's existing dynamic grouped background, row surface, separator, corner treatment, and color-scheme behavior.
+- The palette panel and list must be opaque; terminal content must not bleed through.
+- Typing immediately after Command-K must enter the palette query without a tap or terminal input leakage.
+- Dismissing the palette must restore the terminal's existing focus policy.
+- Keep the change limited to palette focus and the two requested surfaces.
+
+---
+
+### Task 1: Command Palette Input Ownership
+
+**Files:**
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift:186`
+- Modify: `RemuxApp/Sources/App/RootView.swift:192`
+- Modify: `RemuxApp/Sources/App/RootView.swift:399`
+- Modify: `RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift:52`
+- Modify: `RemuxApp/Sources/App/CommandPaletteView.swift:3`
+
+**Interfaces:**
+- Consumes: `RemuxWorkspaceShell.isCommandPalettePresented: Bool` and `GhosttyTerminalResponderFocusPolicy.isTransientInputOwnerPresented: Bool`
+- Produces: `ActiveTerminalSessionView.isAppInputOwnerPresented: Bool` and `GhosttySurfaceScreen.init(..., isAppInputOwnerPresented: Bool = false, ...)`
+
+- [ ] **Step 1: Write the failing live UI regression**
+
+Extend `testLivePhysicalKeyboardRevealsFloatingButtonBarAndOpensCommandPaletteWhenConfigured()` so it types without tapping the search field:
+
+```swift
+let searchField = app.textFields["command-palette.search"]
+XCTAssertTrue(searchField.waitForExistence(timeout: 2))
+
+app.typeText("palette focus")
+
+XCTAssertEqual(searchField.value as? String, "palette focus")
+```
+
+- [ ] **Step 2: Run the regression to verify it fails**
+
+Run:
+
+```bash
+xcodebuild test -project Remux.xcodeproj -scheme Remux \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
+  -only-testing:RemuxAppUITests/RemuxAppUITests/testLivePhysicalKeyboardRevealsFloatingButtonBarAndOpensCommandPaletteWhenConfigured
+```
+
+Expected: the palette appears, but the search field does not receive the typed text because the selected terminal remains eligible to reclaim first responder.
+
+- [ ] **Step 3: Propagate app input ownership to the terminal**
+
+Add `isAppInputOwnerPresented` to `ActiveTerminalSessionView` and `GhosttySurfaceScreen`, pass `isCommandPalettePresented` from `RemuxWorkspaceShell`, and combine it with the existing focus gate:
+
+```swift
+private var isTransientInputOwnerPresented: Bool {
+    isAppInputOwnerPresented
+        || isAttachmentInputOwnerPresented
+        || terminalCoverPhase.ownsTerminalInput
+}
+```
+
+- [ ] **Step 4: Request search focus after responder reconciliation**
+
+Replace the immediate `onAppear` focus request with a view task that seeds results, yields once on the main actor, and then focuses the search field:
+
+```swift
+.task {
+    results = commands
+    await Task.yield()
+    isSearchFocused = true
+}
+```
+
+- [ ] **Step 5: Run the regression to verify it passes**
+
+Run the Step 2 command.
+
+Expected: PASS; typing immediately after Command-K updates `command-palette.search`.
+
+- [ ] **Step 6: Commit the input ownership fix**
+
+```bash
+git add RemuxAppUITests/RemuxAppUITests.swift \
+  RemuxApp/Sources/App/RootView.swift \
+  RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift \
+  RemuxApp/Sources/App/CommandPaletteView.swift
+git commit -m "Keep command palette keyboard focus"
+```
+
+### Task 2: Remux Design-System Surfaces
+
+**Files:**
+- Modify: `RemuxApp/Sources/App/RootView.swift:799`
+- Modify: `RemuxApp/Sources/App/RootView.swift:1345`
+- Modify: `RemuxApp/Sources/App/CommandPaletteView.swift:14`
+
+**Interfaces:**
+- Consumes: the existing dynamic colors currently exposed privately by `LibraryHomePalette`
+- Produces: shared `RemuxAppPalette.background`, `RemuxAppPalette.rowSurface`, and `RemuxAppPalette.separator` colors
+
+- [ ] **Step 1: Expose the existing palette under an app-wide name**
+
+Rename `LibraryHomePalette` to internal `RemuxAppPalette` and update its existing references without changing color values:
+
+```swift
+enum RemuxAppPalette {
+    static let background = Color(uiColor: .libraryHomeBackground)
+    static let rowSurface = Color(uiColor: .libraryHomeRowSurface)
+    static let separator = Color(uiColor: .libraryHomeSeparator)
+    // Preserve the remaining existing semantic colors.
+}
+```
+
+- [ ] **Step 2: Apply the grouped surface to the Physical Keyboard settings entry**
+
+Apply the existing row modifier to the first settings section:
+
+```swift
+Section {
+    NavigationLink("Physical Keyboard") {
+        KeyboardSettingsView(
+            initialSettings: keyboardSettings,
+            onChange: onKeyboardSettingsChange
+        )
+    }
+    .accessibilityIdentifier("settings.physical-keyboard")
+}
+.libraryHomeListRowSurface()
+```
+
+- [ ] **Step 3: Replace the translucent palette material**
+
+Hide the `List` scroll background, apply `RemuxAppPalette.rowSurface` to result rows, use `RemuxAppPalette.background` for the panel, and draw a subtle separator-colored border:
+
+```swift
+.listRowBackground(RemuxAppPalette.rowSurface)
+.listRowSeparatorTint(RemuxAppPalette.separator)
+```
+
+```swift
+.background(
+    RemuxAppPalette.background,
+    in: RoundedRectangle(cornerRadius: 18)
+)
+.overlay {
+    RoundedRectangle(cornerRadius: 18)
+        .stroke(RemuxAppPalette.separator, lineWidth: 1)
+}
+```
+
+- [ ] **Step 4: Run focused and full simulator verification**
+
+Run:
+
+```bash
+xcodebuild test -project Remux.xcodeproj -scheme Remux \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
+  -only-testing:RemuxAppTests \
+  -only-testing:RemuxAppUITests/RemuxAppUITests/testSettingsExposePhysicalKeyboardDefaults \
+  -only-testing:RemuxAppUITests/RemuxAppUITests/testLivePhysicalKeyboardRevealsFloatingButtonBarAndOpensCommandPaletteWhenConfigured
+```
+
+Then run the repository's full documented simulator test command from `docs/development.md`.
+
+Expected: all selected tests and the full suite pass.
+
+- [ ] **Step 5: Commit the surface integration**
+
+```bash
+git add RemuxApp/Sources/App/RootView.swift \
+  RemuxApp/Sources/App/CommandPaletteView.swift
+git commit -m "Match palette and keyboard settings surfaces"
+```
+
+### Task 3: Physical Device Build
+
+**Files:**
+- No source changes expected.
+
+**Interfaces:**
+- Consumes: the completed Debug app and Jesse's registered iPhone 16 Pro
+- Produces: installed and launched `com.fsck.dev.remux.app`
+
+- [ ] **Step 1: Build for Jesse's iPhone**
+
+Run:
+
+```bash
+xcodebuild build -project Remux.xcodeproj -scheme Remux -configuration Debug \
+  -destination 'id=6A5C05AA-0987-5ECC-9937-7E3073636F1D' \
+  -derivedDataPath .local/device-build \
+  DEVELOPMENT_TEAM=87WJ58S66M \
+  PRODUCT_BUNDLE_IDENTIFIER=com.fsck.dev.remux.app \
+  CODE_SIGN_STYLE=Automatic \
+  CODE_SIGN_IDENTITY='Apple Development'
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 2: Install and launch**
+
+Run:
+
+```bash
+xcrun devicectl device install app \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  .local/device-build/Build/Products/Debug-iphoneos/Remux.app
+xcrun devicectl device process launch \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  --terminate-existing com.fsck.dev.remux.app
+```
+
+Expected: install and launch both succeed.
+
+- [ ] **Step 3: Record final evidence**
+
+Report focused-test results, full-suite results, device build/install/launch status, and the remaining manual visual/input acceptance boundary separately.

--- a/docs/superpowers/plans/2026-07-26-global-font-size-key-bindings.md
+++ b/docs/superpowers/plans/2026-07-26-global-font-size-key-bindings.md
@@ -1,0 +1,355 @@
+# Global Font Size Key Bindings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add configurable Command-Plus and Command-Minus bindings that adjust Remux's app-global terminal font size by one point.
+
+**Architecture:** Extend the existing `AppKeyboardCommand` registry and `KeyboardSettings.default` rather than introducing a second shortcut path. Route both commands globally through `RemuxRootModel`, where a pure `TerminalSettings` mutation starts from the current effective device size when automatic sizing is active, clamps to the existing range, persists through the existing repository, and refreshes all active sessions.
+
+**Tech Stack:** Swift 6, SwiftUI, UIKit `UIKeyCommand`, XCTest, XCUITest
+
+## Global Constraints
+
+- Default Increase Font Size to Command-+ and Decrease Font Size to Command--.
+- Font-size commands are app-global and work from Home, terminals, and the command palette.
+- Each activation changes the font by exactly one point.
+- Automatic sizing starts from the current effective device font size.
+- Clamp results to `TerminalSettings.minimumFontSize` (8) and `TerminalSettings.maximumFontSize` (24).
+- Persist through the existing terminal-settings repository and refresh every active terminal.
+- Add the commands to the original keyboard-settings schema and defaults; do not add migration or backward-compatibility code.
+- Preserve existing custom-binding validation, duplicate rejection, and Command-H reservation.
+- Make the smallest reasonable changes and preserve unrelated worktree contents.
+
+---
+
+### Task 1: Configurable App-Global Font Size Commands
+
+**Files:**
+- Modify: `RemuxApp/Sources/Domain/AppKeyboardCommand.swift`
+- Modify: `RemuxApp/Sources/Domain/KeyboardSettings.swift`
+- Modify: `RemuxApp/Sources/Domain/TerminalSettings.swift`
+- Modify: `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift`
+- Modify: `RemuxApp/Sources/App/RemuxRootModel.swift`
+- Modify: `RemuxApp/Sources/App/RootView.swift`
+- Modify: `RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift`
+- Modify: `RemuxAppTests/KeyboardSettingsTests.swift`
+- Modify: `RemuxAppTests/TerminalSettingsTests.swift`
+- Modify: `RemuxAppTests/AppKeyboardCommandRouterTests.swift`
+- Modify: `RemuxAppTests/RemuxRootModelTests.swift`
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+- Consumes: `GhosttyTerminalAppearancePolicy.currentDeviceFontSize(settings:) -> Float32?`
+- Consumes: `RemuxRootModel.updateTerminalSettings(_:) async`
+- Produces: `AppKeyboardCommand.increaseFontSize`
+- Produces: `AppKeyboardCommand.decreaseFontSize`
+- Produces: `AppKeyboardCommandRoute.adjustFontSize(by: Float32)`
+- Produces: `TerminalSettings.adjustFontSize(by:effectiveDefault:)`
+- Produces: `RemuxRootModel.adjustTerminalFontSize(by:effectiveDefault:) async`
+
+- [ ] **Step 1: Add failing tests for defaults, adjustment rules, routing, persistence, and settings visibility**
+
+In `RemuxAppTests/KeyboardSettingsTests.swift`, extend
+`testDefaultsAssignEveryDocumentedCommand()`:
+
+```swift
+XCTAssertEqual(
+    settings.binding(for: .increaseFontSize),
+    KeyboardKeyBinding(input: "+", modifiers: [.command])
+)
+XCTAssertEqual(
+    settings.binding(for: .decreaseFontSize),
+    KeyboardKeyBinding(input: "-", modifiers: [.command])
+)
+```
+
+In `RemuxAppTests/TerminalSettingsTests.swift`, add:
+
+```swift
+func testFontSizeAdjustmentStartsFromEffectiveDefaultAndThenUsesExplicitSize() {
+    var settings = TerminalSettings(fontSize: nil, theme: .remuxDark)
+
+    settings.adjustFontSize(by: 1, effectiveDefault: 12)
+    XCTAssertEqual(settings.fontSize, 13)
+
+    settings.adjustFontSize(by: -1, effectiveDefault: 20)
+    XCTAssertEqual(settings.fontSize, 12)
+}
+
+func testFontSizeAdjustmentClampsToSupportedRange() {
+    var maximum = TerminalSettings(
+        fontSize: TerminalSettings.maximumFontSize,
+        theme: .remuxDark
+    )
+    var minimum = TerminalSettings(
+        fontSize: TerminalSettings.minimumFontSize,
+        theme: .remuxDark
+    )
+
+    maximum.adjustFontSize(by: 1, effectiveDefault: 10)
+    minimum.adjustFontSize(by: -1, effectiveDefault: 10)
+
+    XCTAssertEqual(maximum.fontSize, TerminalSettings.maximumFontSize)
+    XCTAssertEqual(minimum.fontSize, TerminalSettings.minimumFontSize)
+}
+```
+
+In `RemuxAppTests/AppKeyboardCommandRouterTests.swift`, add:
+
+```swift
+func testFontSizeCommandsAreGlobalAdjustments() {
+    let context = AppKeyboardCommandRouteContext(
+        selectedSessionID: nil,
+        isSelectedTerminalReady: false,
+        orderedActiveSessionIDs: []
+    )
+
+    XCTAssertEqual(
+        AppKeyboardCommandRouter.route(.increaseFontSize, in: context),
+        .adjustFontSize(by: 1)
+    )
+    XCTAssertEqual(
+        AppKeyboardCommandRouter.route(.decreaseFontSize, in: context),
+        .adjustFontSize(by: -1)
+    )
+}
+```
+
+In `RemuxAppTests/RemuxRootModelTests.swift`, add:
+
+```swift
+func testAdjustTerminalFontSizePersistsAppGlobalSetting() async throws {
+    let harness = makeHarness(
+        settings: TerminalSettings(fontSize: nil, theme: .remuxDark)
+    )
+    await harness.model.load()
+
+    await harness.model.adjustTerminalFontSize(
+        by: 1,
+        effectiveDefault: 12
+    )
+
+    XCTAssertEqual(harness.model.terminalSettings.fontSize, 13)
+    let saved = try await harness.settingsRepository.loadSettings()
+    XCTAssertEqual(saved.fontSize, 13)
+}
+```
+
+In `RemuxAppUITests/RemuxAppUITests.swift`, extend
+`testSettingsExposePhysicalKeyboardDefaults()`:
+
+```swift
+XCTAssertTrue(app.staticTexts["Increase Font Size"].waitForExistence(timeout: 2))
+XCTAssertTrue(app.staticTexts["Decrease Font Size"].waitForExistence(timeout: 2))
+XCTAssertTrue(app.staticTexts["⌘ +"].waitForExistence(timeout: 2))
+XCTAssertTrue(app.staticTexts["⌘ -"].waitForExistence(timeout: 2))
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/KeyboardSettingsTests \
+  -only-testing:RemuxTests/TerminalSettingsTests \
+  -only-testing:RemuxTests/AppKeyboardCommandRouterTests \
+  -only-testing:RemuxTests/RemuxRootModelTests/testAdjustTerminalFontSizePersistsAppGlobalSetting
+```
+
+Expected: compilation fails because the two commands, adjustment route, and
+font-size mutation APIs do not exist.
+
+- [ ] **Step 3: Extend the command registry and configurable defaults**
+
+In `RemuxApp/Sources/Domain/AppKeyboardCommand.swift`, add the cases:
+
+```swift
+case increaseFontSize
+case decreaseFontSize
+```
+
+Add their display titles:
+
+```swift
+case .increaseFontSize:
+    "Increase Font Size"
+case .decreaseFontSize:
+    "Decrease Font Size"
+```
+
+Treat them as global commands:
+
+```swift
+case .previousSession, .nextSession, .home, .commandPalette,
+     .increaseFontSize, .decreaseFontSize:
+    false
+```
+
+In `RemuxApp/Sources/Domain/KeyboardSettings.swift`, add these entries to
+`KeyboardSettings.default.bindings`:
+
+```swift
+.increaseFontSize: KeyboardKeyBinding(input: "+", modifiers: [.command]),
+.decreaseFontSize: KeyboardKeyBinding(input: "-", modifiers: [.command]),
+```
+
+Do not add decoding fallbacks, schema versions, or migrations.
+
+- [ ] **Step 4: Add the bounded `TerminalSettings` mutation**
+
+In `RemuxApp/Sources/Domain/TerminalSettings.swift`, add:
+
+```swift
+mutating func adjustFontSize(
+    by delta: Float32,
+    effectiveDefault: Float32
+) {
+    fontSize = Self.normalizedFontSize(
+        (fontSize ?? effectiveDefault) + delta
+    )
+}
+```
+
+This reuses the existing normalization rule and makes the first adjustment
+from automatic sizing explicit and testable.
+
+- [ ] **Step 5: Route and persist the app-global adjustment**
+
+In `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift`, add:
+
+```swift
+case adjustFontSize(by: Float32)
+```
+
+Route the new commands before terminal-only routing:
+
+```swift
+case .increaseFontSize:
+    return .adjustFontSize(by: 1)
+case .decreaseFontSize:
+    return .adjustFontSize(by: -1)
+```
+
+In `RemuxApp/Sources/App/RemuxRootModel.swift`, add:
+
+```swift
+func adjustTerminalFontSize(
+    by delta: Float32,
+    effectiveDefault: Float32
+) async {
+    await updateTerminalSettings { settings in
+        settings.adjustFontSize(
+            by: delta,
+            effectiveDefault: effectiveDefault
+        )
+    }
+}
+```
+
+In `RemuxApp/Sources/App/RootView.swift`, handle the new route:
+
+```swift
+case .adjustFontSize(let delta):
+    let effectiveDefault =
+        GhosttyTerminalAppearancePolicy.currentDeviceFontSize(
+            settings: model.terminalSettings
+        ) ?? TerminalSettings.defaultExplicitFontSize
+    Task {
+        await model.adjustTerminalFontSize(
+            by: delta,
+            effectiveDefault: effectiveDefault
+        )
+    }
+```
+
+The existing `updateTerminalSettings` path updates `terminalSettings`, refreshes
+all active session models, and persists before returning.
+
+- [ ] **Step 6: Forward font commands from an active terminal to root routing**
+
+In `RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift`, include the new global
+commands in the forwarding branch of `performAppKeyboardCommand(_:)`:
+
+```swift
+case .previousSession, .nextSession, .home, .commandPalette,
+     .increaseFontSize, .decreaseFontSize:
+    onAppKeyboardCommand(command)
+```
+
+Do not alter terminal input for unmatched key events.
+
+- [ ] **Step 7: Run focused unit tests and verify GREEN**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/KeyboardSettingsTests \
+  -only-testing:RemuxTests/TerminalSettingsTests \
+  -only-testing:RemuxTests/AppKeyboardCommandRouterTests \
+  -only-testing:RemuxTests/RemuxRootModelTests/testAdjustTerminalFontSizePersistsAppGlobalSetting
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the focused settings UI test**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme RemuxUIOnly \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxUITests/RemuxAppUITests/testSettingsExposePhysicalKeyboardDefaults
+```
+
+Expected: PASS with both commands and their default bindings visible.
+
+- [ ] **Step 9: Run full verification**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2'
+
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme RemuxUIOnly \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2'
+
+git diff --check
+```
+
+Expected: both schemes pass and `git diff --check` emits no output.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git status --short
+git add \
+  RemuxApp/Sources/Domain/AppKeyboardCommand.swift \
+  RemuxApp/Sources/Domain/KeyboardSettings.swift \
+  RemuxApp/Sources/Domain/TerminalSettings.swift \
+  RemuxApp/Sources/App/AppKeyboardCommandRouter.swift \
+  RemuxApp/Sources/App/RemuxRootModel.swift \
+  RemuxApp/Sources/App/RootView.swift \
+  RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift \
+  RemuxAppTests/KeyboardSettingsTests.swift \
+  RemuxAppTests/TerminalSettingsTests.swift \
+  RemuxAppTests/AppKeyboardCommandRouterTests.swift \
+  RemuxAppTests/RemuxRootModelTests.swift \
+  RemuxAppUITests/RemuxAppUITests.swift
+git commit -m "Add global font size key bindings"
+```
+

--- a/docs/superpowers/plans/2026-07-26-global-font-size-key-bindings.md
+++ b/docs/superpowers/plans/2026-07-26-global-font-size-key-bindings.md
@@ -352,4 +352,3 @@ git add \
   RemuxAppUITests/RemuxAppUITests.swift
 git commit -m "Add global font size key bindings"
 ```
-

--- a/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
+++ b/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
@@ -37,7 +37,11 @@
 
 - [ ] **Step 1: Write failing default, clearing, custom-chord, and duplicate tests**
 
-Create tests asserting all nine default chords, that `nil` clears a command, that a custom modified chord persists in the value, that a chord with no modifier is rejected, and that assigning a chord already used by another command throws `KeyboardSettings.ValidationError.duplicateBinding`.
+Create tests asserting the exact default chord for all twelve registry commands,
+that `nil` clears a command, that a custom modified chord persists in the
+value, that a chord with no modifier is rejected, and that assigning a chord
+already used by another command throws
+`KeyboardSettings.ValidationError.duplicateBinding`.
 
 - [ ] **Step 2: Run the focused tests and verify RED**
 
@@ -325,10 +329,16 @@ Run `TerminalViewportSnapshotTests`; expect missing snapshot API.
 Build with:
 
 ```bash
-GHOSTTY_SOURCE_DIR=/Users/jesse/Documents/remux-ghostty scripts/build_release_ghosttykit.sh
+GHOSTTY_SOURCE_DIR=../ghostty-remux-upstream-rebuild scripts/build_release_ghosttykit.sh
 ```
 
-Verify the generated header contains `ghostty_terminal_surface_read_viewport`, preserve a recoverable copy of the prior pinned framework, and replace the explicit framework at `/Users/jesse/Documents/ghostty-remux-upstream-rebuild/macos/GhosttyKit.xcframework`.
+Verify the generated header contains
+`ghostty_terminal_surface_read_viewport`. After remux-ghostty PR #7 merges,
+publish an immutable GhosttyKit release containing that API, update
+`scripts/fetch_ghosttykit.sh` to its tag and verified checksum, and verify a
+clean checkout can fetch and build against the new pin. Until that release
+exists, the source build is local verification and the clean-checkout build
+remains externally dependent on PR #7 and its release asset.
 
 - [ ] **Step 4: Implement the Swift wrapper and retained-surface projection**
 
@@ -433,18 +443,25 @@ xcodebuild test -project Remux.xcodeproj -scheme Remux -destination 'platform=iO
 
 Read the complete result and do not infer full-suite success from focused tests.
 
-- [ ] **Step 4: Run release builds and Ghostty verification**
+- [ ] **Step 4: Run the full non-live UI suite**
+
+Temporarily move any live-SSH configuration out of its discovery path, run the
+entire `RemuxUITests` target, restore the configuration without reading or
+copying its contents into logs, and record passed and live-only skipped counts
+separately. Focused UI tests are not a substitute for this gate.
+
+- [ ] **Step 5: Run release builds and Ghostty verification**
 
 Run the Remux Release configuration build plus fresh `zig build test -Demit-macos-app=false` in the fork.
 
-- [ ] **Step 5: Capture rendered simulator evidence**
+- [ ] **Step 6: Capture rendered simulator evidence**
 
 Using the deterministic physical-keyboard override, capture Home palette, terminal palette, chrome hidden, and chrome revealed states. Verify from frames or accessibility geometry that the terminal viewport is identical between hidden and revealed floating-bar states.
 
-- [ ] **Step 6: Review every design requirement**
+- [ ] **Step 7: Review every design requirement**
 
 Check each design section against code, focused tests, full-suite output, and rendered evidence. State explicitly that physical keyboard connection delivery and Command-H priority still require an attached iPad unless performed on one.
 
-- [ ] **Step 7: Commit any final test/evidence-only corrections**
+- [ ] **Step 8: Commit any final test/evidence-only corrections**
 
 Run the relevant failing test before each correction, re-run full verification, then make a final detailed commit without staging the pre-existing `.worktrees`.

--- a/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
+++ b/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
@@ -27,7 +27,7 @@
 **Files:**
 - Create: `RemuxApp/Sources/Domain/AppKeyboardCommand.swift`
 - Create: `RemuxApp/Sources/Domain/KeyboardSettings.swift`
-- Create: `RemuxApp/Tests/KeyboardSettingsTests.swift`
+- Create: `RemuxAppTests/KeyboardSettingsTests.swift`
 
 **Interfaces:**
 - Produces: `enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable`
@@ -44,7 +44,7 @@ Create tests asserting all nine default chords, that `nil` clears a command, tha
 Run:
 
 ```bash
-xcodebuild test -project Remux.xcodeproj -scheme RemuxApp -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)' -only-testing:RemuxAppTests/KeyboardSettingsTests
+xcodebuild test -project Remux.xcodeproj -scheme Remux -destination 'platform=iOS Simulator,id=53D1EE7F-E770-41B6-BEDF-9F416C35D2B9' -only-testing:RemuxTests/KeyboardSettingsTests
 ```
 
 Expected: compilation fails because the keyboard settings types do not exist.
@@ -68,7 +68,7 @@ Run the Task 1 test command and confirm zero failures.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add RemuxApp/Sources/Domain/AppKeyboardCommand.swift RemuxApp/Sources/Domain/KeyboardSettings.swift RemuxApp/Tests/KeyboardSettingsTests.swift
+git add RemuxApp/Sources/Domain/AppKeyboardCommand.swift RemuxApp/Sources/Domain/KeyboardSettings.swift RemuxAppTests/KeyboardSettingsTests.swift
 git commit -m "Add configurable keyboard command domain
 
 Define Remux's fixed app command set, the documented default bindings,
@@ -80,7 +80,7 @@ duplicate chords before persistence."
 
 **Files:**
 - Create: `RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift`
-- Create: `RemuxApp/Tests/KeyboardSettingsRepositoryTests.swift`
+- Create: `RemuxAppTests/KeyboardSettingsRepositoryTests.swift`
 - Modify: `RemuxApp/Sources/App/RemuxAppDependencies.swift`
 
 **Interfaces:**
@@ -114,7 +114,7 @@ Stage only the repository, dependency wiring, and tests; commit with a detailed 
 **Files:**
 - Create: `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift`
 - Create: `RemuxApp/Sources/App/AppKeyboardCommandResponder.swift`
-- Create: `RemuxApp/Tests/AppKeyboardCommandRouterTests.swift`
+- Create: `RemuxAppTests/AppKeyboardCommandRouterTests.swift`
 - Modify: `RemuxApp/Sources/App/RootView.swift`
 - Modify: `RemuxApp/Sources/Terminal/GhosttyTerminalResponderUIView.swift`
 
@@ -154,9 +154,9 @@ Commit the central router, UIKit responders, root wiring, and tests with a messa
 **Files:**
 - Create: `RemuxApp/Sources/App/KeyboardSettingsView.swift`
 - Create: `RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift`
-- Create: `RemuxApp/Tests/KeyboardShortcutCaptureTests.swift`
+- Create: `RemuxAppTests/KeyboardShortcutCaptureTests.swift`
 - Modify: `RemuxApp/Sources/App/RootView.swift`
-- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift`
 
 **Interfaces:**
 - Consumes: repository, settings validation, command metadata
@@ -192,8 +192,8 @@ Commit the settings UI, capture behavior, tests, and accessibility identifiers.
 **Files:**
 - Create: `RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift`
 - Create: `RemuxApp/Sources/Terminal/PhysicalKeyboardChromeState.swift`
-- Create: `RemuxApp/Tests/PhysicalKeyboardChromeStateTests.swift`
-- Modify: `RemuxApp/project.yml`
+- Create: `RemuxAppTests/PhysicalKeyboardChromeStateTests.swift`
+- Modify: `project.yml`
 
 **Interfaces:**
 - Produces: `@MainActor @Observable final class PhysicalKeyboardMonitor`
@@ -225,7 +225,7 @@ Regenerate the Xcode project, build, run the focused tests, and commit monitor/s
 **Files:**
 - Modify: `RemuxApp/Sources/Terminal/GhosttySurfaceScreen.swift`
 - Modify: `RemuxApp/Sources/Terminal/GhosttyKeyboardChrome.swift`
-- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift`
 
 **Interfaces:**
 - Consumes: `PhysicalKeyboardMonitor`, `PhysicalKeyboardChromeState`, `KeyboardSettings.hideButtonBarWhenPhysicalKeyboardConnected`
@@ -304,7 +304,7 @@ Commit only the three API files with a detailed message covering snapshot scope,
 - Modify: `RemuxApp/Sources/Terminal/TmuxTerminalSession.swift`
 - Modify: `RemuxApp/Sources/Terminal/TmuxTerminalScreenAdapter.swift`
 - Create: `RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift`
-- Create: `RemuxApp/Tests/TerminalViewportSnapshotTests.swift`
+- Create: `RemuxAppTests/TerminalViewportSnapshotTests.swift`
 
 **Interfaces:**
 - Consumes: `ghostty_terminal_surface_read_viewport`
@@ -343,7 +343,7 @@ Commit the Remux wrapper, projection, tests, and updated pinned framework togeth
 **Files:**
 - Create: `RemuxApp/Sources/App/CommandPaletteModel.swift`
 - Create: `RemuxApp/Sources/App/CommandPaletteSearch.swift`
-- Create: `RemuxApp/Tests/CommandPaletteModelTests.swift`
+- Create: `RemuxAppTests/CommandPaletteModelTests.swift`
 
 **Interfaces:**
 - Consumes: hosts, route-aware commands, active-session snapshot providers
@@ -376,7 +376,7 @@ Commit model/search behavior and tests.
 - Create: `RemuxApp/Sources/App/CommandPaletteView.swift`
 - Modify: `RemuxApp/Sources/App/RootView.swift`
 - Modify: `RemuxApp/Sources/Terminal/GhosttySurfaceScreen.swift`
-- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift`
 
 **Interfaces:**
 - Consumes: `CommandPaletteModel`, root model methods, terminal focus methods
@@ -428,7 +428,7 @@ Run all new test classes in one fresh `xcodebuild test` invocation and record te
 Run:
 
 ```bash
-xcodebuild test -project Remux.xcodeproj -scheme RemuxApp -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)'
+xcodebuild test -project Remux.xcodeproj -scheme Remux -destination 'platform=iOS Simulator,id=53D1EE7F-E770-41B6-BEDF-9F416C35D2B9'
 ```
 
 Read the complete result and do not infer full-suite success from focused tests.

--- a/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
+++ b/docs/superpowers/plans/2026-07-26-physical-keyboard-commands.md
@@ -1,0 +1,450 @@
+# Physical Keyboard Commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add configurable physical-keyboard commands, a global command palette with visible-terminal search, and auto-hiding floating terminal chrome.
+
+**Architecture:** A persisted keyboard-settings value defines an optional key chord for each fixed app action. Root-level routing owns global commands while each selected terminal exposes its existing local actions through the same command interface; a small UIKit responder turns configured chords into those actions. Visible-text search crosses the existing retained tmux surfaces through one new non-mutating GhosttyKit viewport API, while physical-keyboard monitoring drives a separately tested floating-chrome state machine.
+
+**Tech Stack:** Swift 6, SwiftUI, UIKit, GameController, XCTest, Zig, GhosttyKit C API, XcodeGen
+
+## Global Constraints
+
+- Preserve all touch-first layout and input behavior when no physical keyboard is connected.
+- Treat Bluetooth, Magic Keyboard, and wired keyboards reported by `GCKeyboard.coalescedKeyboard` as physical keyboards.
+- Accept only a key plus one or more of Command, Shift, Option, and Control; allow unassigned commands and reject duplicate chords.
+- Default `Hide button bar when a physical keyboard is connected` to enabled.
+- Search only the currently visible viewport, case-insensitively; do not add scrollback indexing or persistent highlights.
+- Route Command-Left/Right through the same previous/next tmux-window behavior as the existing swipe gesture.
+- Request app priority over system behavior for every configured command, but keep physical-iPad verification as a separate acceptance gate.
+- Do not migrate or alter the existing terminal-settings JSON schema.
+- Make the smallest GhosttyKit fork change required for a non-mutating visible-viewport snapshot.
+
+---
+
+### Task 1: Keyboard Command Domain and Defaults
+
+**Files:**
+- Create: `RemuxApp/Sources/Domain/AppKeyboardCommand.swift`
+- Create: `RemuxApp/Sources/Domain/KeyboardSettings.swift`
+- Create: `RemuxApp/Tests/KeyboardSettingsTests.swift`
+
+**Interfaces:**
+- Produces: `enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable`
+- Produces: `struct KeyboardKeyBinding: Codable, Equatable, Hashable`
+- Produces: `struct KeyboardSettings: Codable, Equatable`
+- Produces: `KeyboardSettings.validated(updating:to:) throws -> KeyboardSettings`
+
+- [ ] **Step 1: Write failing default, clearing, custom-chord, and duplicate tests**
+
+Create tests asserting all nine default chords, that `nil` clears a command, that a custom modified chord persists in the value, that a chord with no modifier is rejected, and that assigning a chord already used by another command throws `KeyboardSettings.ValidationError.duplicateBinding`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Remux.xcodeproj -scheme RemuxApp -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)' -only-testing:RemuxAppTests/KeyboardSettingsTests
+```
+
+Expected: compilation fails because the keyboard settings types do not exist.
+
+- [ ] **Step 3: Implement the smallest immutable command/settings model**
+
+Define stable raw values for:
+
+```swift
+case previousWindow, nextWindow
+case previousSession, nextSession
+case home, windows, panes, attachments, commandPalette
+```
+
+Represent input with UIKit-compatible strings (`UIKeyInputLeftArrow`, `UIKeyInputRightArrow`, and lower-case printable characters) and modifiers with a Codable `OptionSet`. Build `KeyboardSettings.default` from an explicit dictionary and validate the prospective whole dictionary before returning an updated copy.
+
+- [ ] **Step 4: Re-run the focused tests and verify GREEN**
+
+Run the Task 1 test command and confirm zero failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RemuxApp/Sources/Domain/AppKeyboardCommand.swift RemuxApp/Sources/Domain/KeyboardSettings.swift RemuxApp/Tests/KeyboardSettingsTests.swift
+git commit -m "Add configurable keyboard command domain
+
+Define Remux's fixed app command set, the documented default bindings,
+optional unassignment, and whole-settings validation that rejects bare or
+duplicate chords before persistence."
+```
+
+### Task 2: Keyboard Settings Persistence
+
+**Files:**
+- Create: `RemuxApp/Sources/Persistence/KeyboardSettingsRepository.swift`
+- Create: `RemuxApp/Tests/KeyboardSettingsRepositoryTests.swift`
+- Modify: `RemuxApp/Sources/App/RemuxAppDependencies.swift`
+
+**Interfaces:**
+- Consumes: `KeyboardSettings`
+- Produces: `protocol KeyboardSettingsRepositoryProtocol`
+- Produces: `actor KeyboardSettingsRepository` with `load() async throws -> KeyboardSettings` and `save(_:) async throws`
+- Produces: `RemuxAppDependencies.keyboardSettingsRepository`
+
+- [ ] **Step 1: Write failing repository behavior tests**
+
+Use an isolated temporary application-support directory and assert that a missing file loads `.default`, a saved custom value round-trips, and invalid duplicate JSON is rejected rather than becoming live settings.
+
+- [ ] **Step 2: Run the repository tests and verify RED**
+
+Run the simulator test command restricted to `KeyboardSettingsRepositoryTests`; expect missing repository symbols.
+
+- [ ] **Step 3: Implement a separate `keyboard-settings.json` repository**
+
+Reuse `JSONFileStore` conventions, validate decoded settings before returning them, and wire the repository into live and UI-test dependency constructors without changing `terminal-settings.json`.
+
+- [ ] **Step 4: Run repository and dependency tests and verify GREEN**
+
+Run `KeyboardSettingsRepositoryTests` plus existing dependency tests, then confirm zero failures.
+
+- [ ] **Step 5: Commit**
+
+Stage only the repository, dependency wiring, and tests; commit with a detailed message describing the separate schema and missing-file default.
+
+### Task 3: Dynamic Key Commands and Route-Aware Dispatch
+
+**Files:**
+- Create: `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift`
+- Create: `RemuxApp/Sources/App/AppKeyboardCommandResponder.swift`
+- Create: `RemuxApp/Tests/AppKeyboardCommandRouterTests.swift`
+- Modify: `RemuxApp/Sources/App/RootView.swift`
+- Modify: `RemuxApp/Sources/Terminal/GhosttyTerminalResponderUIView.swift`
+
+**Interfaces:**
+- Consumes: `KeyboardSettings`, `AppKeyboardCommand`
+- Produces: `struct AppKeyboardCommandAvailability`
+- Produces: `AppKeyboardCommandRouter.perform(_:)`
+- Produces: configured `UIKeyCommand` values with `wantsPriorityOverSystemBehavior = true`
+- Produces: terminal-local command closure returning whether a command was consumed
+
+- [ ] **Step 1: Write failing routing tests**
+
+Test that global Home and palette commands remain available on Home, terminal-only commands are disabled there, selected-terminal commands dispatch locally, session cycling wraps in Home's active-session order, and an unavailable configured command is consumed rather than sent to Ghostty.
+
+- [ ] **Step 2: Run focused router tests and verify RED**
+
+Run only `AppKeyboardCommandRouterTests`; expect missing router symbols.
+
+- [ ] **Step 3: Implement command conversion and central routing**
+
+Generate `UIKeyCommand` objects directly from the current settings, attach each command action as its property-list payload, request system priority, and rebuild commands when settings change. Root routing handles Home, session cycling, and palette presentation. The selected `GhosttySurfaceScreen` closure handles window cycling and existing window/pane/attachment presentations. Match active-session ordering to `ConnectionLibraryView`.
+
+- [ ] **Step 4: Integrate terminal interception before Ghostty mapping**
+
+In `GhosttyTerminalResponderUIView`, resolve configured app chords before `GhosttyTerminalHardwareCommandMapping`; pass unmatched keys to the existing mapping unchanged. Call the same local methods used by swipe and chrome button callbacks.
+
+- [ ] **Step 5: Run router, hardware mapping, and navigation tests**
+
+Confirm the focused suites pass with no warnings or failures.
+
+- [ ] **Step 6: Commit**
+
+Commit the central router, UIKit responders, root wiring, and tests with a message documenting command ownership and terminal fallthrough.
+
+### Task 4: Keyboard Settings UI and Chord Capture
+
+**Files:**
+- Create: `RemuxApp/Sources/App/KeyboardSettingsView.swift`
+- Create: `RemuxApp/Sources/App/KeyboardShortcutCaptureView.swift`
+- Create: `RemuxApp/Tests/KeyboardShortcutCaptureTests.swift`
+- Modify: `RemuxApp/Sources/App/RootView.swift`
+- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+- Consumes: repository, settings validation, command metadata
+- Produces: capture events as `KeyboardKeyBinding?`
+- Produces: settings navigation link and hide-button-bar toggle
+
+- [ ] **Step 1: Write failing capture-normalization tests**
+
+Assert lower-case printable normalization, arrow-key preservation, combined modifiers, rejection of modifier-only/bare keys, clear-to-`nil`, and duplicate error presentation through a small pure capture reducer.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run `KeyboardShortcutCaptureTests`; expect missing capture reducer.
+
+- [ ] **Step 3: Implement the settings view and UIKit capture control**
+
+Use one row per `AppKeyboardCommand`, an explicit capture button, a clear control, inline validation text, and the exact toggle label `Hide button bar when a physical keyboard is connected`. Keep the edited value local until validation succeeds, then persist through the injected repository.
+
+- [ ] **Step 4: Add an existing-settings-flow navigation link**
+
+Add a `NavigationLink` from `TerminalSettingsView` without reorganizing unrelated settings. Add stable accessibility identifiers for the screen, binding rows, clear actions, validation, and hide toggle.
+
+- [ ] **Step 5: Write and run a UI test**
+
+Exercise navigation, clearing a binding, assigning a custom chord through the deterministic capture seam, duplicate rejection, relaunch persistence, and the default-enabled hide toggle.
+
+- [ ] **Step 6: Run focused unit and UI tests, then commit**
+
+Commit the settings UI, capture behavior, tests, and accessibility identifiers.
+
+### Task 5: Physical Keyboard Projection and Floating-Chrome State
+
+**Files:**
+- Create: `RemuxApp/Sources/App/PhysicalKeyboardMonitor.swift`
+- Create: `RemuxApp/Sources/Terminal/PhysicalKeyboardChromeState.swift`
+- Create: `RemuxApp/Tests/PhysicalKeyboardChromeStateTests.swift`
+- Modify: `RemuxApp/project.yml`
+
+**Interfaces:**
+- Produces: `@MainActor @Observable final class PhysicalKeyboardMonitor`
+- Produces: `struct PhysicalKeyboardChromeState`
+- Produces: events `keyboardConnectionChanged`, `terminalTapped`, `chromeInteracted`, and `autoHideElapsed`
+
+- [ ] **Step 1: Write failing state-transition tests**
+
+Cover initial hidden state when connected and hide-enabled, reveal on terminal tap, hide after the timer event, timer restart after chrome interaction, persistent visibility when hide is disabled, and restoration of normal non-floating chrome on disconnect.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run only `PhysicalKeyboardChromeStateTests`; expect missing state symbols.
+
+- [ ] **Step 3: Implement the pure state reducer**
+
+Keep timer scheduling outside the value type. Make state expose `usesFloatingChrome`, `isChromeVisible`, and a monotonically changing timer token only when a three-second hide should be scheduled.
+
+- [ ] **Step 4: Implement the GameController-backed monitor**
+
+Initialize from `GCKeyboard.coalescedKeyboard`, reconcile both connect/disconnect notifications against the current coalesced value, and support `REMUX_UI_TEST_PHYSICAL_KEYBOARD=1` as a deterministic UI-test projection.
+
+- [ ] **Step 5: Add GameController linkage, run tests, and commit**
+
+Regenerate the Xcode project, build, run the focused tests, and commit monitor/state/project changes.
+
+### Task 6: Floating Button Bar Integration
+
+**Files:**
+- Modify: `RemuxApp/Sources/Terminal/GhosttySurfaceScreen.swift`
+- Modify: `RemuxApp/Sources/Terminal/GhosttyKeyboardChrome.swift`
+- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+- Consumes: `PhysicalKeyboardMonitor`, `PhysicalKeyboardChromeState`, `KeyboardSettings.hideButtonBarWhenPhysicalKeyboardConnected`
+- Produces: unchanged measured layout without hardware keyboard and unmeasured bottom overlay with one
+
+- [ ] **Step 1: Add a failing geometry UI test**
+
+Under the physical-keyboard override, record the terminal viewport frame with chrome hidden and shown and assert identical height and bottom edge. Also assert that a terminal tap reveals the bar and a deterministic auto-hide hook hides it.
+
+- [ ] **Step 2: Run the UI test and verify RED**
+
+Confirm the current measured chrome shortens the terminal and the new test fails for that reason.
+
+- [ ] **Step 3: Integrate floating chrome with one timer task**
+
+When hardware is connected, render `GhosttyKeyboardChrome` in an overlay excluded from `GhosttyBottomChromeHeightPreferenceKey`. A terminal tap reveals without calling the software-keyboard path; every bar callback sends `chromeInteracted` before its existing action. Cancel and replace a `Task.sleep(for: .seconds(3))` task using the state token.
+
+- [ ] **Step 4: Preserve the disconnected path byte-for-byte where practical**
+
+Keep existing measured chrome, keyboard show/hide, and terminal tap behavior when no hardware keyboard is attached. When hide is disabled, keep the overlay visible and do not schedule a timer.
+
+- [ ] **Step 5: Run geometry UI test, existing terminal UI tests, and commit**
+
+Commit the floating overlay integration and evidence-producing UI assertions.
+
+### Task 7: GhosttyKit Visible-Viewport API
+
+**Files:**
+- Modify: `/Users/jesse/Documents/remux-ghostty/src/renderer/TerminalSurface.zig`
+- Modify: `/Users/jesse/Documents/remux-ghostty/src/renderer/TerminalSurfaceC.zig`
+- Modify: `/Users/jesse/Documents/remux-ghostty/include/ghostty.h`
+
+**Interfaces:**
+- Produces: `TerminalSurface.viewportText() ![]const u8`
+- Produces: `ghostty_terminal_surface_read_viewport(ghostty_terminal_surface_t, ghostty_text_s*)`
+- Consumes: existing `ghostty_terminal_surface_free_text`
+
+- [ ] **Step 1: Create the Ghostty WIP branch and write failing Zig tests**
+
+Create `codex/viewport-text-snapshot`. Add core tests proving only viewport rows are returned, alternate-screen content is used while active, and selection plus scroll state are unchanged. Extend the C ABI declaration test for the new export.
+
+- [ ] **Step 2: Run focused Zig tests and verify RED**
+
+Run:
+
+```bash
+zig build test -Dtest-filter='TerminalSurface viewport text'
+```
+
+Expected: failure because `viewportText` and the C export do not exist.
+
+- [ ] **Step 3: Implement the locked, non-mutating snapshot**
+
+Lock the surface mutex, call the terminal viewport dump allocator, unlock, and return owned UTF-8 bytes. Add the C export using the same result/error mapping and allocator/free contract as selection text. Document visible-viewport scope and ownership in `ghostty.h`.
+
+- [ ] **Step 4: Format and run Ghostty verification**
+
+Run:
+
+```bash
+zig fmt src/renderer/TerminalSurface.zig src/renderer/TerminalSurfaceC.zig
+zig build test -Dtest-filter='TerminalSurface viewport text'
+zig build test -Demit-macos-app=false
+```
+
+Confirm all commands exit zero.
+
+- [ ] **Step 5: Commit in the Ghostty fork**
+
+Commit only the three API files with a detailed message covering snapshot scope, mutation guarantees, and ownership.
+
+### Task 8: Remux Viewport Snapshot Wrapper and Search Projection
+
+**Files:**
+- Modify: `RemuxApp/Sources/Ghostty/GhosttyKitControlSurface.swift`
+- Modify: `RemuxApp/Sources/Terminal/TmuxTerminalSession.swift`
+- Modify: `RemuxApp/Sources/Terminal/TmuxTerminalScreenAdapter.swift`
+- Create: `RemuxApp/Sources/Domain/TerminalViewportSnapshot.swift`
+- Create: `RemuxApp/Tests/TerminalViewportSnapshotTests.swift`
+
+**Interfaces:**
+- Consumes: `ghostty_terminal_surface_read_viewport`
+- Produces: `GhosttyKitControlSurface.visibleText() -> String?`
+- Produces: `TerminalViewportSnapshot` containing workspace/server/window/pane identity and text
+- Produces: adapter async snapshot enumeration that tolerates per-surface failure
+
+- [ ] **Step 1: Write failing projection tests**
+
+Use real adapter fixtures with multiple retained panes and assert exact metadata, all-pane enumeration, omission of a failed/disappeared surface, and no all-or-nothing failure.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run `TerminalViewportSnapshotTests`; expect missing snapshot API.
+
+- [ ] **Step 3: Build and install the forked XCFramework**
+
+Build with:
+
+```bash
+GHOSTTY_SOURCE_DIR=/Users/jesse/Documents/remux-ghostty scripts/build_release_ghosttykit.sh
+```
+
+Verify the generated header contains `ghostty_terminal_surface_read_viewport`, preserve a recoverable copy of the prior pinned framework, and replace the explicit framework at `/Users/jesse/Documents/ghostty-remux-upstream-rebuild/macos/GhosttyKit.xcframework`.
+
+- [ ] **Step 4: Implement the Swift wrapper and retained-surface projection**
+
+Decode and free the returned text immediately. Enumerate the existing `surfacesByPaneID` under tmux-session ownership and join topology/identity metadata in the adapter; never issue `capture-pane` or reconstruct terminal state from transport bytes.
+
+- [ ] **Step 5: Run focused tests, build Remux, and commit**
+
+Commit the Remux wrapper, projection, tests, and updated pinned framework together so the checkout remains buildable.
+
+### Task 9: Command Palette Filtering and Search Engine
+
+**Files:**
+- Create: `RemuxApp/Sources/App/CommandPaletteModel.swift`
+- Create: `RemuxApp/Sources/App/CommandPaletteSearch.swift`
+- Create: `RemuxApp/Tests/CommandPaletteModelTests.swift`
+
+**Interfaces:**
+- Consumes: hosts, route-aware commands, active-session snapshot providers
+- Produces: `CommandPaletteItem` command and text-result cases
+- Produces: debounced `setQuery(_:)`, cancellation on replacement/close, and `select(_:)`
+
+- [ ] **Step 1: Write failing palette-model tests**
+
+Assert empty-query action inventory, case-insensitive command filtering, case-insensitive visible-line matching, snippet and session/host/window/pane metadata, debounce replacement, close cancellation, and omission of failed surfaces.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run `CommandPaletteModelTests`; expect missing model symbols.
+
+- [ ] **Step 3: Implement command inventory and pure line matching**
+
+Include `Add Connection`, `New Session on <host>` for each defined host, and currently available navigation/overlay commands. Search snapshots only for non-empty queries and construct short matching-line snippets without mutating surface state.
+
+- [ ] **Step 4: Implement one cancellable debounce task**
+
+On each query change cancel the previous task, wait the chosen short interval, snapshot all current providers, and publish only if the task/query generation is still current. Cancel and discard results when closed.
+
+- [ ] **Step 5: Run focused tests and commit**
+
+Commit model/search behavior and tests.
+
+### Task 10: Global Command Palette UI and Selection Routing
+
+**Files:**
+- Create: `RemuxApp/Sources/App/CommandPaletteView.swift`
+- Modify: `RemuxApp/Sources/App/RootView.swift`
+- Modify: `RemuxApp/Sources/Terminal/GhosttySurfaceScreen.swift`
+- Modify: `RemuxApp/UITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+- Consumes: `CommandPaletteModel`, root model methods, terminal focus methods
+- Produces: global overlay available on Home and terminal routes
+
+- [ ] **Step 1: Write failing routing tests for palette selections**
+
+Assert Add Connection invokes `beginNewServer`, New Session preselects the chosen host through `beginNewWorkspace(for:)`, and a text result closes the palette before selecting workspace, window, and pane.
+
+- [ ] **Step 2: Run routing tests and verify RED**
+
+Confirm failure due to missing palette selection routing.
+
+- [ ] **Step 3: Implement a focused SwiftUI palette overlay**
+
+Present a searchable overlay from `RemuxWorkspaceShell`, keep the existing saved-command `ShortcutPalette` untouched, show command and text-result sections with disabled unavailable actions, and provide stable accessibility identifiers.
+
+- [ ] **Step 4: Route exact search results**
+
+Call `showActiveSession`, then `focusTmuxTopLevel`, then `focusTmuxPane` using the result identities. If the target disappeared, dismiss without crashing or redirecting to an arbitrary surface.
+
+- [ ] **Step 5: Add and run UI tests**
+
+Cover Command-K from Home and terminal, Add Connection, preselected New Session, existing windows/panes/attachments via configured commands, command filtering, and exact text-result routing with deterministic fixtures.
+
+- [ ] **Step 6: Commit**
+
+Commit the global palette UI, selection routing, and UI tests.
+
+### Task 11: Full Verification and Acceptance Record
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md` only if implementation evidence reveals a genuine contract correction
+
+**Interfaces:**
+- Consumes: all prior tasks
+- Produces: fresh automated and rendered evidence; explicitly leaves the physical-device gate open if no iPad is attached
+
+- [ ] **Step 1: Regenerate and inspect**
+
+Run `xcodegen generate`, `git diff --check`, and inspect both repositories' status/diffs to ensure unrelated `.worktrees` remain untouched and no generated or backup debris is staged.
+
+- [ ] **Step 2: Run focused unit tests**
+
+Run all new test classes in one fresh `xcodebuild test` invocation and record test counts and failures.
+
+- [ ] **Step 3: Run the full Remux simulator suite**
+
+Run:
+
+```bash
+xcodebuild test -project Remux.xcodeproj -scheme RemuxApp -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4)'
+```
+
+Read the complete result and do not infer full-suite success from focused tests.
+
+- [ ] **Step 4: Run release builds and Ghostty verification**
+
+Run the Remux Release configuration build plus fresh `zig build test -Demit-macos-app=false` in the fork.
+
+- [ ] **Step 5: Capture rendered simulator evidence**
+
+Using the deterministic physical-keyboard override, capture Home palette, terminal palette, chrome hidden, and chrome revealed states. Verify from frames or accessibility geometry that the terminal viewport is identical between hidden and revealed floating-bar states.
+
+- [ ] **Step 6: Review every design requirement**
+
+Check each design section against code, focused tests, full-suite output, and rendered evidence. State explicitly that physical keyboard connection delivery and Command-H priority still require an attached iPad unless performed on one.
+
+- [ ] **Step 7: Commit any final test/evidence-only corrections**
+
+Run the relevant failing test before each correction, re-run full verification, then make a final detailed commit without staging the pre-existing `.worktrees`.

--- a/docs/superpowers/plans/2026-07-27-command-palette-spacing-and-typography.md
+++ b/docs/superpowers/plans/2026-07-27-command-palette-spacing-and-typography.md
@@ -1,0 +1,353 @@
+# Command Palette Spacing and Typography Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply the approved Balanced spacing and Dynamic Type treatment to the
+floating Command-K palette without changing its keyboard or search behavior.
+
+**Architecture:** Keep `CommandPaletteView` as the palette's single view
+composition. Add named layout values beside its existing row-height values,
+apply the internal inset and clipping with SwiftUI modifiers, and configure the
+specialized UIKit search field with a semantic font in its initializer. Extend
+the existing unit and UI tests so the visual contract is checked through the
+real field and rendered palette geometry.
+
+**Tech Stack:** Swift 6, SwiftUI, UIKit, XCTest, XCUITest, XcodeBuildMCP,
+Xcode 26.
+
+## Global Constraints
+
+- The palette remains centered and its width remains capped at 620 points.
+- The outer card remains at least 20 points from every edge of its presentation
+  container.
+- The outer card has a 10-point inset around the grouped search and result
+  surfaces.
+- The inner group uses a 12-point continuous corner radius.
+- The outer card keeps its existing opaque background, 18-point corner radius,
+  border, shadow, and Remux semantic colors.
+- Result titles use SwiftUI's dynamic `subheadline` style.
+- The UIKit search field uses `UIFont.preferredFont(forTextStyle: .footnote)`
+  and adjusts for Dynamic Type.
+- Search and result row heights remain exactly 44 and 56 points.
+- Search focus, Escape dismissal, arrow selection, Return activation, result
+  filtering, and terminal-focus restoration do not change.
+- Do not modify or stage `.superpowers/brainstorm/` or the four unrelated
+  `.worktrees/` directories.
+
+---
+
+### Task 1: Apply the Balanced palette presentation
+
+**Files:**
+
+- Modify: `RemuxApp/Sources/App/CommandPaletteView.swift:4-223`
+- Modify: `RemuxAppTests/CommandPaletteSearchTests.swift:148-190`
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift:146-181`
+
+**Interfaces:**
+
+- Consumes: `LibraryHomePalette` semantic colors,
+  `CommandPaletteLayout.resultAreaHeight(for:)`, and the established
+  `CommandPaletteTextField` responder behavior.
+- Produces: `CommandPaletteLayout.screenMargin`,
+  `CommandPaletteLayout.cardInset`,
+  `CommandPaletteLayout.innerCornerRadius`, a compact Dynamic Type font on
+  `CommandPaletteTextField`, and rendered card geometry with the approved
+  margins.
+
+- [ ] **Step 1: Add unit tests for the spacing and search-field type contracts**
+
+Add these tests beside
+`testFloatingLayoutCapsAtSixRowsAndKeepsEmptyStateCompact()` in
+`RemuxAppTests/CommandPaletteSearchTests.swift`:
+
+```swift
+func testFloatingLayoutUsesBalancedSpacing() {
+    XCTAssertEqual(CommandPaletteLayout.screenMargin, 20)
+    XCTAssertEqual(CommandPaletteLayout.cardInset, 10)
+    XCTAssertEqual(CommandPaletteLayout.innerCornerRadius, 12)
+}
+
+@MainActor
+func testSearchFieldUsesCompactDynamicTypeFont() {
+    let field = CommandPaletteTextField()
+    let expected = UIFont.preferredFont(forTextStyle: .footnote)
+
+    XCTAssertEqual(field.font?.pointSize, expected.pointSize)
+    XCTAssertEqual(
+        field.font?.fontDescriptor.object(forKey: .textStyle) as? String,
+        UIFont.TextStyle.footnote.rawValue
+    )
+    XCTAssertTrue(field.adjustsFontForContentSizeCategory)
+}
+```
+
+The spacing test catches a regression to the former 16-point screen padding or
+the loss of the approved internal grouping. The field test catches a return to
+the default body-sized UIKit font, a fixed 13-point font, or disabled Dynamic
+Type scaling.
+
+- [ ] **Step 2: Run the unit tests and verify RED**
+
+With the XcodeBuildMCP defaults set to project `Remux.xcodeproj`, scheme
+`Remux`, and simulator `9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2`, run:
+
+```text
+test_sim(
+  extraArgs: ["-only-testing:RemuxTests/CommandPaletteSearchTests"],
+  progress: false
+)
+```
+
+Expected: build failure because `screenMargin`, `cardInset`, and
+`innerCornerRadius` do not exist. If compilation is temporarily limited to the
+font test, it fails because the field still uses UIKit's default body-sized
+font.
+
+- [ ] **Step 3: Add a rendered-geometry UI assertion**
+
+In
+`testCommandPaletteSupportsKeyboardSelectionAndDismissal()`, immediately after
+the palette appears, add:
+
+```swift
+let appFrame = app.frame
+let minimumScreenMargin: CGFloat = 19.5
+XCTAssertGreaterThanOrEqual(
+    palette.frame.minX - appFrame.minX,
+    minimumScreenMargin
+)
+XCTAssertGreaterThanOrEqual(
+    appFrame.maxX - palette.frame.maxX,
+    minimumScreenMargin
+)
+XCTAssertGreaterThanOrEqual(
+    palette.frame.minY - appFrame.minY,
+    minimumScreenMargin
+)
+XCTAssertGreaterThanOrEqual(
+    appFrame.maxY - palette.frame.maxY,
+    minimumScreenMargin
+)
+```
+
+The half-point tolerance allows pixel alignment while still rejecting the
+existing 16-point treatment. The assertion exercises the rendered card rather
+than only the named value.
+
+- [ ] **Step 4: Run the UI test and verify RED**
+
+Set the XcodeBuildMCP scheme to `RemuxUIOnly` and run:
+
+```text
+test_sim(
+  extraArgs: [
+    "-only-testing:RemuxUITests/RemuxAppUITests/testCommandPaletteSupportsKeyboardSelectionAndDismissal"
+  ],
+  progress: false
+)
+```
+
+Expected: FAIL because at least one horizontal palette margin is below
+19.5 points under the current 16-point treatment. Restore the scheme to `Remux`
+after recording the expected failure.
+
+- [ ] **Step 5: Add the minimal layout and typography implementation**
+
+Add the approved geometry beside the existing values in
+`CommandPaletteLayout`:
+
+```swift
+static let screenMargin: CGFloat = 20
+static let cardInset: CGFloat = 10
+static let innerCornerRadius: CGFloat = 12
+```
+
+Give the result title its semantic style:
+
+```swift
+Text(item.title)
+    .font(.subheadline)
+    .lineLimit(1)
+```
+
+Clip the existing search/results stack and insert the internal space before
+the outer card's frame and background:
+
+```swift
+.clipShape(
+    RoundedRectangle(
+        cornerRadius: CommandPaletteLayout.innerCornerRadius,
+        style: .continuous
+    )
+)
+.padding(CommandPaletteLayout.cardInset)
+.frame(maxWidth: 620)
+```
+
+Keep the existing `fixedSize`, outer background, stroke, and shadow modifiers.
+Apply the accessibility container and `command-palette` identifier to the card,
+then replace the final screen padding with:
+
+```swift
+.padding(CommandPaletteLayout.screenMargin)
+```
+
+The accessibility identifier must continue containing the independently
+addressable `command-palette.search` text field. Do not add an intermediate
+accessibility container for the clipped group.
+
+Configure the specialized field in `CommandPaletteTextField.init(frame:)`
+before installing its delegate:
+
+```swift
+font = UIFont.preferredFont(forTextStyle: .footnote)
+adjustsFontForContentSizeCategory = true
+```
+
+Do not change palette state, search, responder, or command-routing code.
+
+- [ ] **Step 6: Run the unit tests and verify GREEN**
+
+Set the XcodeBuildMCP scheme to `Remux` and run the focused unit class:
+
+```text
+test_sim(
+  extraArgs: ["-only-testing:RemuxTests/CommandPaletteSearchTests"],
+  progress: false
+)
+```
+
+Expected: all palette unit tests pass with no failures.
+
+- [ ] **Step 7: Run the focused UI tests and verify GREEN**
+
+Set the XcodeBuildMCP scheme to `RemuxUIOnly` and run:
+
+```text
+test_sim(
+  extraArgs: [
+    "-only-testing:RemuxUITests/RemuxAppUITests/testCommandPaletteSupportsKeyboardSelectionAndDismissal",
+    "-only-testing:RemuxUITests/RemuxAppUITests/testCommandPaletteReceivesImmediateTyping"
+  ],
+  progress: false
+)
+```
+
+Expected: both tests pass. The geometry assertion proves the external margin,
+and the immediate-typing test proves the visual wrapper did not disturb field
+focus.
+
+- [ ] **Step 8: Inspect and commit the implementation**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff -- RemuxApp/Sources/App/CommandPaletteView.swift \
+  RemuxAppTests/CommandPaletteSearchTests.swift \
+  RemuxAppUITests/RemuxAppUITests.swift
+```
+
+Confirm only the three intended files changed. Then commit:
+
+```bash
+git add RemuxApp/Sources/App/CommandPaletteView.swift \
+  RemuxAppTests/CommandPaletteSearchTests.swift \
+  RemuxAppUITests/RemuxAppUITests.swift
+git commit -m "Refine command palette spacing and type" \
+  -m "Apply the approved Balanced palette treatment with a 20-point presentation margin, a 10-point inset around a clipped grouped surface, and smaller semantic Dynamic Type styles. Preserve the established row heights, colors, keyboard focus, and selection behavior." \
+  -m "Cover the named layout contract, the real UIKit field configuration, rendered screen margins, and immediate keyboard focus."
+```
+
+### Task 2: Verify and install the finished build
+
+**Files:**
+
+- Verify: `RemuxApp/Sources/App/CommandPaletteView.swift`
+- Verify: `RemuxAppTests/CommandPaletteSearchTests.swift`
+- Verify: `RemuxAppUITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+
+- Consumes: the committed Task 1 implementation and the existing signed iPhone
+  build configuration.
+- Produces: full automated evidence plus an installed device build ready for
+  Jesse's visual and physical-keyboard acceptance.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Set the XcodeBuildMCP scheme to `Remux` and run `test_sim(progress: false)`
+without `only-testing` arguments.
+
+Expected: every unit test passes. Record counts, failures, and warnings
+separately.
+
+- [ ] **Step 2: Run the full non-live UI suite**
+
+Set the XcodeBuildMCP scheme to `RemuxUIOnly` and run
+`test_sim(progress: false)` without `only-testing` arguments.
+
+Expected: all non-live UI tests pass and configured live tests skip. If
+XCUITest reports an infrastructure timeout, inspect the result and rerun the
+affected test individually; report both outcomes rather than replacing the
+original result.
+
+- [ ] **Step 3: Inspect the final branch**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline --decorate -10
+```
+
+Expected: no tracked changes remain. The brainstorm artifacts and four
+unrelated worktrees remain untracked and untouched.
+
+- [ ] **Step 4: Build, sign, install, and launch on Jesse's iPhone**
+
+Use the existing device configuration:
+
+```bash
+xcodebuild build -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -configuration Debug \
+  -destination 'id=6A5C05AA-0987-5ECC-9937-7E3073636F1D' \
+  -derivedDataPath .local/device-build \
+  DEVELOPMENT_TEAM=87WJ58S66M \
+  PRODUCT_BUNDLE_IDENTIFIER=com.fsck.dev.remux.app \
+  CODE_SIGN_STYLE=Automatic \
+  CODE_SIGN_IDENTITY='Apple Development'
+
+codesign --verify --deep --strict --verbose=2 \
+  .local/device-build/Build/Products/Debug-iphoneos/Remux.app
+
+xcrun devicectl device install app \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  .local/device-build/Build/Products/Debug-iphoneos/Remux.app
+
+xcrun devicectl device process launch \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  com.fsck.dev.remux.app
+```
+
+Expected: the signed app verifies, installs, and launches on the unlocked
+iPhone.
+
+- [ ] **Step 5: Request hardware acceptance**
+
+Ask Jesse to open Command-K and confirm:
+
+- the palette reads as a floating card with visible space around and inside it;
+- the search input and result titles are smaller but legible;
+- typing still lands in the search field immediately;
+- arrows, Return, and Escape still work.
+
+Do not open a pull request until Jesse accepts this exact installed build.

--- a/docs/superpowers/plans/2026-07-27-floating-command-palette-and-new-remote-window.md
+++ b/docs/superpowers/plans/2026-07-27-floating-command-palette-and-new-remote-window.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - Keep the existing opaque Remux palette surfaces, separator, corner treatment, shadow, and dimming scrim.
-- Cap the floating card at 620 points wide with at least 16-point screen margins.
+- Cap the floating card at 620 points wide with at least 20-point screen margins.
 - Keep the search field to one intrinsic single-line row; it must never flex vertically.
 - Show at most six result rows before scrolling.
 - Establish the first enabled selection synchronously before the field can receive a key.
@@ -694,7 +694,8 @@ Remove `.frame(maxWidth: 620, maxHeight: 520)` and use:
 ```
 
 Keep the existing rounded opaque background, separator stroke, shadow, and
-outer `.padding(16)` so the card remains centered with required margins.
+outer `.padding(CommandPaletteLayout.screenMargin)` with a 20-point value so
+the card remains centered with the approved margins.
 
 - [ ] **Step 7: Publish priority arrow commands alongside Return and Escape**
 

--- a/docs/superpowers/plans/2026-07-27-floating-command-palette-and-new-remote-window.md
+++ b/docs/superpowers/plans/2026-07-27-floating-command-palette-and-new-remote-window.md
@@ -1,0 +1,951 @@
+# Floating Command Palette and New Remote Window Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Command-K a compact, immediately keyboard-operable floating chooser and add configurable Command-N creation of one tmux window in the currently open remote session.
+
+**Architecture:** Extend the existing `AppKeyboardCommand` registry and terminal-scoped routing so Command-N reaches the same topology action used by the window chooser's `New Window` button. Keep palette query/selection as local value state initialized synchronously, and give the UIKit search field priority `UIKeyCommand` entries for Up, Down, Return, and Escape. Drive the floating card's bounded height from small, pure layout metrics rather than another presentation controller.
+
+**Tech Stack:** Swift 6, SwiftUI, UIKit responder-chain key commands, XCTest, XCUITest, the existing tmux/Ghostty terminal adapter, and the existing live-SSH cleanup harness.
+
+## Global Constraints
+
+- Keep the existing opaque Remux palette surfaces, separator, corner treatment, shadow, and dimming scrim.
+- Cap the floating card at 620 points wide with at least 16-point screen margins.
+- Keep the search field to one intrinsic single-line row; it must never flex vertically.
+- Show at most six result rows before scrolling.
+- Establish the first enabled selection synchronously before the field can receive a key.
+- Up and Down select enabled results before any query is typed; Return invokes; Escape dismisses without reaching the terminal.
+- Command-N defaults to `Command-N`, remains configurable, and is terminal-scoped.
+- Command-N creates exactly one tmux window in the existing ready remote session by reusing the current `New Window` topology action.
+- Command-N must not create a pane, Remux connection, or saved Remux session.
+- Do not add a settings migration or any backward-compatibility path.
+- Do not add dependencies or replace the existing window or pane chooser.
+- Keep simulator, live-SSH, and physical-device evidence separate.
+- Do not open a pull request until Jesse accepts the behavior on a real device with a physical keyboard.
+
+---
+
+## File Map
+
+- `RemuxApp/Sources/Domain/AppKeyboardCommand.swift`
+  - Owns the new command identifier, display title, and terminal scope.
+- `RemuxApp/Sources/Domain/KeyboardSettings.swift`
+  - Owns the fresh-install Command-N default.
+- `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift`
+  - Enforces ready-terminal availability before handing Command-N to the selected terminal.
+- `RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift`
+  - Maps the terminal command to the existing tmux-window topology action and shares that action with the chooser button.
+- `RemuxApp/Sources/App/CommandPaletteSearch.swift`
+  - Owns testable palette result and selection value state.
+- `RemuxApp/Sources/App/CommandPaletteView.swift`
+  - Owns compact card geometry, synchronous state construction, and priority navigation/dismissal key commands.
+- `RemuxAppTests/KeyboardSettingsTests.swift`
+  - Covers the new default and existing validation contracts.
+- `RemuxAppTests/AppKeyboardCommandRouterTests.swift`
+  - Covers terminal availability and terminal-surface command mapping.
+- `RemuxAppTests/GhosttyTerminalResponderViewTests.swift`
+  - Covers publication and dispatch of the configured Command-N key command.
+- `RemuxAppTests/CommandPaletteSearchTests.swift`
+  - Covers synchronous initial selection, movement, compact sizing, and actual `UIKeyCommand` actions.
+- `RemuxAppUITests/RemuxAppUITests.swift`
+  - Covers compact palette geometry, pre-query selection/navigation, and live remote-window creation.
+
+---
+
+### Task 1: Register and Route Command-N
+
+**Files:**
+- Modify: `RemuxApp/Sources/Domain/AppKeyboardCommand.swift:3-51`
+- Modify: `RemuxApp/Sources/Domain/KeyboardSettings.swift:28-67`
+- Modify: `RemuxApp/Sources/App/AppKeyboardCommandRouter.swift:13-49`
+- Test: `RemuxAppTests/KeyboardSettingsTests.swift:5-52`
+- Test: `RemuxAppTests/AppKeyboardCommandRouterTests.swift:5-124`
+- Test: `RemuxAppTests/GhosttyTerminalResponderViewTests.swift:70-118`
+
+**Interfaces:**
+- Consumes: existing `KeyboardKeyBinding`, `KeyboardKeyModifiers`, and `AppKeyboardCommandRouteContext`.
+- Produces: `AppKeyboardCommand.newWindow`, display title `"New Window"`, fresh default `Command-N`, and `.terminal(.newWindow)` routing for a ready selected terminal.
+
+- [ ] **Step 1: Write failing default and availability tests**
+
+Add this assertion to
+`KeyboardSettingsTests.testDefaultsAssignEveryDocumentedCommand()`:
+
+```swift
+XCTAssertEqual(
+    settings.binding(for: .newWindow),
+    KeyboardKeyBinding(input: "n", modifiers: [.command])
+)
+```
+
+Extend `AppKeyboardCommandRouterTests.testSelectedTerminalCommandsRouteLocally()`:
+
+```swift
+XCTAssertEqual(
+    AppKeyboardCommandRouter.route(.newWindow, in: context),
+    .terminal(.newWindow)
+)
+```
+
+Extend
+`AppKeyboardCommandRouterTests.testDisconnectedSelectedTerminalDisablesTerminalCommands()`:
+
+```swift
+XCTAssertEqual(
+    AppKeyboardCommandRouter.route(.newWindow, in: context),
+    .unavailable
+)
+```
+
+Add a focused responder assertion to
+`GhosttyTerminalResponderViewTests.testResponderPublishesPriorityAppKeyCommandsAndDispatchesSelection()` after obtaining `commands`:
+
+```swift
+let newWindow = try! XCTUnwrap(
+    commands.first {
+        $0.input == "n"
+            && $0.modifierFlags == [.command]
+    }
+)
+view.perform(newWindow.action, with: newWindow)
+XCTAssertEqual(receivedCommands.last, .newWindow)
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/KeyboardSettingsTests \
+  -only-testing:RemuxTests/AppKeyboardCommandRouterTests \
+  -only-testing:RemuxTests/GhosttyTerminalResponderViewTests
+```
+
+Expected: compilation fails because `AppKeyboardCommand` has no member
+`newWindow`. This is the intended RED failure.
+
+- [ ] **Step 3: Add the command and its fresh default**
+
+Add `newWindow` next to the existing window commands in
+`AppKeyboardCommand.swift`:
+
+```swift
+enum AppKeyboardCommand: String, Codable, CaseIterable, Identifiable, Sendable {
+    case previousWindow
+    case nextWindow
+    case previousSession
+    case nextSession
+    case home
+    case windows
+    case newWindow
+    case panes
+    case attachments
+    case increaseFontSize
+    case decreaseFontSize
+    case commandPalette
+```
+
+Add the display title:
+
+```swift
+case .newWindow:
+    "New Window"
+```
+
+Keep it terminal-scoped:
+
+```swift
+case .previousWindow, .nextWindow, .windows, .newWindow, .panes, .attachments:
+    true
+```
+
+Add the default in `KeyboardSettings.default.bindings`:
+
+```swift
+.newWindow: KeyboardKeyBinding(input: "n", modifiers: [.command]),
+```
+
+Do not change decoding, repository loading, or `validated()`. The user
+explicitly rejected a migration.
+
+- [ ] **Step 4: Route the command only for a ready selected terminal**
+
+Add `.newWindow` to the terminal-scoped branch in
+`AppKeyboardCommandRouter.route(_:in:)`:
+
+```swift
+case .previousWindow, .nextWindow, .windows, .newWindow, .panes, .attachments:
+    guard
+        context.selectedSessionID != nil,
+        context.isSelectedTerminalReady
+    else {
+        return .unavailable
+    }
+    return .terminal(command)
+```
+
+No separate settings or palette code is required: both enumerate
+`AppKeyboardCommand.allCases`.
+
+- [ ] **Step 5: Run the focused tests and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all `KeyboardSettingsTests`, `AppKeyboardCommandRouterTests`, and
+`GhosttyTerminalResponderViewTests` pass.
+
+- [ ] **Step 6: Commit**
+
+Immediately inspect status, then stage only the task files:
+
+```bash
+git status --short
+git add \
+  RemuxApp/Sources/Domain/AppKeyboardCommand.swift \
+  RemuxApp/Sources/Domain/KeyboardSettings.swift \
+  RemuxApp/Sources/App/AppKeyboardCommandRouter.swift \
+  RemuxAppTests/KeyboardSettingsTests.swift \
+  RemuxAppTests/AppKeyboardCommandRouterTests.swift \
+  RemuxAppTests/GhosttyTerminalResponderViewTests.swift
+git commit -m "Add configurable Command-N remote windows" \
+  -m "Register New Window as a terminal-scoped app command with a fresh Command-N default. Route it only when the selected remote terminal is ready, and cover resolver publication and unavailable states without adding a settings migration."
+```
+
+---
+
+### Task 2: Reuse the Existing New Window Topology Action
+
+**Files:**
+- Modify: `RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift:719-735,2120-2135`
+- Test: `RemuxAppTests/AppKeyboardCommandRouterTests.swift`
+
+**Interfaces:**
+- Consumes: `AppKeyboardCommand.newWindow`,
+  `GhosttyTmuxTopologyActionInteractionEffect`,
+  `model.createTmuxWindowInteractionEffect()`, and
+  `model.createTmuxWindow()`.
+- Produces: `GhosttySurfaceKeyboardCommandRoute.createWindow`,
+  `GhosttySurfaceKeyboardCommandRouter.route(_:)`, and one shared
+  `createTmuxWindow(event:)` path used by both keyboard and chooser actions.
+
+- [ ] **Step 1: Write a failing terminal-surface mapping test**
+
+Add this test to `AppKeyboardCommandRouterTests`:
+
+```swift
+func testTerminalSurfaceMapsNewWindowToTopologyCreation() {
+    XCTAssertEqual(
+        GhosttySurfaceKeyboardCommandRouter.route(.newWindow),
+        .createWindow
+    )
+    XCTAssertEqual(
+        GhosttySurfaceKeyboardCommandRouter.route(.commandPalette),
+        .forward(.commandPalette)
+    )
+}
+```
+
+- [ ] **Step 2: Run the mapping test and verify RED**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/AppKeyboardCommandRouterTests/testTerminalSurfaceMapsNewWindowToTopologyCreation
+```
+
+Expected: compilation fails because
+`GhosttySurfaceKeyboardCommandRouter` does not exist.
+
+- [ ] **Step 3: Add the testable terminal-surface route**
+
+Add these internal types in `GhosttySurfaceScreen.swift`, immediately before
+`GhosttySurfaceScreen`:
+
+```swift
+enum GhosttySurfaceKeyboardCommandRoute: Equatable {
+    case previousWindow
+    case nextWindow
+    case showWindows
+    case createWindow
+    case showPanes
+    case toggleAttachments
+    case forward(AppKeyboardCommand)
+}
+
+enum GhosttySurfaceKeyboardCommandRouter {
+    static func route(
+        _ command: AppKeyboardCommand
+    ) -> GhosttySurfaceKeyboardCommandRoute {
+        switch command {
+        case .previousWindow:
+            .previousWindow
+        case .nextWindow:
+            .nextWindow
+        case .windows:
+            .showWindows
+        case .newWindow:
+            .createWindow
+        case .panes:
+            .showPanes
+        case .attachments:
+            .toggleAttachments
+        case .previousSession, .nextSession, .home, .commandPalette,
+             .increaseFontSize, .decreaseFontSize:
+            .forward(command)
+        }
+    }
+}
+```
+
+This route is small domain behavior, not a view-testing shim. It makes the
+terminal command/effect mapping independently testable and keeps the view's
+dispatch switch exhaustive.
+
+- [ ] **Step 4: Dispatch through the route and shared action**
+
+Replace `performAppKeyboardCommand(_:)` with:
+
+```swift
+private func performAppKeyboardCommand(_ command: AppKeyboardCommand) {
+    switch GhosttySurfaceKeyboardCommandRouter.route(command) {
+    case .previousWindow:
+        handleWindowSwipe(.previous)
+    case .nextWindow:
+        handleWindowSwipe(.next)
+    case .showWindows:
+        showWindows()
+    case .createWindow:
+        createTmuxWindow(event: "ui.keyCommand.newWindow")
+    case .showPanes:
+        showPanes()
+    case .toggleAttachments:
+        toggleAttachmentTray()
+    case .forward(let command):
+        onAppKeyboardCommand(command)
+    }
+}
+```
+
+Extract the current chooser behavior into a shared method:
+
+```swift
+private func createTmuxWindow(event: String) {
+    GhosttyRuntimeTrace.flowBegin(
+        "tmux.newWindow",
+        event: event,
+        fields: [
+            "topLevelsBefore": "\(model.terminalInteractionProjection.windowCount)",
+            "workspaceID": presentation.workspaceID.uuidString,
+        ]
+    )
+    let effect = model.createTmuxWindowInteractionEffect()
+    performTopologyActionInteraction(effect) {
+        model.createTmuxWindow()
+    }
+}
+
+private func createTmuxWindowFromSelectionSheet() {
+    createTmuxWindow(event: "ui.tap.newWindow")
+}
+```
+
+The existing `GhosttyWindowSelectionSheet(onCreateWindow:)` call remains
+unchanged and therefore uses the same topology interaction effect and model
+action as Command-N.
+
+- [ ] **Step 5: Run focused routing and topology tests**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/AppKeyboardCommandRouterTests \
+  -only-testing:RemuxTests/GhosttyTerminalInputCoordinatorTests \
+  -only-testing:RemuxTests/TmuxSessionControllerClientSizeTests
+```
+
+Expected: all selected tests pass, including the new `.createWindow` mapping.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git status --short
+git add \
+  RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift \
+  RemuxAppTests/AppKeyboardCommandRouterTests.swift
+git commit -m "Route Command-N through tmux New Window" \
+  -m "Map the terminal-scoped New Window command to the same topology interaction and model action used by the existing chooser button. Keep tracing source-specific while sharing focus reconciliation and creation behavior."
+```
+
+---
+
+### Task 3: Make the Palette Compact and Immediately Keyboard-Operable
+
+**Files:**
+- Modify: `RemuxApp/Sources/App/CommandPaletteSearch.swift:29-64`
+- Modify: `RemuxApp/Sources/App/CommandPaletteView.swift:1-238`
+- Test: `RemuxAppTests/CommandPaletteSearchTests.swift:70-194`
+- Test: `RemuxAppUITests/RemuxAppUITests.swift:143-176`
+
+**Interfaces:**
+- Consumes: `CommandPaletteItem`,
+  `CommandPaletteSelection.initialID(in:)`,
+  `CommandPaletteSelection.moving(from:direction:in:)`, and the existing Remux
+  palette colors.
+- Produces: `CommandPaletteState`,
+  `CommandPaletteLayout.maximumVisibleResultCount`,
+  `CommandPaletteLayout.resultAreaHeight(for:)`, synchronous view state,
+  and priority Up/Down/Return/Escape `UIKeyCommand` entries.
+
+- [ ] **Step 1: Write failing synchronous-state tests**
+
+Add these tests to `CommandPaletteSearchTests`:
+
+```swift
+func testStateStartsWithCommandsAndFirstEnabledSelection() {
+    let disabled = item(id: "disabled", isEnabled: false)
+    let first = item(id: "first")
+    let state = CommandPaletteState(results: [disabled, first])
+
+    XCTAssertEqual(state.results, [disabled, first])
+    XCTAssertEqual(state.selectedResultID, first.id)
+    XCTAssertEqual(state.selectedResult, first)
+}
+
+func testStateCanMoveBeforeAQueryAndResetsWhenResultsChange() {
+    let first = item(id: "first")
+    let second = item(id: "second")
+    var state = CommandPaletteState(results: [first, second])
+
+    state.moveSelection(.next)
+    XCTAssertEqual(state.selectedResultID, second.id)
+
+    let replacement = item(id: "replacement")
+    state.replaceResults([replacement])
+    XCTAssertEqual(state.selectedResultID, replacement.id)
+}
+```
+
+- [ ] **Step 2: Write failing layout and priority-command tests**
+
+Add this layout test:
+
+```swift
+func testFloatingLayoutCapsAtSixRowsAndKeepsEmptyStateCompact() {
+    XCTAssertEqual(CommandPaletteLayout.inputRowHeight, 44)
+    XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 0), 120)
+    XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 1), 56)
+    XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 6), 336)
+    XCTAssertEqual(CommandPaletteLayout.resultAreaHeight(for: 9), 336)
+}
+```
+
+Replace the final key-command assertions in
+`testSearchFieldRoutesNavigationAndActivationKeysWithoutModifiers()` with:
+
+```swift
+XCTAssertEqual(
+    field.keyCommands?.compactMap(\.input),
+    [
+        UIKeyCommand.inputUpArrow,
+        UIKeyCommand.inputDownArrow,
+        "\r",
+        UIKeyCommand.inputEscape,
+    ]
+)
+XCTAssertTrue(
+    field.keyCommands?.allSatisfy(\.wantsPriorityOverSystemBehavior)
+        == true
+)
+```
+
+Add a separate test that invokes the real selectors rather than the raw helper:
+
+```swift
+@MainActor
+func testPriorityKeyCommandsMoveActivateAndDismiss() throws {
+    let field = CommandPaletteTextField()
+    var actions: [String] = []
+    field.onMoveSelection = {
+        switch $0 {
+        case .previous:
+            actions.append("previous")
+        case .next:
+            actions.append("next")
+        }
+    }
+    field.onActivateSelection = { actions.append("activate") }
+    field.onDismiss = { actions.append("dismiss") }
+
+    for input in [
+        UIKeyCommand.inputUpArrow,
+        UIKeyCommand.inputDownArrow,
+        "\r",
+        UIKeyCommand.inputEscape,
+    ] {
+        let command = try XCTUnwrap(
+            field.keyCommands?.first(where: { $0.input == input })
+        )
+        field.perform(command.action, with: command)
+    }
+
+    XCTAssertEqual(
+        actions,
+        ["previous", "next", "activate", "dismiss"]
+    )
+}
+```
+
+- [ ] **Step 3: Add the failing compact-geometry UI assertion**
+
+In
+`RemuxAppUITests.testCommandPaletteSupportsKeyboardSelectionAndDismissal()`,
+after the palette appears, add:
+
+```swift
+let search = app.textFields["command-palette.search"]
+XCTAssertTrue(search.waitForExistence(timeout: 2))
+XCTAssertLessThanOrEqual(search.frame.height, 44.5)
+XCTAssertLessThanOrEqual(
+    palette.frame.height,
+    430,
+    "The chooser should remain a compact floating card with six visible rows."
+)
+```
+
+Keep the existing first-result `.isSelected` assertion and unmodified
+Down-arrow action before any `typeText` call. Do not add an XCUITest Escape
+assertion: on this simulator XCUITest maps Escape to software-keyboard
+dismissal instead of a physical Escape event. The real selector test above and
+the device gate below cover that contract honestly.
+
+- [ ] **Step 4: Run the tests and verify RED**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxTests/CommandPaletteSearchTests
+```
+
+Expected: compilation fails because `CommandPaletteState` and
+`CommandPaletteLayout` do not exist. After adding only enough declarations to
+compile, the priority-command assertion must still fail because Up and Down are
+not yet published as priority commands.
+
+Run the UI test:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme RemuxUIOnly \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  -only-testing:RemuxUITests/RemuxAppUITests/testCommandPaletteSupportsKeyboardSelectionAndDismissal
+```
+
+Expected: FAIL because the current palette expands to its 520-point maximum
+rather than the new compact bound.
+
+- [ ] **Step 5: Add synchronous palette value state**
+
+Add this value type to `CommandPaletteSearch.swift`:
+
+```swift
+struct CommandPaletteState: Equatable {
+    private(set) var results: [CommandPaletteItem]
+    private(set) var selectedResultID: CommandPaletteItem.ID?
+
+    init(results: [CommandPaletteItem]) {
+        self.results = results
+        selectedResultID = CommandPaletteSelection.initialID(in: results)
+    }
+
+    var selectedResult: CommandPaletteItem? {
+        guard let selectedResultID else { return nil }
+        return results.first {
+            $0.id == selectedResultID && $0.isEnabled
+        }
+    }
+
+    mutating func replaceResults(_ newResults: [CommandPaletteItem]) {
+        results = newResults
+        selectedResultID = CommandPaletteSelection.initialID(in: newResults)
+    }
+
+    mutating func moveSelection(
+        _ direction: CommandPaletteSelectionDirection
+    ) {
+        selectedResultID = CommandPaletteSelection.moving(
+            from: selectedResultID,
+            direction: direction,
+            in: results
+        )
+    }
+}
+```
+
+In `CommandPaletteView`, replace the separate `results` and
+`selectedResultID` state with:
+
+```swift
+@State private var paletteState: CommandPaletteState
+```
+
+Add an explicit initializer that stores the closures and initializes state
+synchronously:
+
+```swift
+init(
+    commands: [CommandPaletteItem],
+    snapshots: @escaping () -> [TerminalViewportSnapshot],
+    onSelect: @escaping (CommandPaletteAction) -> Void,
+    onDismiss: @escaping () -> Void
+) {
+    self.commands = commands
+    self.snapshots = snapshots
+    self.onSelect = onSelect
+    self.onDismiss = onDismiss
+    _paletteState = State(
+        initialValue: CommandPaletteState(results: commands)
+    )
+}
+```
+
+Use `paletteState.results`, `paletteState.selectedResultID`,
+`paletteState.replaceResults(_:)`, `paletteState.moveSelection(_:)`, and
+`paletteState.selectedResult` throughout the view. Remove the `.task` that
+previously populated results after presentation.
+
+- [ ] **Step 6: Add compact, deterministic card metrics**
+
+Add this internal layout contract to `CommandPaletteView.swift`:
+
+```swift
+enum CommandPaletteLayout {
+    static let maximumVisibleResultCount = 6
+    static let inputRowHeight: CGFloat = 44
+    static let resultRowHeight: CGFloat = 56
+    static let emptyResultHeight: CGFloat = 120
+
+    static func resultAreaHeight(for resultCount: Int) -> CGFloat {
+        guard resultCount > 0 else { return emptyResultHeight }
+        return CGFloat(min(resultCount, maximumVisibleResultCount))
+            * resultRowHeight
+    }
+}
+```
+
+Change the input row from unrestricted `.padding()` to:
+
+```swift
+.padding(.horizontal, 12)
+.frame(height: CommandPaletteLayout.inputRowHeight)
+.background(LibraryHomePalette.rowSurface)
+```
+
+For each result button label, enforce one predictable row:
+
+```swift
+.frame(
+    maxWidth: .infinity,
+    minHeight: CommandPaletteLayout.resultRowHeight,
+    alignment: .leading
+)
+```
+
+Use zero vertical list insets so the pure metric matches rendering:
+
+```swift
+.listRowInsets(
+    EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+)
+```
+
+Give the list and empty state the bounded result-area height:
+
+```swift
+.frame(
+    height: CommandPaletteLayout.resultAreaHeight(
+        for: paletteState.results.count
+    )
+)
+```
+
+Remove `.frame(maxWidth: 620, maxHeight: 520)` and use:
+
+```swift
+.frame(maxWidth: 620)
+.fixedSize(horizontal: false, vertical: true)
+```
+
+Keep the existing rounded opaque background, separator stroke, shadow, and
+outer `.padding(16)` so the card remains centered with required margins.
+
+- [ ] **Step 7: Publish priority arrow commands alongside Return and Escape**
+
+Return these commands from `CommandPaletteTextField.keyCommands` in this order:
+
+```swift
+[
+    priorityKeyCommand(
+        input: UIKeyCommand.inputUpArrow,
+        action: #selector(selectPreviousResult)
+    ),
+    priorityKeyCommand(
+        input: UIKeyCommand.inputDownArrow,
+        action: #selector(selectNextResult)
+    ),
+    priorityKeyCommand(
+        input: "\r",
+        action: #selector(activateSelection)
+    ),
+    priorityKeyCommand(
+        input: UIKeyCommand.inputEscape,
+        action: #selector(dismissPalette)
+    ),
+]
+```
+
+Add the two selectors:
+
+```swift
+@objc
+private func selectPreviousResult() {
+    onMoveSelection?(.previous)
+}
+
+@objc
+private func selectNextResult() {
+    onMoveSelection?(.next)
+}
+```
+
+Keep `wantsPriorityOverSystemBehavior = true`. Apple documents that this
+reverses iOS 15+'s default text-input-first delivery order, which is required
+for arrows to select results rather than move the text cursor:
+`https://developer.apple.com/documentation/uikit/uikeycommand/wantspriorityoversystembehavior`.
+
+- [ ] **Step 8: Run focused unit and UI tests and verify GREEN**
+
+Run both commands from Step 4.
+
+Expected: `CommandPaletteSearchTests` pass; the palette UI test shows the first
+enabled result selected before typing, Down selects the next option, Return
+activates it, the search field is one line high, and the card is at most 430
+points high.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git status --short
+git add \
+  RemuxApp/Sources/App/CommandPaletteSearch.swift \
+  RemuxApp/Sources/App/CommandPaletteView.swift \
+  RemuxAppTests/CommandPaletteSearchTests.swift \
+  RemuxAppUITests/RemuxAppUITests.swift
+git commit -m "Make Command-K a compact keyboard chooser" \
+  -m "Initialize palette results and selection synchronously, cap the floating card at six rows, and keep the search control to one line. Publish priority Up, Down, Return, and Escape commands so text input cannot consume palette navigation or dismissal."
+```
+
+---
+
+### Task 4: Prove Live Command-N and Ship the Device Candidate
+
+**Files:**
+- Modify: `RemuxAppUITests/RemuxAppUITests.swift`
+
+**Interfaces:**
+- Consumes: `launchLiveSSHAppIfConfigured`,
+  `generatedLiveLatencySessionName`, `waitForLiveTerminalReady`,
+  `openWindowsSheet`, and `recordLiveTmuxWindowCountExpectation`.
+- Produces: a live-SSH acceptance test showing Command-N creates exactly one
+  new remote tmux window.
+
+- [ ] **Step 1: Add the live-SSH Command-N test**
+
+Add this test beside the other generated live tmux action tests:
+
+```swift
+func testLiveSSHCommandNCreatesRemoteWindowWhenConfigured() throws {
+    let sessionName = try generatedLiveLatencySessionName("command-n")
+    defer {
+        cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+    }
+
+    try launchLiveSSHAppIfConfigured(
+        traceRuntime: true,
+        sessionNameOverride: sessionName
+    )
+    openFirstSavedSession()
+    waitForLiveTerminalReady(timeout: 90)
+
+    app.typeKey("n", modifierFlags: .command)
+    waitForLiveTerminalReady(timeout: 30)
+
+    openWindowsSheet()
+    XCTAssertTrue(
+        app.buttons["terminal.window.tile.1"]
+            .waitForExistence(timeout: 10)
+    )
+    XCTAssertTrue(
+        app.buttons["terminal.window.tile.2"]
+            .waitForExistence(timeout: 10)
+    )
+    XCTAssertFalse(
+        app.buttons["terminal.window.tile.3"]
+            .waitForExistence(timeout: 2),
+        "Command-N should create exactly one additional tmux window."
+    )
+    recordLiveTmuxWindowCountExpectation(
+        sessionName: sessionName,
+        expectedCount: 2
+    )
+}
+```
+
+- [ ] **Step 2: Run the live test through the cleanup harness**
+
+Run:
+
+```bash
+scripts/remux_live_ui_test_with_cleanup.sh \
+  --destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2' \
+  --only-testing RemuxUITests/RemuxAppUITests/testLiveSSHCommandNCreatesRemoteWindowWhenConfigured
+```
+
+Expected: PASS, and the harness verifies the remote tmux window count is two
+before deleting only the generated allowlisted session.
+
+- [ ] **Step 3: Commit the live acceptance test**
+
+```bash
+git status --short
+git add RemuxAppUITests/RemuxAppUITests.swift
+git commit -m "Cover Command-N against live tmux" \
+  -m "Drive the configured Command-N shortcut through the live SSH UI harness and require exactly one additional remote tmux window, with allowlisted cleanup and remote count verification."
+```
+
+- [ ] **Step 4: Run the full unit suite**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2'
+```
+
+Expected: exit 0. Record any pre-existing warnings separately; do not call the
+gate green if a test fails.
+
+- [ ] **Step 5: Run the full non-live UI suite**
+
+Run:
+
+```bash
+xcodebuild test -quiet \
+  -project Remux.xcodeproj \
+  -scheme RemuxUIOnly \
+  -destination 'platform=iOS Simulator,id=9ECEBD90-D99E-4EBA-B233-A5D3CD6024F2'
+```
+
+Expected: all non-live UI tests pass and configured live tests skip. If
+XCUITest reports infrastructure errors such as process-termination or event
+synthesis timeouts, inspect the `.xcresult` and rerun only the affected tests;
+report the original failure and focused result separately.
+
+- [ ] **Step 6: Inspect the final branch**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline --decorate -8
+```
+
+Expected: no tracked changes remain, `git diff --check` emits nothing, and the
+four existing untracked `.worktrees` directories remain untouched.
+
+- [ ] **Step 7: Build and verify the signed iPhone app**
+
+Run:
+
+```bash
+xcodebuild build -quiet \
+  -project Remux.xcodeproj \
+  -scheme Remux \
+  -configuration Debug \
+  -destination 'id=6A5C05AA-0987-5ECC-9937-7E3073636F1D' \
+  -derivedDataPath .local/device-build \
+  DEVELOPMENT_TEAM=87WJ58S66M \
+  PRODUCT_BUNDLE_IDENTIFIER=com.fsck.dev.remux.app \
+  CODE_SIGN_STYLE=Automatic \
+  CODE_SIGN_IDENTITY='Apple Development'
+
+codesign --verify --deep --strict --verbose=2 \
+  .local/device-build/Build/Products/Debug-iphoneos/Remux.app
+```
+
+Expected: build exit 0 and codesign reports that the app is valid on disk and
+satisfies its designated requirement.
+
+- [ ] **Step 8: Install and launch on Jesse's iPhone**
+
+First verify the device is available and unlocked:
+
+```bash
+xcrun devicectl device info lockState \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D
+```
+
+Then install and launch:
+
+```bash
+xcrun devicectl device install app \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  .local/device-build/Build/Products/Debug-iphoneos/Remux.app
+
+xcrun devicectl device process launch \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D \
+  com.fsck.dev.remux.app \
+  --terminate-existing
+
+xcrun devicectl device info processes \
+  --device 6A5C05AA-0987-5ECC-9937-7E3073636F1D |
+  rg 'Remux.app/Remux'
+```
+
+Expected: install succeeds, launch succeeds on an unlocked phone, and the
+process list contains `Remux.app/Remux`.
+
+- [ ] **Step 9: Hand off the physical-keyboard acceptance gate**
+
+Ask Jesse to verify on the installed build:
+
+1. Command-K opens a centered compact card from Home and a terminal.
+2. The input remains one line high.
+3. The first option is selected before typing.
+4. Up and Down move selection before typing.
+5. Return invokes the selected option.
+6. Escape dismisses without sending input to the terminal.
+7. Command-N in a ready remote session creates one new tmux window.
+8. Command-N outside a ready remote session has no Remux action.
+
+Do not create a pull request until Jesse confirms this gate.

--- a/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
+++ b/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
@@ -1,0 +1,183 @@
+# Physical Keyboard Commands and Floating Chrome
+
+## Goal
+
+Make Remux efficient on iPads with a connected physical keyboard without
+changing its touch-first behavior when no physical keyboard is present.
+
+The feature adds configurable app commands, a global command palette, exact
+search over currently visible terminal text, and a setting that lets the
+terminal use the full viewport while a physical keyboard is connected.
+
+## Command Model
+
+Remux owns a fixed set of app command actions. Each action has one optional,
+persisted key binding. Bindings accept a key plus one or more of Command,
+Shift, Option, and Control. Users may clear a binding. Remux rejects duplicate
+bindings rather than choosing an arbitrary winner.
+
+The default bindings are:
+
+| Binding | Action |
+| --- | --- |
+| Command-Left Arrow | Focus the previous tmux window, matching the current swipe gesture |
+| Command-Right Arrow | Focus the next tmux window, matching the current swipe gesture |
+| Command-Shift-Left Arrow | Focus the previous active Remux session |
+| Command-Shift-Right Arrow | Focus the next active Remux session |
+| Command-H | Show Home |
+| Command-O | Show the existing current-session window popup |
+| Command-P | Show the existing pane popup |
+| Command-A | Show the existing attachment menu |
+| Command-K | Show the Remux command palette |
+
+Window and session cycling wrap at both ends. Session cycling uses the same
+ordering as Home's Active Sessions section. Commands that require a selected
+terminal are unavailable outside an active terminal. Command-K is global and
+works from Home as well as a terminal.
+
+Command-H conflicts with an iPadOS system shortcut. Remux will request priority
+over system behavior for configured app commands, but this behavior requires a
+physical-device acceptance check and will not be claimed from simulator tests
+alone.
+
+## Persistence and Settings
+
+Keyboard settings use a separate repository and JSON file rather than changing
+the existing terminal-settings schema. This keeps existing terminal appearance
+data independent and avoids a migration.
+
+The keyboard settings screen is reachable from the existing settings flow and
+contains:
+
+- one editor row per app command;
+- a capture control for assigning a modified key;
+- a clear action for making a command unassigned;
+- inline duplicate-binding validation;
+- a global `Hide button bar when a physical keyboard is connected` toggle.
+
+The hide-button-bar toggle defaults to enabled.
+
+## Physical Keyboard Detection and Button Bar
+
+Remux observes GameController's coalesced physical keyboard and its connection
+and disconnection notifications. This covers Bluetooth keyboards, Apple's
+Magic Keyboard attachment, and wired keyboards reported by iOS. Software
+keyboard visibility is not treated as physical keyboard attachment.
+
+Without a physical keyboard, the existing button bar and software-keyboard
+layout remain unchanged.
+
+With a physical keyboard connected:
+
+- the button bar overlays the terminal instead of reducing terminal height;
+- when the hide setting is enabled, the bar starts hidden;
+- tapping a terminal surface reveals the bar without changing terminal size;
+- the revealed bar hides after three seconds of inactivity;
+- interacting with the bar restarts the three-second timer;
+- when the hide setting is disabled, the floating bar remains visible;
+- disconnecting the physical keyboard immediately restores the existing
+  touch/software-keyboard layout.
+
+Overlay presentation must not send a smaller viewport to tmux. The terminal
+continues to occupy the full available window, and the bar may cover the bottom
+edge temporarily.
+
+## Command Routing
+
+A central command registry owns action metadata, defaults, validation, and
+display labels. A central router receives a resolved action and delegates it to
+the current app state:
+
+- Root navigation handles Home, active-session cycling, and the global command
+  palette.
+- The selected terminal screen handles adjacent tmux windows and the existing
+  window, pane, and attachment presentations.
+- Unsupported actions are disabled and do not leak through to the remote
+  terminal.
+- Unmatched physical-keyboard input continues through the existing Ghostty
+  terminal input path.
+
+The same action methods back button taps and keyboard commands so the two input
+paths cannot drift.
+
+## Command Palette
+
+Command-K presents one global palette over the current route. It is separate
+from Remux's existing saved-command Shortcut Palette.
+
+With an empty query, the palette offers:
+
+- `Add Connection`, which opens the existing connection setup;
+- one `New Session on <host>` action per saved host, which opens the existing
+  new-session form preselected for that host;
+- available navigation and overlay commands.
+
+Typing filters command actions and, after a short debounce, searches the
+currently visible text of every pane in every tmux window belonging to every
+active Remux session. Search is case-insensitive. Results show a short matching
+line, session name, host, window name or index, and pane index.
+
+Selecting a text result closes the palette and focuses its exact Remux session,
+tmux window, and pane. No persistent match highlighting is added. Search covers
+only the visible viewport; scrollback indexing is out of scope.
+
+If a surface disappears while a search is running, its result is omitted. A
+failed snapshot from one surface does not block results from other surfaces.
+The palette cancels obsolete searches when the query changes or the palette
+closes.
+
+## GhosttyKit Boundary
+
+The pinned GhosttyKit terminal-surface API can read a user selection but does
+not expose a non-mutating snapshot of visible viewport text. Remux will add the
+smallest required API to its GhosttyKit fork:
+
+- read the currently presented viewport for one terminal surface;
+- return owned UTF-8 text plus enough row information to form result snippets;
+- avoid changing selection, scroll position, focus, or renderer state;
+- expose only the visible presentation, not full scrollback;
+- free returned storage through the matching terminal-surface allocator.
+
+Remux wraps that API in `GhosttyKitControlSurface` and projects searchable
+surface metadata through the existing tmux adapter. It does not reconstruct
+terminal state from the byte stream or issue network `capture-pane` requests.
+
+## Failure Handling
+
+- Invalid or duplicate user bindings are not saved.
+- A configured command that cannot act in the current route is ignored and is
+  shown disabled in the palette.
+- A disconnected session remains eligible for session navigation but has no
+  searchable terminal results.
+- Physical-keyboard connect/disconnect notifications are reconciled against
+  the current coalesced keyboard value so duplicate or stale notifications do
+  not strand the button bar.
+- Search snapshot failures remain local to the affected pane.
+
+## Testing and Acceptance
+
+Focused tests cover:
+
+- default bindings, clearing, custom capture, and duplicate rejection;
+- repository round trips and missing-file defaults;
+- route-aware command availability and dispatch;
+- wrapping window and active-session navigation;
+- palette command filtering, search debouncing, cancellation, result metadata,
+  and selection routing;
+- physical-keyboard connection projection and floating-bar visibility/timer
+  state;
+- GhosttyKit viewport snapshot ownership, visible-row boundaries, alternate
+  screen behavior, and no selection/scroll mutation.
+
+UI tests cover settings editing, global palette actions, reuse of the existing
+window/pane/attachment presentations, and floating chrome geometry using a
+deterministic physical-keyboard override.
+
+Acceptance evidence remains separated:
+
+1. focused automated tests for domain and routing behavior;
+2. the full Remux simulator test suite;
+3. rendered simulator checks proving the floating bar overlays rather than
+   shrinks the terminal;
+4. a physical iPad keyboard check for connection detection, command delivery,
+   and the Command-H system-priority behavior.

--- a/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
+++ b/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
@@ -24,27 +24,35 @@ The default bindings are:
 | Command-Right Arrow | Focus the next tmux window, matching the current swipe gesture |
 | Command-Shift-Left Arrow | Focus the previous active Remux session |
 | Command-Shift-Right Arrow | Focus the next active Remux session |
-| Command-H | Show Home |
+| Command-Shift-H | Show Home |
 | Command-O | Show the existing current-session window popup |
 | Command-P | Show the existing pane popup |
 | Command-A | Show the existing attachment menu |
 | Command-K | Show the Remux command palette |
+| Command-+ | Increase the app-global terminal font size by one point |
+| Command-- | Decrease the app-global terminal font size by one point |
 
 Window and session cycling wrap at both ends. Session cycling uses the same
 ordering as Home's Active Sessions section. Commands that require a selected
 terminal are unavailable outside an active terminal. Command-K is global and
-works from Home as well as a terminal.
+works from Home as well as a terminal. Font-size commands are also global and
+work from every route.
 
-Command-H conflicts with an iPadOS system shortcut. Remux will request priority
-over system behavior for configured app commands, but this behavior requires a
-physical-device acceptance check and will not be claimed from simulator tests
-alone.
+Each font-size command changes the persisted terminal font size by one point
+and immediately refreshes every active terminal. When automatic font sizing is
+active, the first adjustment starts from the current effective device font
+size. Adjustments clamp to the existing 8 through 24 point range.
+
+Command-H remains reserved for iPadOS Home and cannot be assigned as a custom
+binding.
 
 ## Persistence and Settings
 
 Keyboard settings use a separate repository and JSON file rather than changing
 the existing terminal-settings schema. This keeps existing terminal appearance
-data independent and avoids a migration.
+data independent. The font-size commands are part of the original keyboard
+settings defaults; no compatibility migration is required because keyboard
+settings have not been deployed.
 
 The keyboard settings screen is reachable from the existing settings flow and
 contains:
@@ -90,6 +98,9 @@ the current app state:
 
 - Root navigation handles Home, active-session cycling, and the global command
   palette.
+- Root routing applies app-global font-size adjustments through the existing
+  terminal-settings persistence path so all current and future sessions use
+  the same value.
 - The selected terminal screen handles adjacent tmux windows and the existing
   window, pane, and attachment presentations.
 - Unsupported actions are disabled and do not leak through to the remote
@@ -162,6 +173,7 @@ terminal state from the byte stream or issue network `capture-pane` requests.
 ## Failure Handling
 
 - Invalid or duplicate user bindings are not saved.
+- Bindings reserved by iPadOS, including Command-H, are not saved.
 - A configured command that cannot act in the current route is ignored and is
   shown disabled in the palette.
 - A disconnected session remains eligible for session navigation but has no
@@ -175,9 +187,12 @@ terminal state from the byte stream or issue network `capture-pane` requests.
 
 Focused tests cover:
 
-- default bindings, clearing, custom capture, and duplicate rejection;
+- default bindings, clearing, custom capture, duplicate rejection, and
+  system-reserved binding rejection;
 - repository round trips and missing-file defaults;
 - route-aware command availability and dispatch;
+- app-global font-size increments from explicit and automatic sizes, bounds,
+  persistence, and propagation to active sessions;
 - wrapping window and active-session navigation;
 - palette command filtering, search debouncing, cancellation, result metadata,
   selection routing, and immediate keyboard focus;
@@ -196,5 +211,5 @@ Acceptance evidence remains separated:
 2. the full Remux simulator test suite;
 3. rendered simulator checks proving the floating bar overlays rather than
    shrinks the terminal;
-4. a physical iPad keyboard check for connection detection, command delivery,
-   and the Command-H system-priority behavior.
+4. a physical iPad keyboard check for connection detection and command
+   delivery.

--- a/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
+++ b/docs/superpowers/specs/2026-07-26-physical-keyboard-commands-design.md
@@ -126,6 +126,23 @@ failed snapshot from one surface does not block results from other surfaces.
 The palette cancels obsolete searches when the query changes or the palette
 closes.
 
+## Visual Integration and Input Ownership
+
+The command palette uses Remux's dynamic app background, grouped row surface,
+separator, corner treatment, and color-scheme behavior. Its panel and list are
+opaque rather than using a generic translucent material, so terminal content
+does not bleed through and reduce contrast.
+
+The keyboard settings entry uses the same grouped row surface as the other
+settings entries. It must not fall back to a translucent or system-default list
+background that visually separates it from the settings design system.
+
+While the command palette is presented, it owns keyboard input. The selected
+terminal relinquishes first-responder eligibility before the palette search
+field requests focus. Typing immediately after Command-K therefore enters the
+query without requiring a tap or leaking characters to the terminal. Dismissing
+the palette restores the terminal's normal focus policy.
+
 ## GhosttyKit Boundary
 
 The pinned GhosttyKit terminal-surface API can read a user selection but does
@@ -163,7 +180,7 @@ Focused tests cover:
 - route-aware command availability and dispatch;
 - wrapping window and active-session navigation;
 - palette command filtering, search debouncing, cancellation, result metadata,
-  and selection routing;
+  selection routing, and immediate keyboard focus;
 - physical-keyboard connection projection and floating-bar visibility/timer
   state;
 - GhosttyKit viewport snapshot ownership, visible-row boundaries, alternate

--- a/docs/superpowers/specs/2026-07-27-command-palette-spacing-and-typography-design.md
+++ b/docs/superpowers/specs/2026-07-27-command-palette-spacing-and-typography-design.md
@@ -1,0 +1,91 @@
+# Command Palette Spacing and Typography
+
+## Goal
+
+Give the floating Command-K palette enough space to read as a distinct window
+and reduce its type scale so more results fit comfortably without weakening
+its keyboard-first behavior.
+
+This is a focused visual refinement of
+`2026-07-27-floating-command-palette-and-new-remote-window-design.md`. Where
+that design specified 16-point minimum screen margins, this refinement replaces
+them with the approved 20-point margin.
+
+## Approved Treatment
+
+Use the Balanced treatment:
+
+- keep the palette centered and cap its width at 620 points;
+- keep at least 20 points between the palette card and each screen edge;
+- add a 10-point inset between the outer card and the grouped search and
+  result surfaces;
+- render result titles with SwiftUI's dynamic `subheadline` text style;
+- render the UIKit search field with the dynamic `footnote` text style;
+- keep result subtitles at their existing caption styles;
+- preserve the 44-point search row and 56-point result rows.
+
+The 20-point value is external space around the card. The 10-point value is
+visible internal space inside it. They are not interchangeable and must remain
+independently testable.
+
+## Card and Surface Structure
+
+The outer card retains Remux's existing opaque background, 18-point corner
+radius, border, and shadow. It provides the 10-point inset around one inner
+rounded group containing the search row, separator, results, and empty state.
+
+The inner group clips its row backgrounds and separators to its own rounded
+outline. This keeps list surfaces away from the outer card edge without
+introducing new colors or a nested shadow. Search and result surfaces continue
+to use the established Remux background, row, selection, and separator colors.
+
+The card continues sizing to its content. Up to six results are visible;
+additional results scroll inside the existing result area. The inset must not
+increase the intrinsic search or result row heights.
+
+## Typography
+
+Result titles use `subheadline`, approximately 15 points at the default content
+size. The UIKit search field uses
+`UIFont.preferredFont(forTextStyle: .footnote)`, approximately 13 points at the
+default content size, and adjusts for Dynamic Type. Existing caption and
+caption2 styles remain unchanged for result descriptions and shortcut labels.
+
+These are semantic text styles rather than fixed point sizes. Dynamic Type can
+therefore increase them while the default presentation remains denser than the
+current body-sized controls.
+
+## Interaction Contract
+
+This refinement does not change palette behavior. The search field still
+becomes first responder when the palette opens. Escape dismisses it, Up and
+Down change the selection before or after typing, and Return invokes the
+selected result. Selection highlighting, accessibility identifiers, result
+ordering, filtering, and terminal-focus restoration remain unchanged.
+
+The scrim and tap-to-dismiss behavior also remain unchanged.
+
+## Testing and Acceptance
+
+Focused tests cover the independent layout constants for the 20-point screen
+margin and 10-point card inset, the existing 44-point and 56-point row heights,
+and the UIKit search field's semantic font style and Dynamic Type behavior.
+
+A UI geometry assertion verifies that the rendered card remains at least
+20 points from the available screen edges. Existing focused UI tests continue
+to verify first-responder ownership, keyboard selection, activation, dismissal,
+and compact single-line input geometry.
+
+Visual acceptance checks the default content size on Jesse's iPhone:
+
+- the card reads as a floating window rather than an edge-to-edge sheet;
+- the outer background is visibly present around the grouped rows;
+- titles and search input are smaller without becoming difficult to scan;
+- row and separator colors still match the surrounding app.
+
+## Out of Scope
+
+- Changing palette commands, search scope, ordering, or result contents.
+- Changing keyboard bindings or responder-chain behavior.
+- Changing the number of visible results or the established row heights.
+- Introducing fixed font sizes, custom fonts, or a new palette color scheme.

--- a/docs/superpowers/specs/2026-07-27-command-palette-spacing-and-typography-design.md
+++ b/docs/superpowers/specs/2026-07-27-command-palette-spacing-and-typography-design.md
@@ -34,10 +34,11 @@ The outer card retains Remux's existing opaque background, 18-point corner
 radius, border, and shadow. It provides the 10-point inset around one inner
 rounded group containing the search row, separator, results, and empty state.
 
-The inner group clips its row backgrounds and separators to its own rounded
-outline. This keeps list surfaces away from the outer card edge without
-introducing new colors or a nested shadow. Search and result surfaces continue
-to use the established Remux background, row, selection, and separator colors.
+The inner group clips its row backgrounds and separators to a 12-point
+continuous rounded rectangle, matching Remux's existing grouped surfaces. This
+keeps list surfaces away from the outer card edge without introducing new
+colors or a nested shadow. Search and result surfaces continue to use the
+established Remux background, row, selection, and separator colors.
 
 The card continues sizing to its content. Up to six results are visible;
 additional results scroll inside the existing result area. The inset must not
@@ -72,9 +73,9 @@ margin and 10-point card inset, the existing 44-point and 56-point row heights,
 and the UIKit search field's semantic font style and Dynamic Type behavior.
 
 A UI geometry assertion verifies that the rendered card remains at least
-20 points from the available screen edges. Existing focused UI tests continue
-to verify first-responder ownership, keyboard selection, activation, dismissal,
-and compact single-line input geometry.
+20 points from every edge of its presentation container. Existing focused UI
+tests continue to verify first-responder ownership, keyboard selection,
+activation, dismissal, and compact single-line input geometry.
 
 Visual acceptance checks the default content size on Jesse's iPhone:
 

--- a/docs/superpowers/specs/2026-07-27-floating-command-palette-and-new-remote-window-design.md
+++ b/docs/superpowers/specs/2026-07-27-floating-command-palette-and-new-remote-window-design.md
@@ -19,7 +19,7 @@ surface, separator, corner, and shadow styles.
 
 The card sizes to its content rather than filling most of the display:
 
-- its width is capped at 620 points with 16-point minimum screen margins;
+- its width is capped at 620 points with 20-point minimum screen margins;
 - the input occupies one intrinsic single-line control row and never expands
   vertically;
 - results size to their rows up to six visible items;
@@ -55,8 +55,8 @@ The action is terminal-scoped:
 - it creates one new tmux window in that existing remote session;
 - it does not create a Remux connection, a new Remux saved session, or a tmux
   pane;
-- outside a ready terminal it is unavailable and does not claim the key
-  sequence.
+- outside a ready terminal it is unavailable, falls through the responder
+  chain unclaimed by Remux, and sends no terminal bytes.
 
 Command-N calls the same tmux window-creation behavior used by the existing
 `New Window` button. The keyboard path and button path share the topology

--- a/docs/superpowers/specs/2026-07-27-floating-command-palette-and-new-remote-window-design.md
+++ b/docs/superpowers/specs/2026-07-27-floating-command-palette-and-new-remote-window-design.md
@@ -1,0 +1,113 @@
+# Floating Command Palette and New Remote Window
+
+## Goal
+
+Refine the global Command-K palette into a compact floating chooser that is
+fully operable from a physical keyboard, and add a configurable Command-N
+action that creates a new shell window inside the currently open remote tmux
+session.
+
+This is a focused extension of
+`2026-07-26-physical-keyboard-commands-design.md`. It does not introduce a new
+session model, pane type, or replacement terminal action.
+
+## Floating Palette Presentation
+
+The command palette appears as a centered, opaque card above the current route
+and its existing dimming scrim. It uses the established Remux background, row
+surface, separator, corner, and shadow styles.
+
+The card sizes to its content rather than filling most of the display:
+
+- its width is capped at 620 points with 16-point minimum screen margins;
+- the input occupies one intrinsic single-line control row and never expands
+  vertically;
+- results size to their rows up to six visible items;
+- additional results scroll within the card;
+- the empty-search state remains compact rather than expanding to the previous
+  520-point maximum height.
+
+Tapping the scrim or close button dismisses the palette.
+
+## Palette Keyboard Ownership
+
+The search field becomes first responder as soon as the palette enters its
+window. Palette results and the initial selection are established
+synchronously, before the field can receive a physical-keyboard press.
+
+The first enabled result is selected before any query is typed. Up and Down
+move among enabled results and stop at the first or last item. Return invokes
+the selected result. Escape dismisses the palette from its active responder
+chain and does not leak to the terminal.
+
+Changing the query replaces the result set and selects its first enabled item.
+The selected row remains visibly highlighted and exposes the selected
+accessibility trait.
+
+## Command-N: New Remote Window
+
+The command registry gains one configurable `New Window` action with
+Command-N as its default binding.
+
+The action is terminal-scoped:
+
+- it is available only when a remote session is selected and ready;
+- it creates one new tmux window in that existing remote session;
+- it does not create a Remux connection, a new Remux saved session, or a tmux
+  pane;
+- outside a ready terminal it is unavailable and does not claim the key
+  sequence.
+
+Command-N calls the same tmux window-creation behavior used by the existing
+`New Window` button. The keyboard path and button path share the topology
+interaction effect, tracing, model call, and focus reconciliation. The
+implementation does not synthesize a button tap or open the window chooser
+first.
+
+Because the command registry drives keyboard settings and palette command
+items, `New Window` automatically appears in both places and can be rebound or
+cleared under the existing validation rules.
+
+No settings migration or backward-compatibility behavior is added. The
+keyboard bindings have not shipped to users, so Command-N is introduced only
+through the new default settings value.
+
+## Error and Focus Behavior
+
+If the selected remote terminal stops being ready before dispatch, the command
+does nothing and sends no bytes to the remote shell. A rejected tmux topology
+action follows the existing interaction-effect handling.
+
+Dismissing the palette restores the terminal's established first-responder
+policy. Unmodified text and unmatched key combinations continue through the
+normal text-input path.
+
+## Testing and Acceptance
+
+Focused automated tests cover:
+
+- Command-N's default binding, rebinding, clearing, and duplicate rejection
+  through the existing settings contracts;
+- terminal-scoped route availability;
+- dispatch through the same new-window model action as the existing button;
+- synchronous initial palette selection before typing;
+- Up, Down, Return, and Escape handling;
+- compact card sizing for zero, one, six, and more than six results.
+
+UI tests cover opening the palette, seeing the first option already selected,
+navigating before typing, invoking a result, dismissing with Escape where the
+test driver can emit a physical Escape event, and verifying the compact
+single-line input geometry.
+
+Simulator evidence does not replace physical-keyboard acceptance. Before a
+pull request, install a signed build on Jesse's iPhone and verify Command-K,
+Escape, pre-query arrow navigation, Return activation, and Command-N against a
+live remote tmux session.
+
+## Out of Scope
+
+- Changing the existing window chooser or pane chooser.
+- Choosing a pane split direction for Command-N.
+- Migrating an older keyboard-settings payload.
+- Adding full-scrollback search or persistent result highlighting.
+- Creating another Remux connection or saved session from Command-N.


### PR DESCRIPTION
## Summary

Add configurable, app-wide physical-keyboard controls to Remux.

- add persisted keyboard settings for window and session navigation, Home,
  session windows, new windows, panes, attachments, font size, and the command
  palette
- keep app shortcuts available while forms or the terminal own keyboard focus,
  while exposing terminal-only commands only when the selected terminal is
  ready
- reserve iPadOS `Cmd-H`; Home defaults to `Cmd-Shift-H`, and shortcut capture
  rejects the system-owned chord
- add a floating `Cmd-K` palette with immediate text focus, arrow-key
  selection, Return activation, and Escape dismissal
- reuse existing flows for adding connections, starting sessions on saved
  hosts, opening the current session's windows, panes, and attachments
- search text currently visible across open terminal panes and route a selected
  result back to its pane
- hide the floating button bar by default while a physical keyboard is
  connected; tapping the terminal reveals it over the content without reducing
  the terminal viewport
- make `Cmd-N` create exactly one new tmux window in the current remote session

Default bindings are:

- `Cmd-Left` / `Cmd-Right`: previous / next window
- `Cmd-Shift-Left` / `Cmd-Shift-Right`: previous / next session
- `Cmd-Shift-H`: Home
- `Cmd-O`: current-session windows
- `Cmd-N`: new remote window
- `Cmd-P`: panes
- `Cmd-A`: attachments
- `Cmd-K`: command palette
- `Cmd-+` / `Cmd--`: increase / decrease font size

## Why

Remux should remain fully navigable when an iPad hardware keyboard is attached,
and the terminal should use the space recovered from the software-keyboard
button bar. The command palette provides a single keyboard-first entry point to
existing actions and the text visible across retained terminal surfaces.

## Dependency

Visible-terminal search depends on
[h3nock/remux-ghostty#7](https://github.com/h3nock/remux-ghostty/pull/7),
which exposes a non-mutating viewport snapshot. That PR is ready for review,
but Remux still needs a new immutable GhosttyKit release asset and checksum
before a clean checkout can update its dependency pin.

## Validation

- 903 unit tests passed, 0 failed
- `RemuxUIOnly`: 12 passed, 26 live-only tests skipped, 0 failed
- signed Debug build installed on an iPhone 16 Pro
- physical-keyboard acceptance passed on the installed build; Jesse confirmed
  the feature works on hardware


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable physical keyboard shortcuts with shortcut capture, validation, and persisted settings.
  * Added a keyboard-driven Command Palette (Command–K) with searchable results from commands and visible terminal text.
  * Added physical keyboard detection and adaptive floating “terminal home”/chrome behavior.
  * Added route-aware keyboard command handling (session/window navigation, pane actions, and font-size adjustments).
* **Bug Fixes**
  * Improved keyboard-command focus and first-responder behavior when other inputs or the palette are active.
* **Tests**
  * Expanded unit, UI, and persistence coverage for keyboard commands, command palette, focus behavior, and physical-keyboard state.
* **Documentation**
  * Added implementation plans/specs for command palette focus/surfaces, physical-keyboard commands, and palette typography/spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->