### PR TITLE
feat(ssh): support Windows tmux control sessions

### DIFF
--- a/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
@@ -1,3 +1,42 @@
+import Foundation
+
+enum SSHTmuxRemotePlatform: Equatable, Sendable, CustomStringConvertible {
+    case posix
+    case windows
+
+    var description: String {
+        switch self {
+        case .posix: "posix"
+        case .windows: "windows"
+        }
+    }
+}
+
+enum SSHTmuxRemotePlatformDetectionError: Error, Equatable {
+    case missingExitStatus
+    case unexpectedSuccessfulOutput
+}
+
+enum SSHTmuxRemotePlatformDetector {
+    static let windowsProbeCommand = "cmd.exe /d /c echo REMUX_WINDOWS_%OS%"
+    private static let windowsMarker = "REMUX_WINDOWS_Windows_NT"
+
+    static func platform(exitStatus: Int?, stdout: Data) throws -> SSHTmuxRemotePlatform {
+        guard let exitStatus else {
+            throw SSHTmuxRemotePlatformDetectionError.missingExitStatus
+        }
+        guard exitStatus == 0 else {
+            return .posix
+        }
+        guard let output = String(data: stdout, encoding: .utf8),
+              output.split(whereSeparator: \.isNewline).contains(Substring(windowsMarker))
+        else {
+            throw SSHTmuxRemotePlatformDetectionError.unexpectedSuccessfulOutput
+        }
+        return .windows
+    }
+}
+
 enum SSHTmuxControlCommandBuilder {
     static let tmuxNotFoundMarker = "remux: tmux executable not found"
     static let tmuxNotExecutableMarker = "remux: tmux executable cannot be executed"
@@ -5,6 +44,28 @@ enum SSHTmuxControlCommandBuilder {
     private static let fallbackRemotePath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     static func attachOrCreateControlSessionCommand(
+        platform: SSHTmuxRemotePlatform = .posix,
+        tmuxExecutable: String,
+        sessionName: String,
+        initialViewport: TmuxControlViewport
+    ) -> String {
+        switch platform {
+        case .posix:
+            posixAttachOrCreateControlSessionCommand(
+                tmuxExecutable: tmuxExecutable,
+                sessionName: sessionName,
+                initialViewport: initialViewport
+            )
+        case .windows:
+            windowsAttachOrCreateControlSessionCommand(
+                tmuxExecutable: tmuxExecutable,
+                sessionName: sessionName,
+                initialViewport: initialViewport
+            )
+        }
+    }
+
+    private static func posixAttachOrCreateControlSessionCommand(
         tmuxExecutable: String,
         sessionName: String,
         initialViewport: TmuxControlViewport
@@ -18,6 +79,30 @@ enum SSHTmuxControlCommandBuilder {
             "\(initialViewport.columns)",
             "\(initialViewport.rows)",
         ].joined(separator: " ")
+    }
+
+    private static func windowsAttachOrCreateControlSessionCommand(
+        tmuxExecutable: String,
+        sessionName: String,
+        initialViewport: TmuxControlViewport
+    ) -> String {
+        // Windows resolves a bare `tmux` executable as `tmux.exe`. Keep the
+        // command behind cmd.exe so an OpenSSH server configured with
+        // PowerShell does not try to interpret the POSIX launcher.
+        let command = [
+            windowsQuotedArgument(tmuxExecutable),
+            "-u",
+            "-CC",
+            "new-session",
+            "-A",
+            "-s",
+            windowsQuotedArgument(sessionName),
+            "-x",
+            "\(initialViewport.columns)",
+            "-y",
+            "\(initialViewport.rows)",
+        ].joined(separator: " ")
+        return "cmd.exe /d /s /c \"\(command)\""
     }
 
     private static let launchScript = [
@@ -40,5 +125,9 @@ enum SSHTmuxControlCommandBuilder {
             return "\\0" + String(repeating: "0", count: 3 - digits.count) + digits
         }
         return "'\(bytes.joined())'"
+    }
+
+    private static func windowsQuotedArgument(_ value: String) -> String {
+        "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
     }
 }

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlCommandBuilder.swift
@@ -37,6 +37,17 @@ enum SSHTmuxRemotePlatformDetector {
     }
 }
 
