### PR TITLE
Make dock and composer control feedback consistently circular

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -113,9 +113,13 @@ private struct GhosttyComposerInputLayout: Layout {
 
         var x = bounds.minX
         for (index, size) in metrics.compactSizes.enumerated() {
+            let centersDictationContent = isDictationActive && index == 1
             subviews[index].place(
-                at: CGPoint(x: x, y: bounds.maxY),
-                anchor: .bottomLeading,
+                at: CGPoint(
+                    x: x,
+                    y: centersDictationContent ? bounds.midY : bounds.maxY
+                ),
+                anchor: centersDictationContent ? .leading : .bottomLeading,
                 proposal: ProposedViewSize(size)
             )
             x += size.width + horizontalSpacing

--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -448,7 +448,7 @@ struct GhosttyComposeBar: View {
                 .symbolRenderingMode(.monochrome)
                 .foregroundStyle(GhosttyPhoneChromePalette.chromeForeground)
                 .frame(width: 42, height: 42)
-                .contentShape(Circle())
+                .contentShape(Rectangle())
         }
         .menuStyle(.button)
         .buttonStyle(.plain)
@@ -523,7 +523,7 @@ private struct GhosttyComposerPressButtonStyle: ButtonStyle {
                             : Color.clear
                     )
             }
-            .contentShape(Circle())
+            .contentShape(Rectangle())
             .animation(.easeOut(duration: 0.10), value: configuration.isPressed)
     }
 }

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -41,6 +41,10 @@ enum GhosttyKeyboardChromeSizing {
     /// grow above this baseline without changing the terminal viewport.
     static let baselineHeight = dockButtonHeight + (controlGroupVerticalPadding * 2)
 
+    /// Standalone controls fill the dock baseline in both axes so their
+    /// circular material cannot be compressed into a capsule.
+    static let standaloneControlDiameter = baselineHeight
+
     static func keyboardReplacementHeight(
         keyboardOverlapHeight: CGFloat,
         bottomSafeAreaHeight: CGFloat
@@ -180,7 +184,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     private var composerSelectorRow: some View {
         HStack(alignment: .bottom, spacing: isCompact ? 8 : 10) {
             standaloneControlGroup {
-                composerToggleButton(systemName: "xmark")
+                composerToggleButton(systemName: "xmark", isStandalone: true)
             }
 
             composerContent()
@@ -189,7 +193,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                 .transition(.opacity)
 
             standaloneControlGroup {
-                keyboardToggleButton
+                keyboardToggleButton(isStandalone: true)
             }
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -203,6 +207,8 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     badge: nil,
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
+                    height: GhosttyKeyboardChromeSizing.dockButtonHeight,
+                    shape: .roundedRectangle,
                     accessibilityLabel: "Sessions",
                     accessibilityHint: "Switch active sessions or open the Remux library.",
                     accessibilityIdentifier: "terminal.sessions",
@@ -216,6 +222,8 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     badge: windowBadge,
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
+                    height: GhosttyKeyboardChromeSizing.dockButtonHeight,
+                    shape: .roundedRectangle,
                     accessibilityLabel: windowAccessibilityLabel,
                     accessibilityHint: windowDetail,
                     accessibilityIdentifier: "terminal.windows",
@@ -229,6 +237,8 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     badge: paneBadge,
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
+                    height: GhosttyKeyboardChromeSizing.dockButtonHeight,
+                    shape: .roundedRectangle,
                     accessibilityLabel: paneAccessibilityLabel,
                     accessibilityHint: paneDetail,
                     accessibilityIdentifier: "terminal.panes",
@@ -270,6 +280,8 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     badge: nil,
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
+                    height: GhosttyKeyboardChromeSizing.dockButtonHeight,
+                    shape: .roundedRectangle,
                     accessibilityLabel: "Home",
                     accessibilityHint: "Open the Remux library.",
                     accessibilityIdentifier: "terminal.home",
@@ -284,12 +296,20 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
         }
     }
 
-    private func composerToggleButton(systemName: String) -> some View {
-        GhosttyKeyboardChromeDockButton(
+    private func composerToggleButton(
+        systemName: String,
+        isStandalone: Bool = false
+    ) -> some View {
+        let dimension = isStandalone
+            ? GhosttyKeyboardChromeSizing.standaloneControlDiameter
+            : nil
+        return GhosttyKeyboardChromeDockButton(
             systemName: systemName,
             badge: nil,
             chromeStyle: chromeStyle,
-            width: dockButtonWidth,
+            width: dimension ?? dockButtonWidth,
+            height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
+            shape: isStandalone ? .circle : .roundedRectangle,
             accessibilityLabel: isComposerPresented ? "Close composer" : "Open composer",
             accessibilityHint: isComposerPresented
                 ? "Hide the compose field while preserving its draft."
@@ -306,11 +326,20 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     }
 
     private var keyboardToggleButton: some View {
-        GhosttyKeyboardChromeDockButton(
+        keyboardToggleButton(isStandalone: false)
+    }
+
+    private func keyboardToggleButton(isStandalone: Bool) -> some View {
+        let dimension = isStandalone
+            ? GhosttyKeyboardChromeSizing.standaloneControlDiameter
+            : nil
+        return GhosttyKeyboardChromeDockButton(
             systemName: "keyboard",
             badge: nil,
             chromeStyle: chromeStyle,
-            width: dockButtonWidth,
+            width: dimension ?? dockButtonWidth,
+            height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
+            shape: isStandalone ? .circle : .roundedRectangle,
             accessibilityLabel: keyboardMode == .hidden ? "Show keyboard controls" : "Hide keyboard controls",
             accessibilityHint: nil,
             accessibilityIdentifier: "terminal.keyboard",
@@ -334,7 +363,8 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     private func standaloneControlGroup<Content: View>(
         @ViewBuilder content: () -> Content
     ) -> some View {
-        controlGroup(content: content)
+        content()
+            .ghosttyStandaloneToolbarSurface()
             .fixedSize()
     }
 
@@ -403,6 +433,8 @@ private struct GhosttyKeyboardChromeDockButton: View {
     let badge: String?
     let chromeStyle: GhosttyTerminalChromeStyle
     let width: CGFloat
+    let height: CGFloat
+    let shape: GhosttyChromeDockButtonShape
     let accessibilityLabel: String
     let accessibilityHint: String?
     let accessibilityIdentifier: String
@@ -428,7 +460,8 @@ private struct GhosttyKeyboardChromeDockButton: View {
             isEnabled: isEnabled,
             chromeStyle: chromeStyle,
             width: width,
-            height: GhosttyKeyboardChromeSizing.dockButtonHeight
+            height: height,
+            shape: shape
         ))
         .disabled(!isEnabled)
         .accessibilityLabel(accessibilityLabel)
@@ -479,7 +512,8 @@ private struct GhosttyKeyboardKeyButton: View {
                 isActive: isActive,
                 isPressed: isPressed,
                 isEnabled: isEnabled,
-                chromeStyle: chromeStyle
+                chromeStyle: chromeStyle,
+                shape: .roundedRectangle
             )
             .scaleEffect(isPressed && isEnabled ? 0.96 : 1)
             .opacity(isEnabled ? 1 : 0.42)
@@ -549,6 +583,7 @@ private struct GhosttyChromeDockButtonStyle: ButtonStyle {
     let chromeStyle: GhosttyTerminalChromeStyle
     let width: CGFloat
     let height: CGFloat
+    let shape: GhosttyChromeDockButtonShape
 
     func makeBody(configuration: Configuration) -> some View {
         GhosttyChromePressBody(
@@ -563,34 +598,54 @@ private struct GhosttyChromeDockButtonStyle: ButtonStyle {
                     isActive: isActive,
                     isPressed: configuration.isPressed,
                     isEnabled: isEnabled,
-                    chromeStyle: chromeStyle
+                    chromeStyle: chromeStyle,
+                    shape: shape
                 )
         }
     }
 }
 
+private enum GhosttyChromeDockButtonShape {
+    case roundedRectangle
+    case circle
+}
+
 private extension View {
     @ViewBuilder
     func ghosttyToolbarGroupSurface() -> some View {
+        ghosttyToolbarSurface(in: Capsule())
+    }
+
+    @ViewBuilder
+    func ghosttyStandaloneToolbarSurface() -> some View {
+        ghosttyToolbarSurface(in: Circle())
+    }
+
+    @ViewBuilder
+    private func ghosttyToolbarSurface<S: InsettableShape>(in shape: S) -> some View {
         if #available(iOS 26.0, *) {
             self
                 .glassEffect(
                     .regular
                         .tint(GhosttyPhoneChromePalette.toolbarGlassTint)
                         .interactive(),
-                    in: Capsule()
+                    in: shape
                 )
                 .overlay {
-                    Capsule()
-                        .strokeBorder(GhosttyPhoneChromePalette.toolbarGlassStroke, lineWidth: 0.75)
+                    shape.strokeBorder(
+                        GhosttyPhoneChromePalette.toolbarGlassStroke,
+                        lineWidth: 0.75
+                    )
                 }
                 .shadow(color: GhosttyPhoneChromePalette.toolbarGlassShadow, radius: 13, y: 7)
         } else {
             self
-                .background(GhosttyPhoneChromePalette.toolbarFallbackFill, in: Capsule())
+                .background(GhosttyPhoneChromePalette.toolbarFallbackFill, in: shape)
                 .overlay {
-                    Capsule()
-                        .strokeBorder(GhosttyPhoneChromePalette.toolbarStroke, lineWidth: 1)
+                    shape.strokeBorder(
+                        GhosttyPhoneChromePalette.toolbarStroke,
+                        lineWidth: 1
+                    )
                 }
                 .shadow(color: GhosttyPhoneChromePalette.toolbarShadow, radius: 8, y: 4)
         }
@@ -601,12 +656,40 @@ private extension View {
         isActive: Bool,
         isPressed: Bool,
         isEnabled: Bool,
-        chromeStyle: GhosttyTerminalChromeStyle
+        chromeStyle: GhosttyTerminalChromeStyle,
+        shape: GhosttyChromeDockButtonShape
     ) -> some View {
-        let shape = RoundedRectangle(
-            cornerRadius: GhosttyKeyboardChromeSizing.dockButtonCornerRadius,
-            style: .continuous
-        )
+        switch shape {
+        case .roundedRectangle:
+            ghosttyToolbarButtonSurface(
+                isActive: isActive,
+                isPressed: isPressed,
+                isEnabled: isEnabled,
+                chromeStyle: chromeStyle,
+                in: RoundedRectangle(
+                    cornerRadius: GhosttyKeyboardChromeSizing.dockButtonCornerRadius,
+                    style: .continuous
+                )
+            )
+        case .circle:
+            ghosttyToolbarButtonSurface(
+                isActive: isActive,
+                isPressed: isPressed,
+                isEnabled: isEnabled,
+                chromeStyle: chromeStyle,
+                in: Circle()
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func ghosttyToolbarButtonSurface<S: Shape>(
+        isActive: Bool,
+        isPressed: Bool,
+        isEnabled: Bool,
+        chromeStyle: GhosttyTerminalChromeStyle,
+        in shape: S
+    ) -> some View {
 
         if #available(iOS 26.0, *) {
             self

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -34,7 +34,6 @@ enum GhosttyKeyboardChromeSizing {
     static let dockButtonHeight: CGFloat = 38
     static let dockButtonWidth: CGFloat = 38
     static let compactDockButtonWidth: CGFloat = 35
-    static let dockButtonCornerRadius: CGFloat = 17
     static let controlGroupVerticalPadding: CGFloat = 4
 
     /// The bottom chrome always reserves one dock row. Composer content may
@@ -208,7 +207,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
                     height: GhosttyKeyboardChromeSizing.dockButtonHeight,
-                    shape: .roundedRectangle,
                     accessibilityLabel: "Sessions",
                     accessibilityHint: "Switch active sessions or open the Remux library.",
                     accessibilityIdentifier: "terminal.sessions",
@@ -223,7 +221,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
                     height: GhosttyKeyboardChromeSizing.dockButtonHeight,
-                    shape: .roundedRectangle,
                     accessibilityLabel: windowAccessibilityLabel,
                     accessibilityHint: windowDetail,
                     accessibilityIdentifier: "terminal.windows",
@@ -238,7 +235,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
                     height: GhosttyKeyboardChromeSizing.dockButtonHeight,
-                    shape: .roundedRectangle,
                     accessibilityLabel: paneAccessibilityLabel,
                     accessibilityHint: paneDetail,
                     accessibilityIdentifier: "terminal.panes",
@@ -281,7 +277,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     chromeStyle: chromeStyle,
                     width: dockButtonWidth,
                     height: GhosttyKeyboardChromeSizing.dockButtonHeight,
-                    shape: .roundedRectangle,
                     accessibilityLabel: "Home",
                     accessibilityHint: "Open the Remux library.",
                     accessibilityIdentifier: "terminal.home",
@@ -309,7 +304,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
             chromeStyle: chromeStyle,
             width: dimension ?? dockButtonWidth,
             height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
-            shape: isStandalone ? .circle : .roundedRectangle,
             accessibilityLabel: isComposerPresented ? "Close composer" : "Open composer",
             accessibilityHint: isComposerPresented
                 ? "Hide the compose field while preserving its draft."
@@ -339,7 +333,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
             chromeStyle: chromeStyle,
             width: dimension ?? dockButtonWidth,
             height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
-            shape: isStandalone ? .circle : .roundedRectangle,
             accessibilityLabel: keyboardMode == .hidden ? "Show keyboard controls" : "Hide keyboard controls",
             accessibilityHint: nil,
             accessibilityIdentifier: "terminal.keyboard",
@@ -434,7 +427,6 @@ private struct GhosttyKeyboardChromeDockButton: View {
     let chromeStyle: GhosttyTerminalChromeStyle
     let width: CGFloat
     let height: CGFloat
-    let shape: GhosttyChromeDockButtonShape
     let accessibilityLabel: String
     let accessibilityHint: String?
     let accessibilityIdentifier: String
@@ -460,8 +452,7 @@ private struct GhosttyKeyboardChromeDockButton: View {
             isEnabled: isEnabled,
             chromeStyle: chromeStyle,
             width: width,
-            height: height,
-            shape: shape
+            height: height
         ))
         .disabled(!isEnabled)
         .accessibilityLabel(accessibilityLabel)
@@ -512,17 +503,11 @@ private struct GhosttyKeyboardKeyButton: View {
                 isActive: isActive,
                 isPressed: isPressed,
                 isEnabled: isEnabled,
-                chromeStyle: chromeStyle,
-                shape: .roundedRectangle
+                chromeStyle: chromeStyle
             )
             .scaleEffect(isPressed && isEnabled ? 0.96 : 1)
             .opacity(isEnabled ? 1 : 0.42)
-            .contentShape(
-                RoundedRectangle(
-                    cornerRadius: GhosttyKeyboardChromeSizing.dockButtonCornerRadius,
-                    style: .continuous
-                )
-            )
+            .contentShape(Rectangle())
             .accessibilityLabel(title)
             .accessibilityIdentifier(accessibilityIdentifier)
             .accessibilityAddTraits(.isButton)
@@ -583,7 +568,6 @@ private struct GhosttyChromeDockButtonStyle: ButtonStyle {
     let chromeStyle: GhosttyTerminalChromeStyle
     let width: CGFloat
     let height: CGFloat
-    let shape: GhosttyChromeDockButtonShape
 
     func makeBody(configuration: Configuration) -> some View {
         GhosttyChromePressBody(
@@ -598,16 +582,11 @@ private struct GhosttyChromeDockButtonStyle: ButtonStyle {
                     isActive: isActive,
                     isPressed: configuration.isPressed,
                     isEnabled: isEnabled,
-                    chromeStyle: chromeStyle,
-                    shape: shape
+                    chromeStyle: chromeStyle
                 )
+                .contentShape(Rectangle())
         }
     }
-}
-
-private enum GhosttyChromeDockButtonShape {
-    case roundedRectangle
-    case circle
 }
 
 private extension View {
@@ -656,40 +635,9 @@ private extension View {
         isActive: Bool,
         isPressed: Bool,
         isEnabled: Bool,
-        chromeStyle: GhosttyTerminalChromeStyle,
-        shape: GhosttyChromeDockButtonShape
+        chromeStyle: GhosttyTerminalChromeStyle
     ) -> some View {
-        switch shape {
-        case .roundedRectangle:
-            ghosttyToolbarButtonSurface(
-                isActive: isActive,
-                isPressed: isPressed,
-                isEnabled: isEnabled,
-                chromeStyle: chromeStyle,
-                in: RoundedRectangle(
-                    cornerRadius: GhosttyKeyboardChromeSizing.dockButtonCornerRadius,
-                    style: .continuous
-                )
-            )
-        case .circle:
-            ghosttyToolbarButtonSurface(
-                isActive: isActive,
-                isPressed: isPressed,
-                isEnabled: isEnabled,
-                chromeStyle: chromeStyle,
-                in: Circle()
-            )
-        }
-    }
-
-    @ViewBuilder
-    private func ghosttyToolbarButtonSurface<S: Shape>(
-        isActive: Bool,
-        isPressed: Bool,
-        isEnabled: Bool,
-        chromeStyle: GhosttyTerminalChromeStyle,
-        in shape: S
-    ) -> some View {
+        let shape = Circle()
 
         if #available(iOS 26.0, *) {
             self
@@ -697,7 +645,6 @@ private extension View {
                 .overlay {
                     shape.fill(isPressed && isEnabled ? GhosttyPhoneChromePalette.toolbarButtonPressedFill : Color.clear)
                 }
-                .contentShape(shape)
         } else {
             let activeFill = isActive ? chromeStyle.toolbarButtonActiveFill : Color.clear
             let pressedFill = isPressed && isEnabled ? GhosttyPhoneChromePalette.toolbarButtonPressedFill : Color.clear
@@ -707,7 +654,6 @@ private extension View {
                 .overlay {
                     shape.fill(pressedFill)
                 }
-                .contentShape(shape)
         }
     }
 }

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -3,6 +3,17 @@ import XCTest
 @testable import Remux
 
 final class GhosttyPhoneChromeLayoutTests: XCTestCase {
+    func testStandaloneControlDiameterMatchesDockBaseline() {
+        XCTAssertEqual(
+            GhosttyKeyboardChromeSizing.standaloneControlDiameter,
+            GhosttyKeyboardChromeSizing.baselineHeight
+        )
+        XCTAssertGreaterThanOrEqual(
+            GhosttyKeyboardChromeSizing.standaloneControlDiameter,
+            44
+        )
+    }
+
     func testNarrowPortraitUsesCompactChrome() {
         let layout = GhosttyPhoneChromeLayout(
             screenSize: CGSize(width: 390, height: 844)

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -163,9 +163,16 @@ final class RemuxAppUITests: XCTestCase {
 
         let terminal = app.otherElements["terminal.screen"]
         XCTAssertTrue(terminal.waitForExistence(timeout: 5))
+
         let composerToggle = app.buttons["terminal.composer.toggle"]
         XCTAssertTrue(composerToggle.waitForExistence(timeout: 5))
-        composerToggle.tap()
+        // Exercise the allocated button cell outside the inscribed circular
+        // feedback. The full cell must remain interactive even though only
+        // the circle is rendered when the control is pressed.
+        composerToggle
+            .coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+            .withOffset(CGVector(dx: 2, dy: 2))
+            .tap()
 
         let composer = app.otherElements["terminal.composer.bounds"]
         XCTAssertTrue(composer.waitForExistence(timeout: 3))

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -169,6 +169,20 @@ final class RemuxAppUITests: XCTestCase {
 
         let composer = app.otherElements["terminal.composer.bounds"]
         XCTAssertTrue(composer.waitForExistence(timeout: 3))
+        let keyboardToggle = app.buttons["terminal.keyboard"]
+        XCTAssertTrue(keyboardToggle.waitForExistence(timeout: 3))
+        XCTAssertEqual(
+            composerToggle.frame.width,
+            composerToggle.frame.height,
+            accuracy: 1,
+            "The standalone composer control must remain circular."
+        )
+        XCTAssertEqual(
+            keyboardToggle.frame.width,
+            keyboardToggle.frame.height,
+            accuracy: 1,
+            "The standalone keyboard control must remain circular."
+        )
         let compactWidth = composer.frame.width
         XCTAssertGreaterThan(
             compactWidth,


### PR DESCRIPTION
### Summary

- Make active and pressed feedback circular across dock and composer controls.
- Keep grouped dock materials capsule-shaped and standalone controls circular.
- Expand button hit regions to the full allocated rectangular cells.
- Remove obsolete shape-selection machinery and corner-radius configuration.
- Center dictation waveform content using the layout’s computed row geometry.

### Behavior preserved

- Existing dimensions and spacing
- Badges and accessibility identifiers
- Gestures, haptics, and transitions
- Keyboard and terminal viewport behavior
- Composer interaction flow

### Validation

- Built and tested on both the physical iPhone and dedicated simulator.
- Focused UI flow passed, including corner tapping outside the visible circle.
- Layout tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved compact composer layout by vertically centering dictation content and aligning controls consistently.
  * Updated attachment, composer, and keyboard controls with clearer circular or rectangular surfaces and hit areas.
  * Enhanced toolbar and dock button sizing across supported iOS versions.
  * Ensured standalone keyboard controls meet minimum touch-target sizing.

* **Tests**
  * Added and updated layout and UI coverage for control sizing, shapes, and composer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->