### PR TITLE
fix: preserve remote tmux pane layouts

### DIFF
--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -947,10 +947,7 @@ final class TmuxSessionController: @unchecked Sendable {
             return
         }
 
-        let hasSibling = topology.panes.contains {
-            $0.windowID == window.id && $0.id != paneID
-        }
-        if window.activePaneID == paneID, window.zoomed || !hasSibling {
+        if window.activePaneID == paneID {
             let admittedRefresh = admitPaneRefreshIfNeeded(
                 paneID,
                 failureRequest: .selectPane
@@ -958,11 +955,10 @@ final class TmuxSessionController: @unchecked Sendable {
             if admittedRefresh, drainOutbound { _ = self.drainOutbound() }
             return
         }
-        let command = window.zoomed
-            ? "select-pane -Z -t %\(paneID.rawValue)"
-            : "resize-pane -Z -t %\(paneID.rawValue)"
         submitPanePresentationCommandOnWriter(
-            command: command,
+            command: window.zoomed
+                ? "select-pane -Z -t %\(paneID.rawValue)"
+                : "select-pane -t %\(paneID.rawValue)",
             request: .selectPane,
             paneID: paneID,
             drainOutbound: drainOutbound
@@ -982,13 +978,9 @@ final class TmuxSessionController: @unchecked Sendable {
             return
         }
         let paneID = preferredPaneID ?? window.activePaneID
-        let hasSibling = topology.panes.contains { pane in
-            pane.windowID == windowID && pane.id != paneID
-        }
-
         if topology.activeWindowID == windowID {
             guard let paneID else { return }
-            if window.zoomed || !hasSibling {
+            if window.activePaneID == paneID {
                 let admittedRefresh = admitPaneRefreshIfNeeded(
                     paneID,
                     failureRequest: .selectWindow
@@ -997,7 +989,9 @@ final class TmuxSessionController: @unchecked Sendable {
                 return
             }
             submitPanePresentationCommandOnWriter(
-                command: "resize-pane -Z -t %\(paneID.rawValue)",
+                command: window.zoomed
+                    ? "select-pane -Z -t %\(paneID.rawValue)"
+                    : "select-pane -t %\(paneID.rawValue)",
                 request: .selectWindow,
                 paneID: paneID,
                 drainOutbound: drainOutbound
@@ -1016,8 +1010,7 @@ final class TmuxSessionController: @unchecked Sendable {
             windowID: windowID,
             activePaneID: window.activePaneID,
             preferredPaneID: preferredPaneID,
-            zoomed: window.zoomed,
-            hasSibling: hasSibling
+            zoomed: window.zoomed
         )
         if commands.count == 1 {
             guard let paneID else {
@@ -1074,20 +1067,17 @@ final class TmuxSessionController: @unchecked Sendable {
         windowID: TmuxWindowID,
         activePaneID: TmuxPaneID?,
         preferredPaneID: TmuxPaneID?,
-        zoomed: Bool,
-        hasSibling: Bool
+        zoomed: Bool
     ) -> [String] {
         let selectWindow = "select-window -t @\(windowID.rawValue)"
-        guard hasSibling,
-              let preferredPaneID
+        guard let preferredPaneID,
+              preferredPaneID != activePaneID
         else { return [selectWindow] }
-        if zoomed, preferredPaneID == activePaneID {
-            return [selectWindow]
-        }
-        let selectPane = zoomed ? "select-pane" : "resize-pane"
         return [
             selectWindow,
-            "\(selectPane) -Z -t %\(preferredPaneID.rawValue)",
+            zoomed
+                ? "select-pane -Z -t %\(preferredPaneID.rawValue)"
+                : "select-pane -t %\(preferredPaneID.rawValue)",
         ]
     }
 

--- a/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
@@ -38,7 +38,6 @@ final class TmuxTerminalSession: ObservableObject {
     private var creatingPaneIDs: Set<TmuxPaneID> = []
     private var failedCreationPaneIDs: Set<TmuxPaneID> = []
     private var pendingPaneID: TmuxPaneID?
-    private var zoomRequestedPaneID: TmuxPaneID?
     private var preparingSurface: TmuxPaneSurface?
     private var viewportMetrics: GhosttySurfaceDisplayMetrics?
     private var isAppActive = true
@@ -145,7 +144,6 @@ final class TmuxTerminalSession: ObservableObject {
         guard !isShutDown else { return }
         isShutDown = true
         pendingPaneID = nil
-        zoomRequestedPaneID = nil
         cancelPendingPresentation()
         livePaneIDs.removeAll()
         pendingTerminalsByPaneID.removeAll()
@@ -193,7 +191,6 @@ final class TmuxTerminalSession: ObservableObject {
         switch newState {
         case .detached, .closed:
             pendingPaneID = nil
-            zoomRequestedPaneID = nil
             cancelPendingPresentation()
             linkIsActive = false
             Task { await link.stop() }
@@ -210,11 +207,6 @@ final class TmuxTerminalSession: ObservableObject {
         livePaneIDs = Set(snapshot.panes.lazy.filter { $0.phase == .live }.map(\.id))
         pendingTerminalsByPaneID = pendingTerminalsByPaneID.filter { paneIDs.contains($0.key) }
         failedCreationPaneIDs.formIntersection(paneIDs)
-        if let zoomRequestedPaneID,
-           activePaneID(in: snapshot) != zoomRequestedPaneID
-            || isFullViewport(paneID: zoomRequestedPaneID, in: snapshot) {
-            self.zoomRequestedPaneID = nil
-        }
         presentActivePane(from: snapshot)
     }
 
@@ -223,7 +215,6 @@ final class TmuxTerminalSession: ObservableObject {
         pendingTerminalsByPaneID.removeValue(forKey: paneID)
         failedCreationPaneIDs.remove(paneID)
         if pendingPaneID == paneID { pendingPaneID = nil }
-        if zoomRequestedPaneID == paneID { zoomRequestedPaneID = nil }
         if preparingSurface?.paneID == paneID { cancelPendingPresentation() }
         if paneSurface?.paneID == paneID { unpublishPane() }
         guard let surface = surfacesByPaneID[paneID] else { return }
@@ -312,12 +303,10 @@ final class TmuxTerminalSession: ObservableObject {
         lastFailedRequest = request
         if request == .selectPane || request == .selectWindow {
             pendingPaneID = nil
-            zoomRequestedPaneID = nil
             cancelPendingPresentation()
         }
         if request == .zoomPane {
-            // Keep the terminal unpresented: split geometry is not the phone's
-            // canonical terminal viewport.
+            // Explicit zoom failed; keep the current pane presentation unchanged.
             return
         }
         if let topology { presentActivePane(from: topology) }
@@ -395,8 +384,7 @@ final class TmuxTerminalSession: ObservableObject {
               let topology,
               topology.panes.contains(where: { $0.id == paneID })
         else { return }
-        if activePaneID(in: topology) == paneID,
-           isFullViewport(paneID: paneID, in: topology) {
+        if activePaneID(in: topology) == paneID {
             let hasConflictingIntent = pendingPaneID != nil && pendingPaneID != paneID
             if !hasConflictingIntent {
                 if paneSurface?.paneID == paneID || preparingSurface?.paneID == paneID {
@@ -411,9 +399,6 @@ final class TmuxTerminalSession: ObservableObject {
         surfacesByPaneID[paneID]?.cancelPickerCaptureForPresentation()
         cancelPendingPresentation()
         pendingPaneID = paneID
-        zoomRequestedPaneID = isFullViewport(paneID: paneID, in: topology)
-            ? nil
-            : paneID
         unpublishPane()
     }
 
@@ -450,8 +435,7 @@ final class TmuxTerminalSession: ObservableObject {
             // contents in place. Keep that real surface focused so input can
             // remain ordered through the control-client queue; only a pane
             // that has not yet been presented must wait for hydration.
-            if paneSurface?.paneID == paneID,
-               isFullViewport(paneID: paneID, in: snapshot) {
+            if paneSurface?.paneID == paneID {
                 paneSurface?.setSceneActive(true)
                 return
             }
@@ -459,16 +443,6 @@ final class TmuxTerminalSession: ObservableObject {
             unpublishPane()
             return
         }
-
-        guard isFullViewport(paneID: paneID, in: snapshot) else {
-            unpublishPane()
-            if zoomRequestedPaneID != paneID {
-                zoomRequestedPaneID = paneID
-                controller.requestZoomPane(paneID: paneID)
-            }
-            return
-        }
-        zoomRequestedPaneID = nil
 
         guard paneSurface?.paneID != paneID else {
             pendingPaneID = nil
@@ -496,8 +470,7 @@ final class TmuxTerminalSession: ObservableObject {
                   let topology,
                   activePaneID(in: topology) == surface.paneID,
                   livePaneIDs.contains(surface.paneID),
-                  pendingPaneID == nil || pendingPaneID == surface.paneID,
-                  isFullViewport(paneID: surface.paneID, in: topology)
+                  pendingPaneID == nil || pendingPaneID == surface.paneID
             else {
                 surface.cancelPresentationPreparation()
                 return
@@ -562,22 +535,8 @@ final class TmuxTerminalSession: ObservableObject {
         return snapshot.windows.first(where: { $0.id == windowID })?.activePaneID
     }
 
-    private func isFullViewport(
-        paneID: TmuxPaneID,
-        in snapshot: TmuxSessionController.TopologySnapshot
-    ) -> Bool {
-        guard let pane = snapshot.panes.first(where: { $0.id == paneID }),
-              let window = snapshot.windows.first(where: { $0.id == pane.windowID })
-        else { return false }
-        if window.zoomed { return true }
-        return !snapshot.panes.contains {
-            $0.windowID == window.id && $0.id != paneID
-        }
-    }
-
     #if DEBUG
     var pendingPaneIDForTesting: TmuxPaneID? { pendingPaneID }
-    var zoomRequestedPaneIDForTesting: TmuxPaneID? { zoomRequestedPaneID }
     var creatingPaneIDsForTesting: Set<TmuxPaneID> { creatingPaneIDs }
     func handleStateForTesting(_ state: TmuxSessionController.SessionState) { handleState(state) }
     func handleRequestFailedForTesting(_ request: TmuxSessionController.Request) {

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -5,34 +5,28 @@ import XCTest
 
 @MainActor
 final class TmuxSessionControllerClientSizeTests: XCTestCase {
+    func testCrossWindowPaneSelectionDoesNotMutateHostLayout() {
+        let commands = TmuxSessionController.crossWindowSelectionCommands(
+            windowID: 2,
+            activePaneID: 20,
+            preferredPaneID: 21,
+            zoomed: false
+        )
+
+        XCTAssertEqual(
+            commands,
+            ["select-window -t @2", "select-pane -t %21"]
+        )
+        XCTAssertFalse(commands.joined(separator: " ").contains("-Z"))
+    }
+
     func testCrossWindowSelectionCommandPolicy() {
         XCTAssertEqual(
             TmuxSessionController.crossWindowSelectionCommands(
                 windowID: 2,
                 activePaneID: 20,
                 preferredPaneID: 20,
-                zoomed: false,
-                hasSibling: true
-            ),
-            ["select-window -t @2", "resize-pane -Z -t %20"]
-        )
-        XCTAssertEqual(
-            TmuxSessionController.crossWindowSelectionCommands(
-                windowID: 2,
-                activePaneID: 20,
-                preferredPaneID: 21,
-                zoomed: true,
-                hasSibling: true
-            ),
-            ["select-window -t @2", "select-pane -Z -t %21"]
-        )
-        XCTAssertEqual(
-            TmuxSessionController.crossWindowSelectionCommands(
-                windowID: 2,
-                activePaneID: 20,
-                preferredPaneID: 20,
-                zoomed: true,
-                hasSibling: true
+                zoomed: true
             ),
             ["select-window -t @2"]
         )
@@ -40,9 +34,26 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             TmuxSessionController.crossWindowSelectionCommands(
                 windowID: 2,
                 activePaneID: 20,
+                preferredPaneID: 21,
+                zoomed: true
+            ),
+            ["select-window -t @2", "select-pane -Z -t %21"]
+        )
+        XCTAssertEqual(
+            TmuxSessionController.crossWindowSelectionCommands(
+                windowID: 2,
+                activePaneID: 20,
+                preferredPaneID: 21,
+                zoomed: false
+            ),
+            ["select-window -t @2", "select-pane -t %21"]
+        )
+        XCTAssertEqual(
+            TmuxSessionController.crossWindowSelectionCommands(
+                windowID: 2,
+                activePaneID: 20,
                 preferredPaneID: nil,
-                zoomed: false,
-                hasSibling: true
+                zoomed: true
             ),
             ["select-window -t @2"]
         )
@@ -410,7 +421,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
     }
 
-    func testRepeatedCrossWindowUnzoomedSelectionDoesNotQueueSecondToggle() async throws {
+    func testRepeatedCrossWindowSelectionDoesNotAddZoom() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.splitTargetWindow,
             expectedPaneCount: 3
@@ -422,14 +433,12 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertPresentationWrite(
             harness.recorder.takeStrings(),
-            command: "select-window -t @1 ; resize-pane -Z -t %1",
+            command: "select-window -t @1",
             paneID: 1,
         )
 
         harness.controller.pump(Data(
             ("%session-window-changed $42 @1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + "%layout-change @1 9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2} b7de,83x44,0,0,1 *Z\n"
                 + responseBlock(commandNumber: &nextCommandNumber)
                 + refreshResponseBlocks(
                     paneID: 1,
@@ -439,11 +448,11 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         XCTAssertTrue(
             harness.recorder.takeStrings().isEmpty,
-            "the repeated intent must re-evaluate as zero after the first group zooms"
+            "the repeated intent must re-evaluate as zero after selection"
         )
     }
 
-    func testDeferredZoomDoesNotToggleAfterWindowSelectionAlreadyZooms() async throws {
+    func testExplicitZoomRunsAfterNonMutatingWindowSelection() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.splitTargetWindow,
             expectedPaneCount: 3
@@ -455,14 +464,12 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertPresentationWrite(
             harness.recorder.takeStrings(),
-            command: "select-window -t @1 ; resize-pane -Z -t %1",
+            command: "select-window -t @1",
             paneID: 1,
         )
 
         harness.controller.pump(Data(
             ("%session-window-changed $42 @1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + "%layout-change @1 9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2} b7de,83x44,0,0,1 *Z\n"
                 + responseBlock(commandNumber: &nextCommandNumber)
                 + refreshResponseBlocks(
                     paneID: 1,
@@ -470,9 +477,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
                 )).utf8
         ))
         await drain(harness.controller)
-        XCTAssertTrue(
-            harness.recorder.takeStrings().isEmpty,
-            "the deferred zoom must re-evaluate to a no-op after the selection group zooms"
+        assertPresentationWrite(
+            harness.recorder.takeStrings(),
+            command: "resize-pane -Z -t %1",
+            paneID: 1,
         )
     }
 
@@ -496,7 +504,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["select-window -t @0\n"])
     }
 
-    func testColdSplitSelectionEnqueuesPresentationThenRefreshInOneWrite() async throws {
+    func testColdSplitSelectionSelectsWithoutZoomThenRefreshesInOneWrite() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.twoPaneUnzoomedWindow,
             expectedPaneCount: 2
@@ -507,7 +515,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         assertPresentationWrite(
             harness.recorder.takeStrings(),
-            command: "resize-pane -Z -t %2",
+            command: "select-pane -t %2",
             paneID: 2,
         )
     }

--- a/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
+++ b/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
@@ -5,6 +5,18 @@ import XCTest
 
 @MainActor
 final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
+    func testUnzoomedActivePaneDoesNotRequestZoomForPresentation() async throws {
+        let runtime = try GhosttyKitRuntime()
+        let session = makeSession(runtime: runtime)
+        session.handleStateForTesting(.ready)
+
+        session.handleTopology(twoPaneSnapshot(activePaneID: 10, zoomed: false))
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertNil(session.lastFailedRequest)
+        await session.shutdown()
+    }
+
     func testRetainedTerminalHandoffPromotesHydratingPaneToLive() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)
@@ -64,7 +76,7 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
         await session.shutdown()
     }
 
-    func testSameWindowSelectionSuppressesDuplicateZoomForIntermediateTopology() async throws {
+    func testSameWindowSelectionKeepsPendingIntentWithoutRequestingZoom() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)
         session.handleTopology(twoPaneSnapshot(activePaneID: 10, zoomed: false))
@@ -75,12 +87,11 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(50))
 
         XCTAssertEqual(session.pendingPaneIDForTesting, 11)
-        XCTAssertEqual(session.zoomRequestedPaneIDForTesting, 11)
-        XCTAssertNil(session.lastFailedRequest, "intermediate topology must not enqueue a second zoom")
+        XCTAssertNil(session.lastFailedRequest, "intermediate topology must not enqueue a zoom")
         await session.shutdown()
     }
 
-    func testCrossWindowSelectionSuppressesDuplicateZoomForIntermediateTopology() async throws {
+    func testCrossWindowSelectionKeepsPendingIntentWithoutRequestingZoom() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)
         session.handleTopology(crossWindowSnapshot(activeWindowID: 1, targetActivePaneID: 20))
@@ -91,12 +102,11 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(50))
 
         XCTAssertEqual(session.pendingPaneIDForTesting, 21)
-        XCTAssertEqual(session.zoomRequestedPaneIDForTesting, 21)
-        XCTAssertNil(session.lastFailedRequest, "group intermediate topology must not toggle zoom again")
+        XCTAssertNil(session.lastFailedRequest, "group intermediate topology must not request zoom")
         await session.shutdown()
     }
 
-    func testSelectionFailureClearsPendingZoomIntent() async throws {
+    func testSelectionFailureClearsPendingIntent() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)
         session.handleTopology(twoPaneSnapshot(activePaneID: 10, zoomed: false))
@@ -105,7 +115,6 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
         session.handleRequestFailedForTesting(.selectPane)
 
         XCTAssertNil(session.pendingPaneIDForTesting)
-        XCTAssertNil(session.zoomRequestedPaneIDForTesting)
         await session.shutdown()
     }
 


### PR DESCRIPTION
## Summary

- stop automatically zooming a pane merely to present it
- preserve zoom when switching panes in an already-zoomed tmux window
- keep unzoomed tmux windows unzoomed during pane selection
- leave explicit pane zoom as a user-initiated action

## Why

Opening or switching terminal panes could mutate the host tmux layout. Pane presentation should select the requested pane without changing whether its tmux window is zoomed.

## Validation

- focused tmux controller and terminal-session tests
- complete Remux test suite
- isolated tmux behavior check for zoom-preserving pane selection
- independent review of the exact commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane and window selection across split layouts and windows.
  * Preserved the current presentation when zoom requests fail or layouts change.
  * Prevented unintended layout changes and unnecessary zoom toggles during selection.
  * Improved selection reliability during shutdown and intermediate layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->