+enum SSHTmuxControlCommandBuilderError: LocalizedError, Equatable {
+    case unsupportedWindowsArgument
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedWindowsArgument:
+            "Windows tmux executable and session names cannot contain a percent sign."
+        }
+    }
+}
+
 enum SSHTmuxControlCommandBuilder {
     static let tmuxNotFoundMarker = "remux: tmux executable not found"
     static let tmuxNotExecutableMarker = "remux: tmux executable cannot be executed"
@@ -48,7 +59,7 @@ enum SSHTmuxControlCommandBuilder {
         tmuxExecutable: String,
         sessionName: String,
         initialViewport: TmuxControlViewport
-    ) -> String {
+    ) throws -> String {
         switch platform {
         case .posix:
             posixAttachOrCreateControlSessionCommand(
@@ -57,7 +68,7 @@ enum SSHTmuxControlCommandBuilder {
                 initialViewport: initialViewport
             )
         case .windows:
-            windowsAttachOrCreateControlSessionCommand(
+            try windowsAttachOrCreateControlSessionCommand(
                 tmuxExecutable: tmuxExecutable,
                 sessionName: sessionName,
                 initialViewport: initialViewport
@@ -85,7 +96,11 @@ enum SSHTmuxControlCommandBuilder {
         tmuxExecutable: String,
         sessionName: String,
         initialViewport: TmuxControlViewport
-    ) -> String {
+    ) throws -> String {
+        guard !tmuxExecutable.contains("%"), !sessionName.contains("%") else {
+            throw SSHTmuxControlCommandBuilderError.unsupportedWindowsArgument
+        }
+
         // Windows resolves a bare `tmux` executable as `tmux.exe`. Keep the
         // command behind cmd.exe so an OpenSSH server configured with
         // PowerShell does not try to interpret the POSIX launcher.

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlTransport.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlTransport.swift
@@ -301,7 +301,7 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
             establishedConnection = try await SSHTmuxControlBootstrap.openControlSession(
                 using: claimedConnection,
                 viewport: startupViewport,
-                command: tmuxAttachCommand(
+                command: try tmuxAttachCommand(
                     platform: remotePlatform,
                     viewport: startupViewport
                 ),
@@ -534,8 +534,8 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
     private func tmuxAttachCommand(
         platform: SSHTmuxRemotePlatform,
         viewport: TmuxControlViewport
-    ) -> String {
-        SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+    ) throws -> String {
+        try SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
             platform: platform,
             tmuxExecutable: configuration.tmuxExecutable,
             sessionName: configuration.sessionName,
@@ -655,7 +655,7 @@ final class SSHTmuxControlStartupOutputAdapter: @unchecked Sendable {
 
         return lock.withLock {
             if startupResolved {
-                return isDCSWrapped ? removingDCSClosers(from: data) : data
+                return isDCSWrapped ? removingDCSCloser(from: data) : data
             }
 
             bufferedPrefix.append(data)
@@ -674,11 +674,11 @@ final class SSHTmuxControlStartupOutputAdapter: @unchecked Sendable {
             isDCSWrapped = true
             let output = Data(bufferedPrefix.dropFirst(Self.dcsOpener.count))
             bufferedPrefix.removeAll(keepingCapacity: false)
-            return removingDCSClosers(from: output)
+            return removingDCSCloser(from: output)
         }
     }
 
-    private func removingDCSClosers(from data: Data) -> Data? {
+    private func removingDCSCloser(from data: Data) -> Data? {
         var output = Data()
         output.reserveCapacity(data.count + (hasPendingEscape ? 1 : 0))
         var iterator = data.makeIterator()
@@ -692,6 +692,12 @@ final class SSHTmuxControlStartupOutputAdapter: @unchecked Sendable {
             if first != UInt8(ascii: "\\") {
                 output.append(UInt8(ascii: "\u{1b}"))
                 output.append(first)
+            } else {
+                isDCSWrapped = false
+                while let byte = iterator.next() {
+                    output.append(byte)
+                }
+                return output.isEmpty ? nil : output
             }
         }
 
@@ -704,7 +710,13 @@ final class SSHTmuxControlStartupOutputAdapter: @unchecked Sendable {
                 hasPendingEscape = true
                 break
             }
-            if next != UInt8(ascii: "\\") {
+            if next == UInt8(ascii: "\\") {
+                isDCSWrapped = false
+                while let remainingByte = iterator.next() {
+                    output.append(remainingByte)
+                }
+                break
+            } else {
                 output.append(byte)
                 output.append(next)
             }

--- a/RemuxApp/Sources/Tmux/SSHTmuxControlTransport.swift
+++ b/RemuxApp/Sources/Tmux/SSHTmuxControlTransport.swift
@@ -207,6 +207,7 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
     private let sessionSFTPScope: RemuxSessionSFTPChildScope
 
     private var pendingWrites: [Data] = []
+    private var inputAdapter: SSHTmuxControlInputAdapter?
     private var preparedRoot: RemuxSSHPreparedRoot?
     private var connection: SSHTmuxControlConnection?
     private var sessionSFTPDrainTask: Task<RemuxSFTPChildDrain, Never>?
@@ -259,6 +260,7 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
         let startupTrace = preparedRoot.trace
         var startedConnection: SSHTmuxControlConnection?
         let establishedConnection: SSHTmuxControlConnection
+        let establishedInputAdapter: SSHTmuxControlInputAdapter
         do {
             let sshRoot = try await startupTrace.stage("sshRoot.ready") {
                 try await preparedRoot.sshRoot()
@@ -277,14 +279,38 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
                 await claimedConnection.release(.reusable)
                 throw SSHTmuxControlTransportError.closed
             }
+            let remotePlatform: SSHTmuxRemotePlatform
+            do {
+                remotePlatform = try await SSHTmuxControlBootstrap.detectRemotePlatform(
+                    using: claimedConnection.sshRoot,
+                    trace: startupTrace
+                )
+            } catch {
+                await claimedConnection.release(.reusable)
+                throw error
+            }
+            guard !isClosed else {
+                await claimedConnection.release(.reusable)
+                throw SSHTmuxControlTransportError.closed
+            }
+            let startupOutputAdapter = SSHTmuxControlStartupOutputAdapter(
+                platform: remotePlatform
+            )
+            let inputAdapter = SSHTmuxControlInputAdapter(platform: remotePlatform)
+            establishedInputAdapter = inputAdapter
             establishedConnection = try await SSHTmuxControlBootstrap.openControlSession(
                 using: claimedConnection,
                 viewport: startupViewport,
-                command: tmuxAttachCommand(viewport: startupViewport),
+                command: tmuxAttachCommand(
+                    platform: remotePlatform,
+                    viewport: startupViewport
+                ),
                 controlNoResponseTimeout: configuration.controlNoResponseTimeout,
                 trace: startupTrace,
-                onOutput: { [inboundStream] data in
-                    inboundStream.yield(data)
+                onOutput: { [inboundStream, startupOutputAdapter] data in
+                    if let adapted = startupOutputAdapter.adapt(data) {
+                        inboundStream.yield(adapted)
+                    }
                 },
                 onFinish: { [inboundStream] error in
                     inboundStream.finish(error)
@@ -308,6 +334,7 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
                 }
             )
             guard !isClosed else { throw SSHTmuxControlTransportError.closed }
+            self.inputAdapter = inputAdapter
             connection = establishedConnection
             startedConnection = nil
         } catch {
@@ -338,7 +365,9 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
         )
         do {
             for data in queuedWrites {
-                try await establishedConnection.write(data)
+                if let adapted = try establishedInputAdapter.adapt(data) {
+                    try await establishedConnection.write(adapted)
+                }
             }
         } catch {
             connection = nil
@@ -378,9 +407,21 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
         GhosttyRuntimeTrace.latency(
             "transport.send begin bytes=\(data.count) preview=\(GhosttyRuntimeTrace.preview(data, limit: 160))"
         )
-        try await connection.write(data)
+        let adapted: Data?
+        if let inputAdapter {
+            adapted = try inputAdapter.adapt(data)
+        } else {
+            adapted = data
+        }
+        guard let adapted else {
+            GhosttyRuntimeTrace.latency(
+                "transport.send buffered bytes=\(data.count) elapsed_ms=\(GhosttyRuntimeTrace.elapsedMilliseconds(from: start))"
+            )
+            return
+        }
+        try await connection.write(adapted)
         GhosttyRuntimeTrace.latency(
-            "transport.send end bytes=\(data.count) elapsed_ms=\(GhosttyRuntimeTrace.elapsedMilliseconds(from: start))"
+            "transport.send end bytes=\(adapted.count) elapsed_ms=\(GhosttyRuntimeTrace.elapsedMilliseconds(from: start))"
         )
     }
 
@@ -393,6 +434,7 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
         let activeConnection = connection
         let pendingPreparedRoot = preparedRoot
         connection = nil
+        inputAdapter = nil
         preparedRoot = nil
         isClosed = true
         let childDrain = await drainSessionSFTPChildren()
@@ -489,12 +531,186 @@ actor SSHTmuxControlTransport: TmuxControlTransport, TmuxControlTransportLivenes
         )
     }
 
-    private func tmuxAttachCommand(viewport: TmuxControlViewport) -> String {
+    private func tmuxAttachCommand(
+        platform: SSHTmuxRemotePlatform,
+        viewport: TmuxControlViewport
+    ) -> String {
         SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+            platform: platform,
             tmuxExecutable: configuration.tmuxExecutable,
             sessionName: configuration.sessionName,
             initialViewport: viewport
         )
+    }
+}
+
+enum SSHTmuxControlInputAdapterError: Error, Equatable {
+    case invalidUTF8
+}
+
+/// Adapt the small subset of upstream tmux control commands whose syntax is
+/// different in Windows tmux.exe. Commands are newline-delimited and may be
+/// split across SSH writes.
+final class SSHTmuxControlInputAdapter: @unchecked Sendable {
+    private let platform: SSHTmuxRemotePlatform
+    private let lock = NIOLock()
+    private var bufferedCommand = Data()
+
+    init(platform: SSHTmuxRemotePlatform) {
+        self.platform = platform
+    }
+
+    func adapt(_ data: Data) throws -> Data? {
+        guard !data.isEmpty else { return nil }
+        guard platform == .windows else { return data }
+
+        return try lock.withLock {
+            bufferedCommand.append(data)
+            var output = Data()
+
+            while let newline = bufferedCommand.firstIndex(of: UInt8(ascii: "\n")) {
+                let line = Data(bufferedCommand[..<newline])
+                output.append(try adaptCommand(line))
+                output.append(UInt8(ascii: "\n"))
+                bufferedCommand.removeSubrange(...newline)
+            }
+
+            return output.isEmpty ? nil : output
+        }
+    }
+
+    private func adaptCommand(_ data: Data) throws -> Data {
+        guard let command = String(data: data, encoding: .utf8) else { return data }
+        if let resized = Self.adaptRefreshClientSize(command) {
+            return Data(resized.utf8)
+        }
+        let tokens = command.split(separator: " ", omittingEmptySubsequences: true)
+        guard tokens.count >= 5,
+              tokens[0] == "send-keys",
+              tokens[1] == "-H",
+              tokens[2] == "-t",
+              tokens[3].first == "%",
+              tokens[3].count > 1,
+              tokens[3].dropFirst().allSatisfy(\.isNumber),
+              tokens[4...].allSatisfy(Self.isHexByte)
+        else {
+            return data
+        }
+
+        var input = Data()
+        for token in tokens[4...] {
+            guard let byte = UInt8(token, radix: 16) else { return data }
+            input.append(byte)
+        }
+        guard let text = String(data: input, encoding: .utf8) else {
+            throw SSHTmuxControlInputAdapterError.invalidUTF8
+        }
+        let scalars = text.unicodeScalars
+            .map { "0x" + String($0.value, radix: 16) }
+            .joined(separator: " ")
+        return Data("send-keys -t \(tokens[3]) \(scalars)".utf8)
+    }
+
+    /// Upstream tmux accepts both `COLSxROWS` and `COLS,ROWS`, while psmux's
+    /// control-client resize parser currently accepts only the comma form.
+    private static func adaptRefreshClientSize(_ command: String) -> String? {
+        let prefix = "refresh-client -C "
+        guard command.hasPrefix(prefix) else { return nil }
+
+        let size = command.dropFirst(prefix.count)
+        let components = size.split(separator: "x", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              components.allSatisfy({ !$0.isEmpty && $0.allSatisfy(\.isNumber) })
+        else {
+            return nil
+        }
+        return prefix + components.joined(separator: ",")
+    }
+
+    private static func isHexByte(_ token: Substring) -> Bool {
+        token.count == 2 && token.allSatisfy(\.isHexDigit)
+    }
+}
+
+/// Windows tmux.exe's `-CC` stream is wrapped in DCS 1000p. Ghostty expects a
+/// plain control stream, so remove only that envelope on positively detected
+/// Windows hosts.
+final class SSHTmuxControlStartupOutputAdapter: @unchecked Sendable {
+    private static let dcsOpener = Data([0x1b, 0x50, 0x31, 0x30, 0x30, 0x30, 0x70])
+
+    private let platform: SSHTmuxRemotePlatform
+    private let lock = NIOLock()
+    private var bufferedPrefix = Data()
+    private var startupResolved = false
+    private var isDCSWrapped = false
+    private var hasPendingEscape = false
+
+    init(platform: SSHTmuxRemotePlatform) {
+        self.platform = platform
+    }
+
+    func adapt(_ data: Data) -> Data? {
+        guard !data.isEmpty else { return nil }
+        guard platform == .windows else { return data }
+
+        return lock.withLock {
+            if startupResolved {
+                return isDCSWrapped ? removingDCSClosers(from: data) : data
+            }
+
+            bufferedPrefix.append(data)
+            let comparedCount = min(bufferedPrefix.count, Self.dcsOpener.count)
+            guard bufferedPrefix.prefix(comparedCount)
+                    == Self.dcsOpener.prefix(comparedCount)
+            else {
+                startupResolved = true
+                defer { bufferedPrefix.removeAll(keepingCapacity: false) }
+                return bufferedPrefix
+            }
+
+            guard bufferedPrefix.count >= Self.dcsOpener.count else { return nil }
+
+            startupResolved = true
+            isDCSWrapped = true
+            let output = Data(bufferedPrefix.dropFirst(Self.dcsOpener.count))
+            bufferedPrefix.removeAll(keepingCapacity: false)
+            return removingDCSClosers(from: output)
+        }
+    }
+
+    private func removingDCSClosers(from data: Data) -> Data? {
+        var output = Data()
+        output.reserveCapacity(data.count + (hasPendingEscape ? 1 : 0))
+        var iterator = data.makeIterator()
+
+        if hasPendingEscape {
+            hasPendingEscape = false
+            guard let first = iterator.next() else {
+                hasPendingEscape = true
+                return nil
+            }
+            if first != UInt8(ascii: "\\") {
+                output.append(UInt8(ascii: "\u{1b}"))
+                output.append(first)
+            }
+        }
+
+        while let byte = iterator.next() {
+            guard byte == UInt8(ascii: "\u{1b}") else {
+                output.append(byte)
+                continue
+            }
+            guard let next = iterator.next() else {
+                hasPendingEscape = true
+                break
+            }
+            if next != UInt8(ascii: "\\") {
+                output.append(byte)
+                output.append(next)
+            }
+        }
+
+        return output.isEmpty ? nil : output
     }
 }
 
@@ -665,7 +881,124 @@ private final class SSHTmuxPreparedControlSession: @unchecked Sendable {
     }
 }
 
+private struct SSHTmuxRemoteCommandResult: Sendable {
+    let exitStatus: Int?
+    let stdout: Data
+}
+
+private struct SSHTmuxRemoteCommandTimedOut: Error {}
+
+private enum SSHTmuxRemoteCommandRunner {
+    static func run(
+        command: String,
+        using sshRoot: RemuxSSHRoot,
+        timeout: TimeAmount,
+        trace: RemuxTransportStartupTrace
+    ) async throws -> SSHTmuxRemoteCommandResult {
+        let channel = try await sshRoot.openSessionChannel(trace: trace)
+        let promise = channel.eventLoop.makePromise(of: SSHTmuxRemoteCommandResult.self)
+        let handler = SSHTmuxRemoteCommandHandler(promise: promise)
+
+        do {
+            try await channel.pipeline.addHandler(handler).get()
+            let timeoutTask = channel.eventLoop.scheduleTask(deadline: .now() + timeout) {
+                handler.fail(SSHTmuxRemoteCommandTimedOut())
+            }
+            defer { timeoutTask.cancel() }
+
+            try await channel.triggerUserOutboundEvent(
+                SSHChannelRequestEvent.ExecRequest(command: command, wantReply: true)
+            )
+            let result = try await promise.futureResult.get()
+            try? await channel.close()
+            return result
+        } catch {
+            try? await channel.close()
+            throw error
+        }
+    }
+}
+
+private final class SSHTmuxRemoteCommandHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = SSHChannelData
+
+    private let promise: EventLoopPromise<SSHTmuxRemoteCommandResult>
+    private var stdout = Data()
+    private var exitStatus: Int?
+    private var didComplete = false
+
+    init(promise: EventLoopPromise<SSHTmuxRemoteCommandResult>) {
+        self.promise = promise
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let channelData = unwrapInboundIn(data)
+        guard channelData.type == .channel,
+              case .byteBuffer(var buffer) = channelData.data,
+              let bytes = buffer.readBytes(length: buffer.readableBytes)
+        else {
+            return
+        }
+        stdout.append(contentsOf: bytes)
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        switch event {
+        case let status as SSHChannelRequestEvent.ExitStatus:
+            exitStatus = Int(status.exitStatus)
+        case is NIOSSH.ChannelFailureEvent:
+            fail(SSHTmuxControlTransportError.channelRequestFailed(.exec))
+        default:
+            context.fireUserInboundEventTriggered(event)
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        complete()
+        context.fireChannelInactive()
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        fail(error)
+        context.close(promise: nil)
+    }
+
+    func fail(_ error: Error) {
+        guard !didComplete else { return }
+        didComplete = true
+        promise.fail(error)
+    }
+
+    private func complete() {
+        guard !didComplete else { return }
+        didComplete = true
+        promise.succeed(
+            SSHTmuxRemoteCommandResult(exitStatus: exitStatus, stdout: stdout)
+        )
+    }
+}
+
 private enum SSHTmuxControlBootstrap {
+    static func detectRemotePlatform(
+        using sshRoot: RemuxSSHRoot,
+        trace: RemuxTransportStartupTrace
+    ) async throws -> SSHTmuxRemotePlatform {
+        let result = try await trace.stage("remotePlatform.detect") {
+            try await SSHTmuxRemoteCommandRunner.run(
+                command: SSHTmuxRemotePlatformDetector.windowsProbeCommand,
+                using: sshRoot,
+                timeout: .seconds(3),
+                trace: trace
+            )
+        }
+        let platform = try SSHTmuxRemotePlatformDetector.platform(
+            exitStatus: result.exitStatus,
+            stdout: result.stdout
+        )
+        trace.event("remotePlatform.detected", fields: ["platform": platform.description])
+        return platform
+    }
+
     static func openSessionChannel(
         using sshRoot: RemuxSSHRoot,
         trace: RemuxTransportStartupTrace
@@ -722,12 +1055,12 @@ private enum SSHTmuxControlBootstrap {
 
         // Deliberately NO pseudo-terminal: the control-mode protocol is a
         // plain byte stream pumped straight into Ghostty's session parser. A PTY
-        // would force `tmux -CC` (which demands a tty and wraps the stream
+        // would force POSIX `tmux -CC` (which demands a tty and wraps the stream
         // in a DCS 1000p envelope Ghostty's parser must not see) and adds
         // echo and CRLF line-discipline hazards. `tmux -C` over a bare exec
-        // channel emits exactly the verified wire contract; TERM is exported
-        // by the remote command line and the client size is owned by the
-        // session's refresh-client reporting.
+        // channel emits exactly the verified wire contract. Windows tmux.exe
+        // uses pipe-capable `-CC`; its DCS envelope is removed before Ghostty
+        // sees it. TERM is exported by the POSIX command line.
         try await trace.stage(
             "exec.request",
             fields: ["commandBytes": "\(command.lengthOfBytes(using: .utf8))"]

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -1120,6 +1120,101 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         XCTAssertEqual(tracker.pendingCount, 0)
     }
 
+    func testWindowsInputAdapterTranslatesGhosttyInput() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertEqual(
+            try adapter.adapt(Data("send-keys -H -t %7 64 69 72 0d\n".utf8)),
+            Data("send-keys -t %7 0x64 0x69 0x72 0xd\n".utf8)
+        )
+    }
+
+    func testWindowsInputAdapterBuffersSplitCommands() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertNil(try adapter.adapt(Data("send-keys -H -t %7 64 ".utf8)))
+        XCTAssertEqual(
+            try adapter.adapt(Data("69 72 0d\n".utf8)),
+            Data("send-keys -t %7 0x64 0x69 0x72 0xd\n".utf8)
+        )
+    }
+
+    func testWindowsInputAdapterTranslatesControlClientResize() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertEqual(
+            try adapter.adapt(Data("refresh-client -C 83x44\n".utf8)),
+            Data("refresh-client -C 83,44\n".utf8)
+        )
+    }
+
+    func testWindowsInputAdapterBuffersSplitControlClientResize() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertNil(try adapter.adapt(Data("refresh-client -C 83x".utf8)))
+        XCTAssertEqual(
+            try adapter.adapt(Data("44\n".utf8)),
+            Data("refresh-client -C 83,44\n".utf8)
+        )
+    }
+
+    func testWindowsInputAdapterTranslatesResizeAndInputInOneWrite() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertEqual(
+            try adapter.adapt(
+                Data("refresh-client -C 83x44\nsend-keys -H -t %7 64 69 72 0d\n".utf8)
+            ),
+            Data("refresh-client -C 83,44\nsend-keys -t %7 0x64 0x69 0x72 0xd\n".utf8)
+        )
+    }
+
+    func testWindowsInputAdapterPreservesMalformedControlClientResize() throws {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+        let command = Data("refresh-client -C 83xwide\n".utf8)
+
+        XCTAssertEqual(try adapter.adapt(command), command)
+    }
+
+    func testWindowsInputAdapterRejectsInvalidUTF8() {
+        let adapter = SSHTmuxControlInputAdapter(platform: .windows)
+
+        XCTAssertThrowsError(
+            try adapter.adapt(Data("send-keys -H -t %7 ff\n".utf8))
+        ) { error in
+            XCTAssertEqual(error as? SSHTmuxControlInputAdapterError, .invalidUTF8)
+        }
+    }
+
+    func testInputAdapterPreservesPOSIXCommands() throws {
+        let command = Data("send-keys -H -t %7 ff\n".utf8)
+
+        XCTAssertEqual(
+            try SSHTmuxControlInputAdapter(platform: .posix).adapt(command),
+            command
+        )
+    }
+
+    func testWindowsStartupOutputAdapterRemovesSplitDCSEnvelope() {
+        let adapter = SSHTmuxControlStartupOutputAdapter(platform: .windows)
+
+        XCTAssertNil(adapter.adapt(Data([0x1b, 0x50, 0x31])))
+        XCTAssertEqual(
+            adapter.adapt(Data("000p%begin 1 1 0\n%exit\n\u{1b}".utf8)),
+            Data("%begin 1 1 0\n%exit\n".utf8)
+        )
+        XCTAssertNil(adapter.adapt(Data("\\".utf8)))
+    }
+
+    func testStartupOutputAdapterPreservesPOSIXOutput() {
+        let output = Data("\u{1b}P1000p%begin 1 1 0\n".utf8)
+
+        XCTAssertEqual(
+            SSHTmuxControlStartupOutputAdapter(platform: .posix).adapt(output),
+            output
+        )
+    }
+
     func testChannelRequestReplyTrackerReportsUnknownFailureWithoutPendingReply() {
         var tracker = SSHTmuxControlChannelRequestReplyTracker()
 
@@ -1334,6 +1429,73 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         XCTAssertFalse(command.contains("\n"))
         XCTAssertFalse(command.contains("!"))
         XCTAssertTrue(command.hasSuffix(" 120 40"))
+    }
+
+    func testRemotePlatformDetectorRecognizesWindowsCmdMarker() {
+        XCTAssertEqual(
+            try SSHTmuxRemotePlatformDetector.platform(
+                exitStatus: 0,
+                stdout: Data("REMUX_WINDOWS_Windows_NT\r\n".utf8)
+            ),
+            .windows
+        )
+    }
+
+    func testRemotePlatformDetectorRecognizesNegativeCmdResultAsPOSIX() {
+        for status in [1, 127] {
+            XCTAssertEqual(
+                try SSHTmuxRemotePlatformDetector.platform(
+                    exitStatus: status,
+                    stdout: Data()
+                ),
+                .posix
+            )
+        }
+    }
+
+    func testRemotePlatformDetectorRejectsInconclusiveProbeResults() {
+        XCTAssertThrowsError(
+            try SSHTmuxRemotePlatformDetector.platform(
+                exitStatus: nil,
+                stdout: Data("REMUX_WINDOWS_Windows_NT".utf8)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SSHTmuxRemotePlatformDetectionError,
+                .missingExitStatus
+            )
+        }
+        XCTAssertThrowsError(
+            try SSHTmuxRemotePlatformDetector.platform(
+                exitStatus: 0,
+                stdout: Data("unexpected output".utf8)
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SSHTmuxRemotePlatformDetectionError,
+                .unexpectedSuccessfulOutput
+            )
+        }
+    }
+
+    func testWindowsControlSessionCommandUsesCmdAndBareTmuxName() {
+        let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+            platform: .windows,
+            tmuxExecutable: "tmux",
+            sessionName: "base",
+            initialViewport: TmuxControlViewport(
+                columns: 120,
+                rows: 40,
+                pixelWidth: 0,
+                pixelHeight: 0
+            )
+        )
+
+        XCTAssertTrue(command.hasPrefix("cmd.exe /d /s /c "))
+        XCTAssertTrue(command.contains(#""tmux" -u -CC new-session -A -s "base""#))
+        XCTAssertTrue(command.hasSuffix("-x 120 -y 40\""))
+        XCTAssertFalse(command.contains("/bin/sh"))
+        XCTAssertFalse(command.contains("tmux.exe"))
     }
 
     func testSendAfterCloseFailsInsteadOfQueueingBytes() async {

--- a/RemuxAppTests/SSHTmuxControlTransportTests.swift
+++ b/RemuxAppTests/SSHTmuxControlTransportTests.swift
@@ -1204,6 +1204,20 @@ final class SSHTmuxControlTransportTests: XCTestCase {
             Data("%begin 1 1 0\n%exit\n".utf8)
         )
         XCTAssertNil(adapter.adapt(Data("\\".utf8)))
+        XCTAssertEqual(
+            adapter.adapt(Data("%exit\n\u{1b}\\".utf8)),
+            Data("%exit\n\u{1b}\\".utf8)
+        )
+    }
+
+    func testWindowsStartupOutputAdapterPreservesUnwrappedOutput() {
+        let adapter = SSHTmuxControlStartupOutputAdapter(platform: .windows)
+
+        XCTAssertEqual(adapter.adapt(Data("%beg".utf8)), Data("%beg".utf8))
+        XCTAssertEqual(
+            adapter.adapt(Data("in 1 1 0\n\u{1b}\\".utf8)),
+            Data("in 1 1 0\n\u{1b}\\".utf8)
+        )
     }
 
     func testStartupOutputAdapterPreservesPOSIXOutput() {
@@ -1393,7 +1407,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
     }
 
     func testControlSessionCommandDelegatesStartupToPOSIXShell() {
-        let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+        let command = try! SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
             tmuxExecutable: "tmux",
             sessionName: "base",
             initialViewport: TmuxControlViewport(
@@ -1413,7 +1427,7 @@ final class SSHTmuxControlTransportTests: XCTestCase {
     func testControlSessionCommandKeepsValuesOutOfLoginShellSyntax() {
         let tmuxExecutable = "/home/owner's tools/tmux"
         let sessionName = "owner's bäse! back\\slash"
-        let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+        let command = try! SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
             tmuxExecutable: tmuxExecutable,
             sessionName: sessionName,
             initialViewport: TmuxControlViewport(
@@ -1478,8 +1492,8 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         }
     }
 
-    func testWindowsControlSessionCommandUsesCmdAndBareTmuxName() {
-        let command = SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+    func testWindowsControlSessionCommandUsesCmdAndBareTmuxName() throws {
+        let command = try SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
             platform: .windows,
             tmuxExecutable: "tmux",
             sessionName: "base",
@@ -1496,6 +1510,25 @@ final class SSHTmuxControlTransportTests: XCTestCase {
         XCTAssertTrue(command.hasSuffix("-x 120 -y 40\""))
         XCTAssertFalse(command.contains("/bin/sh"))
         XCTAssertFalse(command.contains("tmux.exe"))
+    }
+
+    func testWindowsControlSessionCommandRejectsPercentExpansion() {
+        for (tmuxExecutable, sessionName) in [("%TMUX%", "base"), ("tmux", "%SESSION%")]
+        {
+            XCTAssertThrowsError(
+                try SSHTmuxControlCommandBuilder.attachOrCreateControlSessionCommand(
+                    platform: .windows,
+                    tmuxExecutable: tmuxExecutable,
+                    sessionName: sessionName,
+                    initialViewport: .default
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SSHTmuxControlCommandBuilderError,
+                    .unsupportedWindowsArgument
+                )
+            }
+        }
     }
 
     func testSendAfterCloseFailsInsteadOfQueueingBytes() async {

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -625,7 +625,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 4)
     }
 
-    func testClientSizeRefreshesAcrossPortraitLandscapeRoundTrip() async throws {
+    func testPortraitLandscapeSizeSwapIsNotCoalesced() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,
             expectedPaneCount: 1
@@ -633,9 +633,11 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.setClientSize(cols: 120, rows: 32)
         await drain(harness.controller)
+        let landscapeWrites = harness.recorder.takeStrings()
+        XCTAssertEqual(landscapeWrites.count, 1)
         XCTAssertTrue(
-            try XCTUnwrap(harness.recorder.takeStrings().first)
-                .hasPrefix("refresh-client -C 120x32\n")
+            try XCTUnwrap(landscapeWrites.first)
+                .hasPrefix("refresh-client -C 120x32\ndisplay-message")
         )
 
         harness.controller.setClientSize(cols: 44, rows: 83)

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -625,6 +625,27 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 4)
     }
 
+    func testClientSizeRefreshesAcrossPortraitLandscapeRoundTrip() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+
+        harness.controller.setClientSize(cols: 120, rows: 32)
+        await drain(harness.controller)
+        XCTAssertTrue(
+            try XCTUnwrap(harness.recorder.takeStrings().first)
+                .hasPrefix("refresh-client -C 120x32\n")
+        )
+
+        harness.controller.setClientSize(cols: 44, rows: 83)
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["refresh-client -C 44x83\n"]
+        )
+    }
+
     func testInFlightGridRefreshFollowsViewportRevertExactlyOnce() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,


### PR DESCRIPTION
> [!IMPORTANT]
> This is an experimental PR. Windows/psmux support is based on the currently observed psmux control-mode protocol and may need follow-up as that implementation evolves.

## Summary

Add support for Windows-hosted tmux-compatible sessions over SSH.

- detect Windows by probing `cmd.exe`
- launch `tmux -CC` through `cmd.exe`
- unwrap the DCS control-mode envelope
- adapt `send-keys -H` input to psmux's `0xNN` format
- adapt `refresh-client` sizing for psmux
- preserve existing POSIX behavior

## Design decisions

- Probe only `cmd.exe`; do not probe for `psmux.exe` or `tmux.exe`.
- Use the configured bare `tmux` command and let Windows resolve `tmux.exe` through `PATH`.
- Apply protocol adaptations only after Windows is positively detected.
- Keep the existing POSIX `/bin/sh` launch path unchanged.
- Use a non-PTY SSH channel because psmux control mode expects plain pipes.
- Translate only known protocol differences and preserve unrelated commands byte-for-byte.
- Buffer newline-delimited commands so adaptations work across split SSH writes.
- Treat inconclusive platform detection as an error instead of silently selecting the wrong launcher.
- Keep this inside the existing SSH transport rather than introducing a larger backend abstraction.

## Upstream context

psmux uses a slightly different control-mode protocol from upstream tmux. These issues document the relevant compatibility work:

- https://github.com/psmux/psmux/issues/261
- https://github.com/psmux/psmux/issues/490

Issue #261 specifically covers the `-CC` DCS envelope, `0xNN` input encoding, and control-client resizing behavior adapted here.

## Testing

- 101 focused transport and client-size tests pass
- verified connecting and typing in a Windows session over SSH
- verified portrait → landscape → portrait resizing
- verified the Codex TUI reflows to the current viewport

## Screenshot

<img width="1204" height="2182" alt="CleanShot 2026-07-30 at 21 29 49@2x" src="https://github.com/user-attachments/assets/f8485316-0b10-4349-bdd0-35c2651387dc" />

---

Written with Codex using GPT-5.6 Sol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to and controlling tmux sessions on Windows hosts.
  * Remote platform detection automatically selects the appropriate control-session behavior.

* **Bug Fixes**
  * Improved Windows handling for keyboard input, resizing, startup output, and command buffering.
  * Improved error handling when detecting or opening remote sessions.
  * Client-size refresh now remains accurate when switching between portrait and landscape orientations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->