### PR TITLE
redesign the terminal composer as a unified input surface

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -648,6 +648,9 @@ struct GhosttyComposerDictationMeterSizing {
     static let maximumWidth: CGFloat = 220
     static let targetWidthFraction: CGFloat = 0.86
     static let minimumSideInset: CGFloat = 12
+    static let maximumBarCount = Int(
+        (maximumWidth + barSpacing) / (barWidth + barSpacing)
+    )
 
     static func visibleBarCount(
         availableWidth: CGFloat,
@@ -665,12 +668,6 @@ struct GhosttyComposerDictationMeterSizing {
         )
         return min(sampleCount, fittingCount)
     }
-
-    static func renderedWidth(barCount: Int) -> CGFloat {
-        guard barCount > 0 else { return 0 }
-        return (CGFloat(barCount) * barWidth)
-            + (CGFloat(barCount - 1) * barSpacing)
-    }
 }
 
 private struct GhosttyComposerDictationMeter: View {
@@ -682,24 +679,22 @@ private struct GhosttyComposerDictationMeter: View {
                 availableWidth: geometry.size.width,
                 sampleCount: model.levels.count
             )
-            let levels = Array(model.levels.suffix(visibleBarCount))
+            let firstVisibleIndex = model.levels.count - visibleBarCount
 
             HStack(spacing: GhosttyComposerDictationMeterSizing.barSpacing) {
-                ForEach(levels.indices, id: \.self) { index in
+                ForEach(0..<visibleBarCount, id: \.self) { offset in
                     Capsule()
                         .fill(GhosttyPhoneChromePalette.chromeForeground.opacity(0.72))
                         .frame(
                             width: GhosttyComposerDictationMeterSizing.barWidth,
-                            height: max(4, 6 + (levels[index] * 24))
+                            height: max(
+                                4,
+                                6 + (model.levels[firstVisibleIndex + offset] * 24)
+                            )
                         )
                 }
             }
-            .frame(
-                width: GhosttyComposerDictationMeterSizing.renderedWidth(
-                    barCount: visibleBarCount
-                ),
-                height: geometry.size.height
-            )
+            .frame(height: geometry.size.height)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity)

--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -49,7 +49,7 @@ private struct GhosttyComposerInputLayout: Layout {
     let isDictationActive: Bool
     let horizontalSpacing: CGFloat
     let verticalSpacing: CGFloat
-    let expandedContentInset: CGFloat
+    let editingContentInset: CGFloat
 
     func sizeThatFits(
         proposal: ProposedViewSize,
@@ -65,8 +65,10 @@ private struct GhosttyComposerInputLayout: Layout {
             )
         }
 
-        let metrics = metrics(width: width, subviews: subviews)
-        return CGSize(width: width, height: metrics.height)
+        return CGSize(
+            width: width,
+            height: metrics(width: width, subviews: subviews).height
+        )
     }
 
     func placeSubviews(
@@ -78,15 +80,15 @@ private struct GhosttyComposerInputLayout: Layout {
         guard subviews.count == 4 else { return }
         let metrics = metrics(width: bounds.width, subviews: subviews)
 
-        if metrics.isExpanded {
+        if !isDictationActive {
             subviews[1].place(
                 at: CGPoint(
-                    x: bounds.minX + expandedContentInset,
-                    y: bounds.minY + expandedContentInset
+                    x: bounds.minX + editingContentInset,
+                    y: bounds.minY + editingContentInset
                 ),
                 anchor: .topLeading,
                 proposal: ProposedViewSize(
-                    width: max(0, bounds.width - (expandedContentInset * 2)),
+                    width: max(0, bounds.width - (editingContentInset * 2)),
                     height: metrics.center.height
                 )
             )
@@ -130,22 +132,19 @@ private struct GhosttyComposerInputLayout: Layout {
         let leading = subviews[0].sizeThatFits(.unspecified)
         let dictation = subviews[2].sizeThatFits(.unspecified)
         let send = subviews[3].sizeThatFits(.unspecified)
-        let compactCenterWidth = max(
-            0,
-            width - leading.width - dictation.width - send.width - (horizontalSpacing * 3)
-        )
-        let compactCenter = subviews[1].sizeThatFits(
-            ProposedViewSize(width: compactCenterWidth, height: nil)
-        )
         let controlsHeight = max(leading.height, max(dictation.height, send.height))
-        let isExpanded = !isDictationActive && compactCenter.height > controlsHeight
-        let expandedCenterWidth = max(0, width - (expandedContentInset * 2))
-        let center = isExpanded
-            ? subviews[1].sizeThatFits(ProposedViewSize(width: expandedCenterWidth, height: nil))
-            : compactCenter
-        let height = isExpanded
-            ? expandedContentInset + center.height + verticalSpacing + controlsHeight
-            : max(controlsHeight, center.height)
+        let centerWidth = isDictationActive
+            ? max(
+                0,
+                width - leading.width - dictation.width - send.width - (horizontalSpacing * 3)
+            )
+            : max(0, width - (editingContentInset * 2))
+        let center = subviews[1].sizeThatFits(
+            ProposedViewSize(width: centerWidth, height: nil)
+        )
+        let height = isDictationActive
+            ? max(controlsHeight, center.height)
+            : editingContentInset + center.height + verticalSpacing + controlsHeight
 
         return Metrics(
             leading: leading,
@@ -153,7 +152,6 @@ private struct GhosttyComposerInputLayout: Layout {
             dictation: dictation,
             send: send,
             compactSizes: [leading, center, dictation, send],
-            isExpanded: isExpanded,
             height: height
         )
     }
@@ -164,13 +162,16 @@ private struct GhosttyComposerInputLayout: Layout {
         let dictation: CGSize
         let send: CGSize
         let compactSizes: [CGSize]
-        let isExpanded: Bool
         let height: CGFloat
     }
 }
 
 struct GhosttyComposeBar: View {
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
+    @AppStorage("terminal.composer.keyboardDismissHintShown")
+    private var hasShownKeyboardDismissHint = false
+    @State private var isShowingKeyboardDismissHint = false
+    @State private var hasCommittedKeyboardDismissDrag = false
 
     // The bar observes the composer directly so draft keystrokes and
     // dictation updates re-render only this subtree, not the terminal
@@ -179,10 +180,14 @@ struct GhosttyComposeBar: View {
     let isTerminalInputAvailable: Bool
 
     let wantsKeyboardFocus: Bool
+    let isSoftwareKeyboardVisible: Bool
+    let isKeyboardDismissalActive: Bool
     let keyboardActivationToken: Int
     let keyboardResponderHandoff: GhosttyKeyboardResponderHandoff
     let onKeyboardFocusRequest: () -> Void
     let onKeyboardResponderAttached: () -> Void
+    let onDismissKeyboard: () -> Void
+    let onClose: () -> Void
     let onChoosePhotos: () -> Void
     let onChooseFiles: () -> Void
     let onOpenAttachment: (GhosttyPendingAttachment.ID) -> Void
@@ -229,12 +234,16 @@ struct GhosttyComposeBar: View {
         )
     }
 
+    private var showsAttachments: Bool {
+        !dictationPhase.isActive && !attachments.isEmpty
+    }
+
     var body: some View {
 #if DEBUG
         let _ = GhosttySurfaceScreenPerfProbe.recordBarEval()
 #endif
-        VStack(spacing: attachments.isEmpty ? 0 : 6) {
-            if !attachments.isEmpty {
+        VStack(spacing: showsAttachments ? 6 : 0) {
+            if showsAttachments {
                 GhosttyComposerAttachmentStrip(
                     attachments: attachments,
                     isEnabled: submissionState.allowsComposerInput,
@@ -253,11 +262,36 @@ struct GhosttyComposeBar: View {
 
             composerRow
         }
+        .padding(.top, dictationPhase.isActive ? 0 : 12)
         .padding(.vertical, 4)
         .padding(.horizontal, 3)
         .frame(minHeight: GhosttyKeyboardChromeSizing.baselineHeight)
         .frame(maxWidth: .infinity)
         .ghosttyComposerSurface()
+        .animation(
+            GhosttyKeyboardChromeAnimation.composerTransition,
+            value: dictationPhase.isActive
+        )
+        .overlay(alignment: .top) {
+            keyboardDismissAffordance
+                .opacity(showsKeyboardDismissAffordance ? 1 : 0)
+                .allowsHitTesting(showsKeyboardDismissAffordance)
+                .accessibilityHidden(!showsKeyboardDismissAffordance)
+                .animation(
+                    .easeOut(duration: showsKeyboardDismissAffordance ? 0.12 : 0.08),
+                    value: showsKeyboardDismissAffordance
+                )
+        }
+        .onChange(of: showsKeyboardDismissAffordance, initial: true) { _, isVisible in
+            guard isVisible else {
+                isShowingKeyboardDismissHint = false
+                hasCommittedKeyboardDismissDrag = false
+                return
+            }
+            guard !hasShownKeyboardDismissHint else { return }
+            isShowingKeyboardDismissHint = true
+            hasShownKeyboardDismissHint = true
+        }
         .overlay {
             Color.clear
                 .accessibilityElement()
@@ -276,14 +310,20 @@ struct GhosttyComposeBar: View {
         .accessibilityIdentifier("terminal.composer")
     }
 
+    private var showsKeyboardDismissAffordance: Bool {
+        isSoftwareKeyboardVisible
+            && !isKeyboardDismissalActive
+            && !dictationPhase.isActive
+    }
+
     private var composerRow: some View {
         GhosttyComposerInputLayout(
             isDictationActive: dictationPhase.isActive,
             horizontalSpacing: 2,
             verticalSpacing: 2,
-            expandedContentInset: 8
+            editingContentInset: 8
         ) {
-            leadingControl
+            leadingControls
 
             composerTextRegion
 
@@ -296,6 +336,52 @@ struct GhosttyComposeBar: View {
                 action: onSend
             )
         }
+    }
+
+    private var keyboardDismissAffordance: some View {
+        ZStack {
+            Color.clear
+
+            VStack(spacing: 3) {
+                Capsule()
+                    .fill(GhosttyPhoneChromePalette.chromeSecondaryForeground)
+                    .frame(width: 34, height: 5)
+
+                if isShowingKeyboardDismissHint && !dictationPhase.isActive {
+                    Text("Drag down to hide keyboard")
+                        .font(.caption2)
+                        .foregroundStyle(GhosttyPhoneChromePalette.chromeSecondaryForeground)
+                        .transition(.opacity)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 28)
+        .contentShape(Rectangle())
+        .highPriorityGesture(keyboardDismissGesture)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Keyboard")
+        .accessibilityHint("Drag down to hide the keyboard.")
+        .accessibilityIdentifier("terminal.composer.keyboard-dismiss")
+        .accessibilityAction(named: Text("Hide Keyboard")) {
+            onDismissKeyboard()
+        }
+    }
+
+    private var keyboardDismissGesture: some Gesture {
+        DragGesture(minimumDistance: 6)
+            .onChanged { value in
+                guard showsKeyboardDismissAffordance,
+                      !hasCommittedKeyboardDismissDrag else { return }
+                let downwardDistance = value.translation.height
+                guard downwardDistance >= 10,
+                      downwardDistance > abs(value.translation.width) else { return }
+                hasCommittedKeyboardDismissDrag = true
+                onDismissKeyboard()
+            }
+            .onEnded { _ in
+                hasCommittedKeyboardDismissDrag = false
+            }
     }
 
     private var composerTextRegion: some View {
@@ -350,7 +436,7 @@ struct GhosttyComposeBar: View {
     }
 
     @ViewBuilder
-    private var leadingControl: some View {
+    private var leadingControls: some View {
         if dictationPhase.isActive {
             dictationModeButton(
                 systemName: "xmark",
@@ -359,7 +445,10 @@ struct GhosttyComposeBar: View {
                 action: onCancelDictation
             )
         } else {
-            attachmentMenu
+            HStack(spacing: 2) {
+                attachmentMenu
+                closeButton
+            }
         }
     }
 
@@ -461,6 +550,25 @@ struct GhosttyComposeBar: View {
         .opacity(submissionState.allowsComposerInput ? 1 : 0.38)
         .accessibilityLabel("Add attachment")
         .accessibilityIdentifier("terminal.composer.attachments")
+    }
+
+    private var closeButton: some View {
+        Button {
+            Haptic.chromeControlPress()
+            onClose()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 17, weight: .medium))
+                .symbolRenderingMode(.monochrome)
+                .foregroundStyle(GhosttyPhoneChromePalette.chromeForeground)
+                .frame(width: 42, height: 42)
+        }
+        .buttonStyle(GhosttyComposerPressButtonStyle())
+        .disabled(!submissionState.allowsComposerInput)
+        .opacity(submissionState.allowsComposerInput ? 1 : 0.38)
+        .accessibilityLabel("Close composer")
+        .accessibilityHint("Return to direct terminal input while preserving the draft.")
+        .accessibilityIdentifier("terminal.composer.toggle")
     }
 
     private var dictationButton: some View {
@@ -669,7 +777,7 @@ private struct GhosttyComposerTextView: UIViewRepresentable {
         )
         let lineHeight = textView.font?.lineHeight ?? UIFont.preferredFont(forTextStyle: .body).lineHeight
         let verticalInsets = textView.textContainerInset.top + textView.textContainerInset.bottom
-        let maximumHeight = ceil((lineHeight * 5) + verticalInsets)
+        let maximumHeight = ceil((lineHeight * 6) + verticalInsets)
         let resolvedHeight = min(max(measuredHeight, 36), maximumHeight)
         textView.isScrollEnabled = measuredHeight > maximumHeight
         return CGSize(width: width, height: resolvedHeight)

--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -273,14 +273,15 @@ struct GhosttyComposeBar: View {
             value: dictationPhase.isActive
         )
         .overlay(alignment: .top) {
-            keyboardDismissAffordance
-                .opacity(showsKeyboardDismissAffordance ? 1 : 0)
-                .allowsHitTesting(showsKeyboardDismissAffordance)
-                .accessibilityHidden(!showsKeyboardDismissAffordance)
-                .animation(
-                    .easeOut(duration: showsKeyboardDismissAffordance ? 0.12 : 0.08),
-                    value: showsKeyboardDismissAffordance
-                )
+            if showsKeyboardDismissAffordance {
+                keyboardDismissAffordance
+                    .transition(
+                        .asymmetric(
+                            insertion: .opacity.animation(.easeOut(duration: 0.12)),
+                            removal: .opacity.animation(.easeOut(duration: 0.08))
+                        )
+                    )
+            }
         }
         .onChange(of: showsKeyboardDismissAffordance, initial: true) { _, isVisible in
             guard isVisible else {

--- a/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposeBar.swift
@@ -641,22 +641,69 @@ private struct GhosttyComposerPressButtonStyle: ButtonStyle {
     }
 }
 
+struct GhosttyComposerDictationMeterSizing {
+    static let height: CGFloat = 32
+    static let barWidth: CGFloat = 2.5
+    static let barSpacing: CGFloat = 2
+    static let maximumWidth: CGFloat = 220
+    static let targetWidthFraction: CGFloat = 0.86
+    static let minimumSideInset: CGFloat = 12
+
+    static func visibleBarCount(
+        availableWidth: CGFloat,
+        sampleCount: Int
+    ) -> Int {
+        guard sampleCount > 0 else { return 0 }
+
+        let proportionalWidth = availableWidth * targetWidthFraction
+        let insetWidth = availableWidth - (minimumSideInset * 2)
+        let targetWidth = min(maximumWidth, min(proportionalWidth, insetWidth))
+        guard targetWidth >= barWidth else { return 0 }
+
+        let fittingCount = Int(
+            floor((targetWidth + barSpacing) / (barWidth + barSpacing))
+        )
+        return min(sampleCount, fittingCount)
+    }
+
+    static func renderedWidth(barCount: Int) -> CGFloat {
+        guard barCount > 0 else { return 0 }
+        return (CGFloat(barCount) * barWidth)
+            + (CGFloat(barCount - 1) * barSpacing)
+    }
+}
+
 private struct GhosttyComposerDictationMeter: View {
     @ObservedObject var model: GhosttyComposerAudioLevelModel
 
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(model.levels.indices, id: \.self) { index in
-                Capsule()
-                    .fill(GhosttyPhoneChromePalette.chromeForeground.opacity(0.72))
-                    .frame(
-                        width: 2.5,
-                        height: max(4, 6 + (model.levels[index] * 24))
-                    )
+        GeometryReader { geometry in
+            let visibleBarCount = GhosttyComposerDictationMeterSizing.visibleBarCount(
+                availableWidth: geometry.size.width,
+                sampleCount: model.levels.count
+            )
+            let levels = Array(model.levels.suffix(visibleBarCount))
+
+            HStack(spacing: GhosttyComposerDictationMeterSizing.barSpacing) {
+                ForEach(levels.indices, id: \.self) { index in
+                    Capsule()
+                        .fill(GhosttyPhoneChromePalette.chromeForeground.opacity(0.72))
+                        .frame(
+                            width: GhosttyComposerDictationMeterSizing.barWidth,
+                            height: max(4, 6 + (levels[index] * 24))
+                        )
+                }
             }
+            .frame(
+                width: GhosttyComposerDictationMeterSizing.renderedWidth(
+                    barCount: visibleBarCount
+                ),
+                height: geometry.size.height
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 32)
+        .frame(height: GhosttyComposerDictationMeterSizing.height)
         .clipped()
         .accessibilityLabel("Recording audio")
         .accessibilityIdentifier("terminal.composer.dictation.meter")

--- a/RemuxApp/Sources/Ghostty/GhosttyComposerDictationController.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposerDictationController.swift
@@ -28,7 +28,7 @@ enum GhosttyComposerDictationDraft {
 
 @MainActor
 final class GhosttyComposerAudioLevelModel: ObservableObject {
-    nonisolated static let barCount = 28
+    nonisolated static let historyCapacity = 49
 
     @Published private(set) var levels: [CGFloat]
 
@@ -48,14 +48,14 @@ final class GhosttyComposerAudioLevelModel: ObservableObject {
     }
 
     func replace(with levels: [CGFloat]) {
-        precondition(levels.count == Self.barCount)
+        precondition(levels.count == Self.historyCapacity)
         self.levels = levels
     }
 
     private static var emptyLevels: [CGFloat] {
         Array(
             repeating: 0.08,
-            count: Self.barCount
+            count: Self.historyCapacity
         )
     }
 }
@@ -621,8 +621,6 @@ private final class GhosttyComposerAudioTapProcessor:
 
 @MainActor
 final class GhosttyComposerDictationController: ObservableObject {
-    static let meterBarCount = GhosttyComposerAudioLevelModel.barCount
-
     @Published private(set) var phase = GhosttyComposerDictationPhase.idle
     let audioLevelModel: GhosttyComposerAudioLevelModel
 

--- a/RemuxApp/Sources/Ghostty/GhosttyComposerDictationController.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyComposerDictationController.swift
@@ -28,7 +28,7 @@ enum GhosttyComposerDictationDraft {
 
 @MainActor
 final class GhosttyComposerAudioLevelModel: ObservableObject {
-    nonisolated static let historyCapacity = 49
+    nonisolated static let historyCapacity = GhosttyComposerDictationMeterSizing.maximumBarCount
 
     @Published private(set) var levels: [CGFloat]
 

--- a/RemuxApp/Sources/Ghostty/GhosttyDebugComposerDictationBackend.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyDebugComposerDictationBackend.swift
@@ -84,7 +84,7 @@ final class GhosttyDebugComposerDictationBackend:
                 }
 
                 run.handler(.started)
-                for index in 0..<GhosttyComposerAudioLevelModel.barCount {
+                for index in 0..<GhosttyComposerAudioLevelModel.historyCapacity {
                     run.handler(.audioLevel(0.14 + (CGFloat(index % 7) * 0.1)))
                 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -40,10 +40,6 @@ enum GhosttyKeyboardChromeSizing {
     /// grow above this baseline without changing the terminal viewport.
     static let baselineHeight = dockButtonHeight + (controlGroupVerticalPadding * 2)
 
-    /// Standalone controls fill the dock baseline in both axes so their
-    /// circular material cannot be compressed into a capsule.
-    static let standaloneControlDiameter = baselineHeight
-
     static func keyboardReplacementHeight(
         keyboardOverlapHeight: CGFloat,
         bottomSafeAreaHeight: CGFloat
@@ -122,7 +118,6 @@ enum GhosttyKeyboardChromeAnimation {
 
 struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
-    @Namespace private var inputControlTransition
 
     let keyboardMode: GhosttyKeyboardChromeMode
     let isEnabled: Bool
@@ -138,7 +133,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     let onShowLibrary: () -> Void
     let onShowWindows: () -> Void
     let onShowPanes: () -> Void
-    let onToggleComposer: () -> Void
+    let onOpenComposer: () -> Void
     let onToggleKeyboard: () -> Void
     let onToggleControl: () -> Void
     let onShowShortcuts: () -> Void
@@ -181,21 +176,9 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     }
 
     private var composerSelectorRow: some View {
-        HStack(alignment: .bottom, spacing: isCompact ? 8 : 10) {
-            standaloneControlGroup {
-                composerToggleButton(systemName: "xmark", isStandalone: true)
-            }
-
-            composerContent()
-                .frame(maxWidth: .infinity)
-                .layoutPriority(1)
-                .transition(.opacity)
-
-            standaloneControlGroup {
-                keyboardToggleButton(isStandalone: true)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .center)
+        composerContent()
+            .frame(maxWidth: .infinity)
+            .transition(.opacity)
     }
 
     private var navigationControls: some View {
@@ -285,64 +268,41 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     action: onShowLibrary
                 )
 
-                composerToggleButton(systemName: "square.and.pencil")
+                composerButton
                 keyboardToggleButton
             }
         }
     }
 
-    private func composerToggleButton(
-        systemName: String,
-        isStandalone: Bool = false
-    ) -> some View {
-        let dimension = isStandalone
-            ? GhosttyKeyboardChromeSizing.standaloneControlDiameter
-            : nil
-        return GhosttyKeyboardChromeDockButton(
-            systemName: systemName,
+    private var composerButton: some View {
+        GhosttyKeyboardChromeDockButton(
+            systemName: "square.and.pencil",
             badge: nil,
             chromeStyle: chromeStyle,
-            width: dimension ?? dockButtonWidth,
-            height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
-            accessibilityLabel: isComposerPresented ? "Close composer" : "Open composer",
-            accessibilityHint: isComposerPresented
-                ? "Hide the compose field while preserving its draft."
-                : "Prepare an editable message before sending it to the terminal.",
+            width: dockButtonWidth,
+            height: GhosttyKeyboardChromeSizing.dockButtonHeight,
+            accessibilityLabel: "Open composer",
+            accessibilityHint: "Prepare an editable message before sending it to the terminal.",
             accessibilityIdentifier: "terminal.composer.toggle",
             isActive: false,
             isEnabled: !isInteractionLocked,
-            action: onToggleComposer
-        )
-        .matchedGeometryEffect(
-            id: "terminal.composer.toggle",
-            in: inputControlTransition
+            action: onOpenComposer
         )
     }
 
     private var keyboardToggleButton: some View {
-        keyboardToggleButton(isStandalone: false)
-    }
-
-    private func keyboardToggleButton(isStandalone: Bool) -> some View {
-        let dimension = isStandalone
-            ? GhosttyKeyboardChromeSizing.standaloneControlDiameter
-            : nil
-        return GhosttyKeyboardChromeDockButton(
+        GhosttyKeyboardChromeDockButton(
             systemName: "keyboard",
             badge: nil,
             chromeStyle: chromeStyle,
-            width: dimension ?? dockButtonWidth,
-            height: dimension ?? GhosttyKeyboardChromeSizing.dockButtonHeight,
+            width: dockButtonWidth,
+            height: GhosttyKeyboardChromeSizing.dockButtonHeight,
             accessibilityLabel: keyboardMode == .hidden ? "Show keyboard controls" : "Hide keyboard controls",
             accessibilityHint: nil,
             accessibilityIdentifier: "terminal.keyboard",
             isActive: keyboardMode != .hidden,
-            isEnabled: isEnabled || isComposerPresented,
+            isEnabled: isEnabled,
             action: onToggleKeyboard
-        )
-        .matchedGeometryEffect(
-            id: "terminal.keyboard",
-            in: inputControlTransition
         )
     }
 
@@ -351,14 +311,6 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
             .padding(.horizontal, isCompact ? 3 : 5)
             .padding(.vertical, GhosttyKeyboardChromeSizing.controlGroupVerticalPadding)
             .ghosttyToolbarGroupSurface()
-    }
-
-    private func standaloneControlGroup<Content: View>(
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        content()
-            .ghosttyStandaloneToolbarSurface()
-            .fixedSize()
     }
 
     private func accessoryKey(
@@ -593,11 +545,6 @@ private extension View {
     @ViewBuilder
     func ghosttyToolbarGroupSurface() -> some View {
         ghosttyToolbarSurface(in: Capsule())
-    }
-
-    @ViewBuilder
-    func ghosttyStandaloneToolbarSurface() -> some View {
-        ghosttyToolbarSurface(in: Circle())
     }
 
     @ViewBuilder

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -36,8 +36,8 @@ enum GhosttyKeyboardChromeSizing {
     static let compactDockButtonWidth: CGFloat = 35
     static let controlGroupVerticalPadding: CGFloat = 4
 
-    /// The bottom chrome always reserves one dock row. Composer content may
-    /// grow above this baseline without changing the terminal viewport.
+    /// Fallback reservation before the bottom chrome reports its intrinsic
+    /// height. Settled chrome subsequently owns its full measured footprint.
     static let baselineHeight = dockButtonHeight + (controlGroupVerticalPadding * 2)
 
     static func keyboardReplacementHeight(
@@ -49,6 +49,26 @@ enum GhosttyKeyboardChromeSizing {
         }
         let safeAreaHeight = bottomSafeAreaHeight.isFinite ? max(0, bottomSafeAreaHeight) : 0
         return ceil(max(0, keyboardOverlapHeight - safeAreaHeight))
+    }
+}
+
+struct GhosttyBottomChromeReservation: Equatable {
+    private(set) var settledHeight: CGFloat = 0
+
+    func layoutHeight(fallback: CGFloat) -> CGFloat {
+        settledHeight > 0 ? settledHeight : fallback
+    }
+
+    @discardableResult
+    mutating func observe(renderedHeight: CGFloat, isTransient: Bool) -> Bool {
+        guard !isTransient,
+              renderedHeight.isFinite,
+              renderedHeight > 0 else { return false }
+
+        let normalizedHeight = ceil(renderedHeight)
+        guard settledHeight != normalizedHeight else { return false }
+        settledHeight = normalizedHeight
+        return true
     }
 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -70,7 +70,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     @State private var terminalInputController = GhosttyTerminalInputController()
     @State private var keyboardResponderHandoff = GhosttyKeyboardResponderHandoff()
     @State private var selectionSheet: GhosttySurfaceSelectionSheet?
-    @State private var bottomChromeHeight: CGFloat = 0
+    @State private var bottomChromeReservation = GhosttyBottomChromeReservation()
     @State private var softwareKeyboardOverlapHeight: CGFloat = 0
     @State private var lastSoftwareKeyboardOverlapHeight: CGFloat = 0
     @State private var terminalViewportCoordinator = GhosttyTerminalViewportCoordinator()
@@ -173,6 +173,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         isSelected && composer.isPresented
     }
 
+    private var isComposerChromeHeightTransient: Bool {
+        isActiveComposerPresented && composer.dictationController.phase.isActive
+    }
+
     private var composerAttachmentsBinding: Binding<[GhosttyPendingAttachment]> {
         Binding(
             get: { composer.attachments },
@@ -189,6 +193,12 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             let renderedKeyboardMode = inputCoordinator.keyboardMode
             let chrome = GhosttyPhoneChromeLayout(
                 screenSize: screenProxy.size
+            )
+            let bottomChromeFallbackHeight = GhosttyKeyboardChromeSizing.baselineHeight
+                + 4
+                + chrome.bottomPadding
+            let bottomChromeHeight = bottomChromeReservation.layoutHeight(
+                fallback: bottomChromeFallbackHeight
             )
             let screenProjection = model.terminalScreenPresentationProjection
             let readiness = screenProjection.readiness
@@ -406,7 +416,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 Color.clear
-                    .frame(height: GhosttyKeyboardChromeSizing.baselineHeight)
+                    .frame(height: bottomChromeHeight)
                     .overlay(alignment: .bottom) {
                         GhosttyKeyboardChrome(
                             keyboardMode: renderedKeyboardMode,
@@ -431,27 +441,30 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                         ) {
                             selectedComposerBar()
                         }
-                    }
-                    .padding(.horizontal, chrome.surfaceHorizontalPadding)
-                    .padding(.top, 4)
-                    .padding(.bottom, chrome.bottomPadding)
-                    .frame(maxWidth: .infinity, alignment: .bottom)
-                    .background {
-                        GeometryReader { chromeProxy in
-                            Color.clear.preference(
-                                key: GhosttyBottomChromeHeightPreferenceKey.self,
-                                value: chromeProxy.size.height
-                            )
+                        .padding(.horizontal, chrome.surfaceHorizontalPadding)
+                        .padding(.top, 4)
+                        .padding(.bottom, chrome.bottomPadding)
+                        .frame(maxWidth: .infinity, alignment: .bottom)
+                        .background {
+                            GeometryReader { chromeProxy in
+                                Color.clear.preference(
+                                    key: GhosttyRenderedBottomChromeHeightPreferenceKey.self,
+                                    value: chromeProxy.size.height
+                                )
+                            }
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .bottom)
             }
-            .onPreferenceChange(GhosttyBottomChromeHeightPreferenceKey.self) { newHeight in
-                let normalizedHeight = GhosttyViewportSizing.normalizedHeight(newHeight)
-                guard bottomChromeHeight != normalizedHeight else { return }
+            .onPreferenceChange(GhosttyRenderedBottomChromeHeightPreferenceKey.self) { renderedHeight in
+                let previousHeight = bottomChromeReservation.settledHeight
+                guard bottomChromeReservation.observe(
+                    renderedHeight: renderedHeight,
+                    isTransient: isComposerChromeHeightTransient
+                ) else { return }
                 GhosttyRuntimeTrace.tmuxViewport(
-                    "viewport.bottomChrome old=\(bottomChromeHeight.traceLabel) new=\(normalizedHeight.traceLabel) keyboardMode=\(inputCoordinator.keyboardMode.traceLabel) renderedMode=\(renderedKeyboardMode.traceLabel) softwareKeyboardVisible=\(inputCoordinator.isSoftwareKeyboardVisible) overlap=\(softwareKeyboardOverlapHeight.traceLabel)"
+                    "viewport.bottomChrome old=\(previousHeight.traceLabel) new=\(bottomChromeReservation.settledHeight.traceLabel) rendered=\(renderedHeight.traceLabel) keyboardMode=\(inputCoordinator.keyboardMode.traceLabel) renderedMode=\(renderedKeyboardMode.traceLabel) softwareKeyboardVisible=\(inputCoordinator.isSoftwareKeyboardVisible) overlap=\(softwareKeyboardOverlapHeight.traceLabel)"
                 )
-                bottomChromeHeight = normalizedHeight
             }
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) {
                 guard shouldHandleTerminalKeyboardNotification else { return }
@@ -2208,7 +2221,7 @@ private struct GhosttyKeyboardContinuityAccessibilityMarker: View {
 }
 #endif
 
-private struct GhosttyBottomChromeHeightPreferenceKey: PreferenceKey {
+private struct GhosttyRenderedBottomChromeHeightPreferenceKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -411,7 +411,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                         GhosttyKeyboardChrome(
                             keyboardMode: renderedKeyboardMode,
                             isEnabled: interactionProjection.isInputAvailable,
-                            isInteractionLocked: composerSubmissionState.isSending,
+                            isInteractionLocked: composer.isSubmitting,
                             isCompact: chrome.isCompact,
                             isControlArmed: terminalInputController.isControlArmed,
                             selectedWindowIndex: interactionProjection.selectedWindowIndex,
@@ -423,7 +423,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             onShowLibrary: onShowLibrary,
                             onShowWindows: showWindows,
                             onShowPanes: showPanes,
-                            onToggleComposer: toggleComposer,
+                            onOpenComposer: openComposer,
                             onToggleKeyboard: toggleKeyboardChrome,
                             onToggleControl: toggleControlModifier,
                             onShowShortcuts: showShortcutPalette,
@@ -659,10 +659,17 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 isTerminalInputAvailable: isTerminalInputAvailable,
                 wantsKeyboardFocus: inputCoordinator.keyboardMode == .system
                     && inputCoordinator.keyboardOwner == .composer,
+                isSoftwareKeyboardVisible: inputCoordinator.keyboardMode == .system
+                    && inputCoordinator.keyboardOwner == .composer
+                    && softwareKeyboardOverlapHeight > 0,
+                isKeyboardDismissalActive: terminalViewportCoordinator.isKeyboardTransitionActive
+                    && terminalViewportCoordinator.keyboardTransitionTarget == .hidden,
                 keyboardActivationToken: inputCoordinator.composerActivationToken,
                 keyboardResponderHandoff: keyboardResponderHandoff,
                 onKeyboardFocusRequest: handleComposerKeyboardFocusRequest,
                 onKeyboardResponderAttached: handleComposerKeyboardResponderAttached,
+                onDismissKeyboard: dismissComposerKeyboard,
+                onClose: closeComposer,
                 onChoosePhotos: openAttachmentPhotosPicker,
                 onChooseFiles: openAttachmentFilePicker,
                 onOpenAttachment: showPendingAttachmentPreview,
@@ -681,21 +688,6 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         model.terminalInteractionProjection.isInputAvailable
     }
 
-    private var composerSubmissionState: GhosttyComposeBarSubmissionState {
-        if composer.isSubmitting {
-            return .sending
-        }
-        return .composing(
-            canSend: isTerminalInputAvailable
-                && composer.hasContent
-                && composer.areAttachmentsReady
-        )
-    }
-
-    private var isAttachmentTransferInProgress: Bool {
-        composer.isSubmitting
-    }
-
     private var isTerminalViewportFrozen: Bool {
         terminalViewportCoordinator.isFrozen
     }
@@ -703,7 +695,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private var pendingAttachmentInteractionProjection: GhosttyPendingAttachmentInteractionProjection {
         GhosttyPendingAttachmentInteractionProjection(
             hasPreviewableAttachments: composer.attachments.contains(where: \.isPreviewable),
-            isTransferInProgress: isAttachmentTransferInProgress
+            isTransferInProgress: composer.isSubmitting
         )
     }
 
@@ -773,9 +765,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func toggleKeyboardChrome() {
-        let keyboardOwner: GhosttyKeyboardOwner =
-            isActiveComposerPresented ? .composer : .terminal
-        let isInputAvailable = isActiveComposerPresented || isTerminalInputAvailable
+        let isInputAvailable = isTerminalInputAvailable
         GhosttyRuntimeTrace.flowBegin(
             "terminal.input",
             event: "ui.tap.keyboardToggle",
@@ -801,7 +791,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 },
                 applyKeyboardToggle: {
                     inputCoordinator.toggleKeyboard(
-                        owner: keyboardOwner,
+                        owner: .terminal,
                         isOwnerAvailable: projection.isInputAvailable
                     )
                     return inputCoordinator.keyboardMode
@@ -811,17 +801,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         }
     }
 
-    private func toggleComposer() {
-        guard !composerSubmissionState.isSending else { return }
-
-        if isActiveComposerPresented {
-            closeComposer()
-        } else {
-            openComposer()
-        }
-    }
-
     private func openComposer() {
+        guard !composer.isSubmitting else { return }
         withAnimation(GhosttyKeyboardChromeAnimation.composerTransition) {
             composer.open()
         }
@@ -883,6 +864,30 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         guard inputCoordinator.keyboardMode != .system
                 || inputCoordinator.keyboardOwner != .composer else { return }
         showComposerKeyboard()
+    }
+
+    private func dismissComposerKeyboard() {
+        guard isActiveComposerPresented,
+              inputCoordinator.keyboardMode == .system,
+              inputCoordinator.keyboardOwner == .composer else { return }
+
+        let projection = GhosttyKeyboardToggleProjection(
+            keyboardMode: inputCoordinator.keyboardMode,
+            isInputAvailable: true
+        )
+        performKeyboardChromeStateChange {
+            keyboardViewportTransitionCoordinator.performKeyboardToggleTransition(
+                projection: projection,
+                beginTransition: { request in
+                    _ = beginKeyboardViewportTransition(request)
+                },
+                applyKeyboardToggle: {
+                    inputCoordinator.dismissKeyboard()
+                    return inputCoordinator.keyboardMode
+                },
+                completeTransition: completeKeyboardViewportTransition
+            )
+        }
     }
 
     private func showComposerKeyboard() {
@@ -1341,7 +1346,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func showWindows() {
-        guard !isAttachmentTransferInProgress else { return }
+        guard !composer.isSubmitting else { return }
         guard let projection = model.windowSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.newWindow", event: "ui.showWindows")
         applySelectionSheetPresentation(
@@ -1380,7 +1385,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func showPanes() {
-        guard !isAttachmentTransferInProgress else { return }
+        guard !composer.isSubmitting else { return }
         guard let projection = model.selectedPaneSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.splitPane", event: "ui.showPanes")
 

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -824,17 +824,18 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private func closeComposer() {
         if inputCoordinator.keyboardMode == .system,
            inputCoordinator.keyboardOwner == .composer {
-            guard isTerminalInputAvailable,
-                  keyboardResponderHandoff.transfer(to: .terminal) else {
-                GhosttyRuntimeTrace.perf(
-                    "composer.toggle close deferred terminalResponderUnavailable"
+            if isTerminalInputAvailable,
+               keyboardResponderHandoff.transfer(to: .terminal) {
+                inputCoordinator.transferKeyboardOwnerIfActive(
+                    to: .terminal,
+                    isOwnerAvailable: true
                 )
-                return
+            } else {
+                GhosttyRuntimeTrace.perf(
+                    "composer.toggle close fallback=dismissKeyboard terminalResponderUnavailable"
+                )
+                dismissComposerKeyboard()
             }
-            inputCoordinator.transferKeyboardOwnerIfActive(
-                to: .terminal,
-                isOwnerAvailable: true
-            )
         }
 
         withAnimation(GhosttyKeyboardChromeAnimation.composerTransition) {

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -133,10 +133,6 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
         )
 
         XCTAssertEqual(count, 49)
-        XCTAssertEqual(
-            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
-            218.5
-        )
     }
 
     func testDictationMeterFollowsTargetWidthInPortraitCenterLane() {
@@ -146,10 +142,6 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
         )
 
         XCTAssertEqual(count, 46)
-        XCTAssertEqual(
-            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
-            205
-        )
     }
 
     func testDictationMeterAdaptsBarCountToCenterLane() {
@@ -159,10 +151,6 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
         )
 
         XCTAssertEqual(count, 38)
-        XCTAssertEqual(
-            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
-            169
-        )
     }
 
     func testDictationMeterPreservesControlBreathingRoomInCompactLane() {
@@ -170,13 +158,7 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
             availableWidth: 160,
             sampleCount: GhosttyComposerAudioLevelModel.historyCapacity
         )
-        let renderedWidth = GhosttyComposerDictationMeterSizing.renderedWidth(
-            barCount: count
-        )
-
         XCTAssertEqual(count, 30)
-        XCTAssertEqual(renderedWidth, 133)
-        XCTAssertGreaterThanOrEqual((160 - renderedWidth) / 2, 12)
     }
 
     func testDictationMeterNeverInventsMoreBarsThanHistoryContains() {

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -125,4 +125,67 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
         XCTAssertTrue(reservation.observe(renderedHeight: 138, isTransient: false))
         XCTAssertEqual(reservation.settledHeight, 138)
     }
+
+    func testDictationMeterUsesMaximumWidthOnWideCenterLane() {
+        let count = GhosttyComposerDictationMeterSizing.visibleBarCount(
+            availableWidth: 300,
+            sampleCount: GhosttyComposerAudioLevelModel.historyCapacity
+        )
+
+        XCTAssertEqual(count, 49)
+        XCTAssertEqual(
+            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
+            218.5
+        )
+    }
+
+    func testDictationMeterFollowsTargetWidthInPortraitCenterLane() {
+        let count = GhosttyComposerDictationMeterSizing.visibleBarCount(
+            availableWidth: 240,
+            sampleCount: GhosttyComposerAudioLevelModel.historyCapacity
+        )
+
+        XCTAssertEqual(count, 46)
+        XCTAssertEqual(
+            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
+            205
+        )
+    }
+
+    func testDictationMeterAdaptsBarCountToCenterLane() {
+        let count = GhosttyComposerDictationMeterSizing.visibleBarCount(
+            availableWidth: 200,
+            sampleCount: GhosttyComposerAudioLevelModel.historyCapacity
+        )
+
+        XCTAssertEqual(count, 38)
+        XCTAssertEqual(
+            GhosttyComposerDictationMeterSizing.renderedWidth(barCount: count),
+            169
+        )
+    }
+
+    func testDictationMeterPreservesControlBreathingRoomInCompactLane() {
+        let count = GhosttyComposerDictationMeterSizing.visibleBarCount(
+            availableWidth: 160,
+            sampleCount: GhosttyComposerAudioLevelModel.historyCapacity
+        )
+        let renderedWidth = GhosttyComposerDictationMeterSizing.renderedWidth(
+            barCount: count
+        )
+
+        XCTAssertEqual(count, 30)
+        XCTAssertEqual(renderedWidth, 133)
+        XCTAssertGreaterThanOrEqual((160 - renderedWidth) / 2, 12)
+    }
+
+    func testDictationMeterNeverInventsMoreBarsThanHistoryContains() {
+        XCTAssertEqual(
+            GhosttyComposerDictationMeterSizing.visibleBarCount(
+                availableWidth: 240,
+                sampleCount: 12
+            ),
+            12
+        )
+    }
 }

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -99,4 +99,30 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
             274
         )
     }
+
+    func testBottomChromeReservationTracksSettledChromeHeight() {
+        var reservation = GhosttyBottomChromeReservation()
+
+        XCTAssertEqual(reservation.layoutHeight(fallback: 52), 52)
+        XCTAssertTrue(reservation.observe(renderedHeight: 91.2, isTransient: false))
+        XCTAssertEqual(reservation.settledHeight, 92)
+        XCTAssertEqual(reservation.layoutHeight(fallback: 52), 92)
+    }
+
+    func testBottomChromeReservationIgnoresTransientDictationHeight() {
+        var reservation = GhosttyBottomChromeReservation()
+        reservation.observe(renderedHeight: 124, isTransient: false)
+
+        XCTAssertFalse(reservation.observe(renderedHeight: 54, isTransient: true))
+        XCTAssertEqual(reservation.settledHeight, 124)
+    }
+
+    func testBottomChromeReservationAdoptsFinalComposerHeightAfterDictation() {
+        var reservation = GhosttyBottomChromeReservation()
+        reservation.observe(renderedHeight: 92, isTransient: false)
+        reservation.observe(renderedHeight: 54, isTransient: true)
+
+        XCTAssertTrue(reservation.observe(renderedHeight: 138, isTransient: false))
+        XCTAssertEqual(reservation.settledHeight, 138)
+    }
 }

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -3,17 +3,6 @@ import XCTest
 @testable import Remux
 
 final class GhosttyPhoneChromeLayoutTests: XCTestCase {
-    func testStandaloneControlDiameterMatchesDockBaseline() {
-        XCTAssertEqual(
-            GhosttyKeyboardChromeSizing.standaloneControlDiameter,
-            GhosttyKeyboardChromeSizing.baselineHeight
-        )
-        XCTAssertGreaterThanOrEqual(
-            GhosttyKeyboardChromeSizing.standaloneControlDiameter,
-            44
-        )
-    }
-
     func testNarrowPortraitUsesCompactChrome() {
         let layout = GhosttyPhoneChromeLayout(
             screenSize: CGSize(width: 390, height: 844)

--- a/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
+++ b/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
@@ -181,17 +181,14 @@ final class GhosttyTerminalInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.composerActivationToken, 0)
     }
 
-    func testComposerKeyboardToggleHidesKeyboardAndClearsOwner() {
+    func testComposerKeyboardDismissHidesKeyboardAndClearsOwner() {
         var coordinator = GhosttyTerminalInputCoordinator()
         coordinator.showSystemKeyboard(
             owner: .composer,
             isOwnerAvailable: true
         )
 
-        coordinator.toggleKeyboard(
-            owner: .composer,
-            isOwnerAvailable: true
-        )
+        coordinator.dismissKeyboard()
 
         XCTAssertEqual(coordinator.keyboardMode, .hidden)
         XCTAssertEqual(coordinator.keyboardOwner, .none)

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -62,6 +62,10 @@ final class RemuxAppUITests: XCTestCase {
         let composer = app.otherElements["terminal.composer.bounds"]
         XCTAssertTrue(composer.waitForExistence(timeout: 3))
         let editingComposerFrame = composer.frame
+        let editingTerminalFrame = app.otherElements["terminal.screen"].frame
+        guard let editingContinuity = waitForKeyboardContinuity(owner: "none") else {
+            return
+        }
         XCTAssertGreaterThan(
             editingComposerFrame.height,
             60,
@@ -101,6 +105,16 @@ final class RemuxAppUITests: XCTestCase {
             accuracy: 1,
             "Dictation must not shrink the composer."
         )
+        XCTAssertEqual(
+            app.otherElements["terminal.screen"].frame,
+            editingTerminalFrame,
+            "Transient dictation must not resize the terminal surface."
+        )
+        guard let recordingContinuity = waitForKeyboardContinuity(owner: "none") else {
+            return
+        }
+        XCTAssertEqual(recordingContinuity.effectiveViewport, editingContinuity.effectiveViewport)
+        XCTAssertEqual(recordingContinuity.bottomChrome, editingContinuity.bottomChrome)
 
         RunLoop.current.run(until: Date().addingTimeInterval(0.6))
         stop.tap()
@@ -247,7 +261,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["No speech detected. Try again."].exists)
     }
 
-    func testComposerToggleKeepsOpenKeyboardAndTerminalViewportStable() {
+    func testComposerTogglePreservesKeyboardWhileReservingComposerViewport() {
         app.launchEnvironment["REMUX_UI_TEST_INPUT_READY"] = "1"
         launchSimulatorApp()
         openConnectionSetup()
@@ -277,7 +291,8 @@ final class RemuxAppUITests: XCTestCase {
         guard let hiddenOpenContinuity = waitForKeyboardContinuity(owner: "none") else {
             return
         }
-        XCTAssertEqual(hiddenOpenContinuity.effectiveViewport, hiddenContinuity.effectiveViewport)
+        XCTAssertNotEqual(hiddenOpenContinuity.effectiveViewport, hiddenContinuity.effectiveViewport)
+        XCTAssertNotEqual(hiddenOpenContinuity.bottomChrome, hiddenContinuity.bottomChrome)
 
         composerToggle.tap()
         XCTAssertFalse(composerField.waitForExistence(timeout: 1))
@@ -308,10 +323,10 @@ final class RemuxAppUITests: XCTestCase {
         }
         XCTAssertEqual(composerContinuity.willHideCount, initialContinuity.willHideCount)
         XCTAssertEqual(keyboard.frame, initialKeyboardFrame)
-        XCTAssertEqual(
+        XCTAssertNotEqual(
             composerContinuity.effectiveViewport,
             initialContinuity.effectiveViewport,
-            "Opening the composer changed the terminal viewport "
+            "Opening the composer must reserve its full height from the terminal viewport "
                 + "from live=\(initialContinuity.liveViewport), effective=\(initialContinuity.effectiveViewport) "
                 + "to live=\(composerContinuity.liveViewport), effective=\(composerContinuity.effectiveViewport); "
                 + "bottomChrome \(initialContinuity.bottomChrome) → \(composerContinuity.bottomChrome), "
@@ -348,7 +363,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertEqual(reopenedContinuity.willHideCount, initialContinuity.willHideCount)
         XCTAssertEqual(composerField.value as? String, "Keep this draft")
         XCTAssertEqual(keyboard.frame, initialKeyboardFrame)
-        XCTAssertEqual(reopenedContinuity.effectiveViewport, initialContinuity.effectiveViewport)
+        XCTAssertEqual(reopenedContinuity.effectiveViewport, composerContinuity.effectiveViewport)
 
         composerToggle.tap()
         XCTAssertFalse(composerField.waitForExistence(timeout: 1))

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -61,12 +61,16 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertNotNil(waitForKeyboardPresence(false, label: "composer opened without keyboard"))
         let composer = app.otherElements["terminal.composer.bounds"]
         XCTAssertTrue(composer.waitForExistence(timeout: 3))
-        let compactComposerFrame = composer.frame
-        XCTAssertLessThanOrEqual(compactComposerFrame.height, 60)
+        let editingComposerFrame = composer.frame
         XCTAssertGreaterThan(
-            compactComposerFrame.width,
-            app.otherElements["terminal.screen"].frame.width * 0.55,
-            "The compact composer must fill the middle dock slot."
+            editingComposerFrame.height,
+            60,
+            "The editor and controls must use distinct rows even for an empty draft."
+        )
+        XCTAssertGreaterThan(
+            editingComposerFrame.width,
+            app.otherElements["terminal.screen"].frame.width * 0.9,
+            "The composer must use the full bottom-chrome width."
         )
         let placeholder = app.staticTexts["terminal.composer.placeholder"]
         XCTAssertTrue(placeholder.exists)
@@ -78,32 +82,25 @@ final class RemuxAppUITests: XCTestCase {
         let cancel = app.buttons["terminal.composer.dictation.cancel"]
         let stop = app.buttons["terminal.composer.dictation.stop"]
         let meter = app.descendants(matching: .any)["terminal.composer.dictation.meter"]
+        let keyboardDismiss = app.descendants(matching: .any)["terminal.composer.keyboard-dismiss"]
         XCTAssertTrue(cancel.waitForExistence(timeout: 3))
         XCTAssertTrue(stop.waitForExistence(timeout: 3))
         XCTAssertTrue(meter.waitForExistence(timeout: 3))
         XCTAssertFalse(placeholder.exists)
         XCTAssertNotNil(waitForKeyboardPresence(false, label: "dictation started with keyboard hidden"))
+        XCTAssertFalse(keyboardDismiss.exists)
         attachScreenshot(named: "composer-dictation-recording")
-        XCTAssertEqual(composer.frame.height, compactComposerFrame.height, accuracy: 1)
+        XCTAssertLessThan(
+            composer.frame.height,
+            editingComposerFrame.height,
+            "Active dictation must collapse the same composer surface into a compact row."
+        )
         XCTAssertEqual(
             composer.frame.width,
-            compactComposerFrame.width,
+            editingComposerFrame.width,
             accuracy: 1,
             "Dictation must not shrink the composer."
         )
-
-        composerToggle.tap()
-        XCTAssertFalse(composer.waitForExistence(timeout: 1))
-        openHomeFromTerminal()
-        let activeSession = activeSessionRows.firstMatch
-        XCTAssertTrue(activeSession.waitForExistence(timeout: 3))
-        activeSession.tap()
-        XCTAssertTrue(app.otherElements["terminal.screen"].waitForExistence(timeout: 5))
-        XCTAssertTrue(composerToggle.waitForExistence(timeout: 3))
-        composerToggle.tap()
-        XCTAssertTrue(composer.waitForExistence(timeout: 3))
-        XCTAssertTrue(stop.waitForExistence(timeout: 3))
-        XCTAssertTrue(meter.waitForExistence(timeout: 3))
 
         RunLoop.current.run(until: Date().addingTimeInterval(0.6))
         stop.tap()
@@ -111,6 +108,8 @@ final class RemuxAppUITests: XCTestCase {
         let status = app.staticTexts["terminal.composer.dictation.status"]
         XCTAssertTrue(status.waitForExistence(timeout: 1))
         XCTAssertEqual(status.label, "Transcribing…")
+        XCTAssertNotNil(waitForKeyboardPresence(false, label: "transcribing kept keyboard hidden"))
+        XCTAssertFalse(keyboardDismiss.exists)
         attachScreenshot(named: "composer-dictation-transcribing")
 
         let field = app.textViews["terminal.composer.field"]
@@ -121,8 +120,8 @@ final class RemuxAppUITests: XCTestCase {
 
         field.tap()
         XCTAssertNotNil(waitForKeyboardPresence(true, label: "composer field focused"))
-        field.typeText(" Keep this draft")
         let visibleKeyboardFrame = app.keyboards.firstMatch.frame
+        field.typeText(" Keep this draft")
         guard let originalDraft = field.value as? String else {
             XCTFail("Composer field did not expose its edited draft")
             return
@@ -130,8 +129,9 @@ final class RemuxAppUITests: XCTestCase {
         mic.tap()
         XCTAssertTrue(cancel.waitForExistence(timeout: 3))
         XCTAssertFalse(placeholder.exists)
-        XCTAssertNotNil(waitForKeyboardPresence(true, label: "dictation started with keyboard visible"))
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "dictation kept keyboard visible"))
         XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
+        XCTAssertFalse(keyboardDismiss.exists, "Transient dictation states must not show the keyboard drag affordance.")
         attachScreenshot(named: "composer-dictation-recording-keyboard-visible")
         RunLoop.current.run(until: Date().addingTimeInterval(0.6))
         cancel.tap()
@@ -140,20 +140,27 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertEqual(field.value as? String, originalDraft)
         XCTAssertNotNil(waitForKeyboardPresence(true, label: "dictation cancelled with keyboard visible"))
         XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
+        XCTAssertTrue(keyboardDismiss.waitForExistence(timeout: 3))
         attachScreenshot(named: "composer-dictation-cancelled")
 
         mic.tap()
         XCTAssertTrue(stop.waitForExistence(timeout: 3))
-        XCTAssertNotNil(waitForKeyboardPresence(true, label: "second dictation started with keyboard visible"))
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "second dictation kept keyboard visible"))
         XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
+        XCTAssertFalse(keyboardDismiss.exists)
         stop.tap()
 
+        XCTAssertTrue(status.waitForExistence(timeout: 1))
+        XCTAssertEqual(status.label, "Transcribing…")
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "transcribing kept keyboard visible"))
+        XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
         XCTAssertTrue(field.waitForExistence(timeout: 3))
         XCTAssertNotNil(waitForKeyboardPresence(true, label: "dictation stopped with keyboard visible"))
         XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
+        XCTAssertTrue(keyboardDismiss.waitForExistence(timeout: 3))
     }
 
-    func testComposerDictationKeepsMiddleDockWidth() {
+    func testComposerDictationKeepsFullChromeWidth() {
         app.launchEnvironment["REMUX_DEBUG_DICTATION_TRANSCRIPT"] = "Width stability"
         launchSimulatorApp()
         openConnectionSetup()
@@ -177,24 +184,12 @@ final class RemuxAppUITests: XCTestCase {
         let composer = app.otherElements["terminal.composer.bounds"]
         XCTAssertTrue(composer.waitForExistence(timeout: 3))
         let keyboardToggle = app.buttons["terminal.keyboard"]
-        XCTAssertTrue(keyboardToggle.waitForExistence(timeout: 3))
-        XCTAssertEqual(
-            composerToggle.frame.width,
-            composerToggle.frame.height,
-            accuracy: 1,
-            "The standalone composer control must remain circular."
-        )
-        XCTAssertEqual(
-            keyboardToggle.frame.width,
-            keyboardToggle.frame.height,
-            accuracy: 1,
-            "The standalone keyboard control must remain circular."
-        )
-        let compactWidth = composer.frame.width
+        XCTAssertFalse(keyboardToggle.exists, "Composer mode must not expose a keyboard button.")
+        let composerWidth = composer.frame.width
         XCTAssertGreaterThan(
-            compactWidth,
-            terminal.frame.width * 0.55,
-            "The compact composer must fill the middle dock slot."
+            composerWidth,
+            terminal.frame.width * 0.9,
+            "The composer must use the full bottom-chrome width."
         )
 
         let mic = app.buttons["terminal.composer.mic"]
@@ -207,7 +202,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(meter.waitForExistence(timeout: 3))
         XCTAssertEqual(
             composer.frame.width,
-            compactWidth,
+            composerWidth,
             accuracy: 1,
             "Dictation must not shrink the composer."
         )
@@ -215,7 +210,7 @@ final class RemuxAppUITests: XCTestCase {
 
         cancel.tap()
         XCTAssertTrue(mic.waitForExistence(timeout: 3))
-        XCTAssertEqual(composer.frame.width, compactWidth, accuracy: 1)
+        XCTAssertEqual(composer.frame.width, composerWidth, accuracy: 1)
     }
 
     func testComposerDictationCanRestartAfterNoSpeech() {
@@ -307,6 +302,7 @@ final class RemuxAppUITests: XCTestCase {
 
         composerToggle.tap()
         XCTAssertTrue(composerField.waitForExistence(timeout: 3))
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "composer keyboard after terminal handoff"))
         guard let composerContinuity = waitForKeyboardContinuity(owner: "composer") else {
             return
         }
@@ -327,6 +323,13 @@ final class RemuxAppUITests: XCTestCase {
 
         composerToggle.tap()
         XCTAssertFalse(composerField.waitForExistence(timeout: 1))
+        XCTAssertNotNil(
+            waitForKeyboardPresence(
+                true,
+                label: "terminal keyboard after composer close",
+                stableFor: 0.75
+            )
+        )
         guard let terminalContinuity = waitForKeyboardContinuity(owner: "terminal") else {
             return
         }
@@ -338,6 +341,7 @@ final class RemuxAppUITests: XCTestCase {
 
         composerToggle.tap()
         XCTAssertTrue(composerField.waitForExistence(timeout: 3))
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "composer keyboard after reopen"))
         guard let reopenedContinuity = waitForKeyboardContinuity(owner: "composer") else {
             return
         }
@@ -348,12 +352,63 @@ final class RemuxAppUITests: XCTestCase {
 
         composerToggle.tap()
         XCTAssertFalse(composerField.waitForExistence(timeout: 1))
+        XCTAssertNotNil(
+            waitForKeyboardPresence(
+                true,
+                label: "terminal keyboard after second composer close",
+                stableFor: 0.75
+            )
+        )
         guard let reclosedContinuity = waitForKeyboardContinuity(owner: "terminal") else {
             return
         }
         XCTAssertEqual(reclosedContinuity.willHideCount, initialContinuity.willHideCount)
         XCTAssertEqual(keyboard.frame, initialKeyboardFrame)
         XCTAssertEqual(reclosedContinuity.effectiveViewport, initialContinuity.effectiveViewport)
+    }
+
+    func testComposerHandleDismissesAndEditorRestoresKeyboard() {
+        app.launchEnvironment["REMUX_UI_TEST_INPUT_READY"] = "1"
+        app.launchArguments += ["-terminal.composer.keyboardDismissHintShown", "NO"]
+        launchSimulatorApp()
+        openConnectionSetup()
+        fillConnectionForm()
+        saveConnectionAndWaitForTerminal()
+        _ = waitForTerminalHomeButton()
+        waitForLiveTerminalInputReady(timeout: 10)
+
+        hideKeyboardIfPresent()
+        let composerToggle = app.buttons["terminal.composer.toggle"]
+        XCTAssertTrue(composerToggle.waitForExistence(timeout: 5))
+        composerToggle.tap()
+
+        let field = app.textViews["terminal.composer.field"]
+        XCTAssertTrue(field.waitForExistence(timeout: 3))
+        field.tap()
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "composer keyboard before handle drag"))
+        guard let visibleContinuity = waitForKeyboardContinuity(owner: "composer") else {
+            return
+        }
+
+        let handle = app.descendants(matching: .any)["terminal.composer.keyboard-dismiss"]
+        XCTAssertTrue(handle.waitForExistence(timeout: 3))
+        attachScreenshot(named: "composer-keyboard-dismiss-hint")
+        let dragStart = handle.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let dragEnd = dragStart.withOffset(CGVector(dx: 0, dy: 14))
+        dragStart.press(forDuration: 0.05, thenDragTo: dragEnd)
+
+        XCTAssertNotNil(waitForKeyboardPresence(false, label: "composer keyboard after handle drag"))
+        XCTAssertTrue(field.exists, "Dismissing the keyboard must keep the composer open.")
+        guard let hiddenContinuity = waitForKeyboardContinuity(owner: "none") else {
+            return
+        }
+        XCTAssertGreaterThan(hiddenContinuity.willHideCount, visibleContinuity.willHideCount)
+        attachScreenshot(named: "composer-keyboard-dismissed")
+
+        field.tap()
+        XCTAssertNotNil(waitForKeyboardPresence(true, label: "composer keyboard after editor retap"))
+        XCTAssertNotNil(waitForKeyboardContinuity(owner: "composer"))
+        XCTAssertTrue(handle.waitForExistence(timeout: 3))
     }
 
     func testComposerMultilineKeepsWidthAndKeyboardStable() {
@@ -382,7 +437,7 @@ final class RemuxAppUITests: XCTestCase {
             waitForSoftwareKeyboardOnScreen(timeout: 3),
             "Composer Send continuity must be exercised with the software keyboard visibly on screen."
         )
-        let compactTextWidth = composerField.frame.width
+        let initialTextWidth = composerField.frame.width
 
         let initialText = "Explain why this composer keeps its width"
         composerField.typeText(initialText)
@@ -394,7 +449,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertGreaterThan(
             composerWidthBeforeWrapping,
             terminal.frame.width * 0.55,
-            "The composer must fill the middle dock slot rather than shrink-wrap its content."
+            "The composer must fill the bottom chrome rather than shrink-wrap its content."
         )
         composerField.typeText(
             " and explain why the composer keeps the same width while its text wraps across multiple lines"
@@ -408,20 +463,25 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertGreaterThan(
             composerField.frame.width,
             composerBounds.frame.width * 0.88,
-            "Expanded text must use the composer width instead of staying between the controls."
+            "The editor must use the composer width instead of sitting between controls."
         )
-        XCTAssertGreaterThan(
+        XCTAssertEqual(
             composerField.frame.width,
-            compactTextWidth,
-            "The text region must widen when it moves above the control row."
+            initialTextWidth,
+            accuracy: 1,
+            "The editor must keep its full width as text wraps."
         )
 
         let attachmentButton = app.buttons["terminal.composer.attachments"]
+        let closeButton = app.buttons["terminal.composer.toggle"]
         let micButton = app.buttons["terminal.composer.mic"]
         let sendButton = app.buttons["terminal.composer.send"]
         XCTAssertLessThanOrEqual(composerField.frame.maxY, attachmentButton.frame.minY)
+        XCTAssertEqual(attachmentButton.frame.midY, closeButton.frame.midY, accuracy: 1)
         XCTAssertEqual(attachmentButton.frame.midY, micButton.frame.midY, accuracy: 1)
         XCTAssertEqual(micButton.frame.midY, sendButton.frame.midY, accuracy: 1)
+        XCTAssertLessThanOrEqual(attachmentButton.frame.maxX, closeButton.frame.minX)
+        XCTAssertLessThan(closeButton.frame.maxX, micButton.frame.minX)
         attachScreenshot(named: "composer-multiline-width-stable")
 
         let keyboard = app.keyboards.firstMatch
@@ -2338,17 +2398,26 @@ final class RemuxAppUITests: XCTestCase {
         _ expected: Bool,
         label: String,
         timeout: TimeInterval = 3,
-        pollInterval: TimeInterval = 0.01
+        pollInterval: TimeInterval = 0.01,
+        stableFor minimumStableDuration: TimeInterval = 0
     ) -> TimeInterval? {
         let start = Date()
         let deadline = start.addingTimeInterval(timeout)
         let keyboard = app.keyboards.firstMatch
+        var matchingSince: Date?
 
         repeat {
-            if keyboard.exists == expected {
-                let elapsed = Date().timeIntervalSince(start)
-                print("Remux UI perf keyboard.\(expected ? "visible" : "hidden") label=\"\(label)\" elapsed_ms=\(String(format: "%.3f", elapsed * 1000))")
-                return elapsed
+            if isSoftwareKeyboardOnScreen(keyboard) == expected {
+                let now = Date()
+                matchingSince = matchingSince ?? now
+                if let matchingSince,
+                   now.timeIntervalSince(matchingSince) >= minimumStableDuration {
+                    let elapsed = now.timeIntervalSince(start)
+                    print("Remux UI perf keyboard.\(expected ? "visible" : "hidden") label=\"\(label)\" elapsed_ms=\(String(format: "%.3f", elapsed * 1000))")
+                    return elapsed
+                }
+            } else {
+                matchingSince = nil
             }
             RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
         } while Date() < deadline
@@ -3650,19 +3719,19 @@ final class RemuxAppUITests: XCTestCase {
         let keyboard = app.keyboards.firstMatch
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            let frame = keyboard.frame
-            if keyboard.exists,
-               frame.height > 100,
-               frame.intersects(app.frame) {
+            if isSoftwareKeyboardOnScreen(keyboard) {
                 return true
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.1))
         }
 
+        return isSoftwareKeyboardOnScreen(keyboard)
+    }
+
+    private func isSoftwareKeyboardOnScreen(_ keyboard: XCUIElement) -> Bool {
+        guard keyboard.exists else { return false }
         let frame = keyboard.frame
-        return keyboard.exists
-            && frame.height > 100
-            && frame.intersects(app.frame)
+        return frame.height > 100 && frame.intersects(app.frame)
     }
 
     private func waitForCopyMenuItem(timeout: TimeInterval) -> XCUIElement {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -172,6 +172,13 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertNotNil(waitForKeyboardPresence(true, label: "dictation stopped with keyboard visible"))
         XCTAssertEqual(app.keyboards.firstMatch.frame, visibleKeyboardFrame)
         XCTAssertTrue(keyboardDismiss.waitForExistence(timeout: 3))
+
+        composerToggle.tap()
+        XCTAssertFalse(
+            composer.waitForExistence(timeout: 1),
+            "Close must dismiss the composer when terminal keyboard handoff is unavailable."
+        )
+        XCTAssertNotNil(waitForKeyboardPresence(false, label: "composer close fallback"))
     }
 
     func testComposerDictationKeepsFullChromeWidth() {


### PR DESCRIPTION
## Summary

Redesign the terminal composer as a single full-width input surface that better uses the available space and keeps related controls together.

- Place the editor above the composer action row.
- Keep attachment and close controls on the left, with dictation and send on the right.
- Allow the editor to grow to six lines before scrolling.
- Collapse the same composer surface into a compact recording or transcription state.
- Adapt the dictation waveform to the available center space while preserving control spacing.

## Keyboard behavior

- Dock mode continues to send keyboard input directly to the terminal.
- Opening the composer does not force the keyboard to appear.
- Tapping the editor opens the keyboard normally.
- If the keyboard is already visible, ownership transfers between the terminal and composer without dismissing and presenting it again.
- A short downward drag on the composer handle dismisses the keyboard while keeping the composer open.
- The first keyboard session explains the drag gesture.
- Closing the composer returns an active keyboard to the terminal and preserves the draft.
- Recording and transcription do not change the existing keyboard state.

## Terminal geometry

Reserve the full settled composer height from the terminal viewport so terminal content remains above the composer.

The temporary compact dictation height is excluded from viewport sizing. This avoids unnecessary terminal resizes while recording or transcribing. Once dictation finishes, the composer naturally returns to the height required by the resulting draft.

## Validation

- Full unit test suite passes.
- Composer keyboard ownership and viewport transitions are covered by UI tests.
- Dictation start, stop, cancellation, transcription, and restart flows are covered.
- Keyboard-visible and keyboard-hidden dictation states were visually verified.
- Composer resizing and waveform geometry were verified on the simulator.
- The final build was installed and exercised on a physical iPhone.

## Screenshots 

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a4c68f14-6fc9-4832-ab9e-25a8c1ed379f" width="500"></td>
    <td><img src="https://github.com/user-attachments/assets/1fc1064a-ac9e-4343-bcf5-5717bc88e359" width="500"></td>
  </tr>
</table>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard dismissal controls, including an accessibility action, hint, and downward drag gesture.
  * Added a composer close action alongside attachment controls.
  * Expanded text input support to six lines.
  * Improved dictation visualization across different screen widths.
  * Added support for restoring the keyboard by tapping the editor.

* **Bug Fixes**
  * Improved bottom keyboard-chrome sizing and layout stability.
  * Maintained keyboard and viewport behavior more reliably while composing.
  * Improved composer transitions and interaction locking during submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->