### PR TITLE
fix preview navigation and refresh behavior

### DIFF
--- a/RemuxApp/Sources/Preview/TerminalPreviewLiveWeb.swift
+++ b/RemuxApp/Sources/Preview/TerminalPreviewLiveWeb.swift
@@ -46,6 +46,20 @@ struct TerminalPreviewWebLinkPolicy {
     }
 }
 
+@MainActor
+func reloadTerminalPreviewWebView(
+    _ webView: WKWebView,
+    ifRequested generation: UInt,
+    lastGeneration: inout UInt,
+    fallbackURL: URL
+) {
+    guard lastGeneration != generation else { return }
+    lastGeneration = generation
+    if webView.reloadFromOrigin() == nil {
+        webView.load(URLRequest(url: webView.url ?? fallbackURL))
+    }
+}
+
 enum TerminalPreviewLiveWebError: LocalizedError, Equatable, Sendable {
     case invalidLocalURL
 
@@ -160,36 +174,56 @@ struct TerminalPreviewLiveWebClient: Sendable {
 
 struct TerminalPreviewLiveWebView: UIViewRepresentable {
     let resource: TerminalPreviewLiveWebResource
+    let reloadGeneration: UInt
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(resource: resource)
+        Coordinator(
+            resource: resource,
+            reloadGeneration: reloadGeneration
+        )
     }
 
     func makeUIView(context: Context) -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        webView.isOpaque = false
-        webView.backgroundColor = .clear
-        webView.scrollView.backgroundColor = .clear
+        let webView = Self.makeWebView()
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
         webView.load(URLRequest(url: resource.localURL))
         return webView
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {}
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        reloadTerminalPreviewWebView(
+            webView,
+            ifRequested: reloadGeneration,
+            lastGeneration: &context.coordinator.reloadGeneration,
+            fallbackURL: resource.localURL
+        )
+    }
+
+    static func makeWebView() -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        webView.scrollView.backgroundColor = .clear
+        return webView
+    }
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         private let policy: TerminalPreviewWebLinkPolicy
+        fileprivate var reloadGeneration: UInt
 
         init(
             resource: TerminalPreviewLiveWebResource,
+            reloadGeneration: UInt = 0,
             openExternalURL: @escaping @MainActor (URL) -> Void = {
                 UIApplication.shared.open($0)
             }
         ) {
             let localPort = resource.localPort
+            self.reloadGeneration = reloadGeneration
             self.policy = TerminalPreviewWebLinkPolicy(
                 allowsNavigation: { url in
                     guard let scheme = url.scheme?.lowercased(),

--- a/RemuxApp/Sources/Preview/TerminalPreviewSession.swift
+++ b/RemuxApp/Sources/Preview/TerminalPreviewSession.swift
@@ -71,7 +71,7 @@ final class TerminalPreviewSession: ObservableObject {
         startLoading(candidate, resolvingPathWith: resolver, client: client)
     }
 
-    func refresh() {
+    func restart() {
         guard let client, let currentCandidate, let pathResolver else { return }
         task?.cancel()
         releaseReadyResource()

--- a/RemuxApp/Sources/Preview/TerminalPreviewStaticHTML.swift
+++ b/RemuxApp/Sources/Preview/TerminalPreviewStaticHTML.swift
@@ -364,7 +364,7 @@ private actor TerminalPreviewStaticHTMLTransport {
     }
 
     private let entryURL: URL
-    private let entryMetadata: RemuxSFTPFileMetadata
+    private var entryMetadata: RemuxSFTPFileMetadata?
     private let readLease: TerminalPreviewStaticHTMLReadLease
     private var operations: [ObjectIdentifier: Operation] = [:]
     private var closed = false
@@ -391,7 +391,13 @@ private actor TerminalPreviewStaticHTMLTransport {
         }
         guard !sink.isStopped else { return }
         let readLease = readLease
-        let knownMetadata = url == entryURL ? entryMetadata : nil
+        let knownMetadata: RemuxSFTPFileMetadata?
+        if url == entryURL {
+            knownMetadata = entryMetadata
+            entryMetadata = nil
+        } else {
+            knownMetadata = nil
+        }
         let token = UUID()
         let task = Task {
             do {
@@ -526,9 +532,13 @@ private final class TerminalPreviewStaticHTMLSchemeTaskSink: @unchecked Sendable
 
 struct TerminalPreviewStaticHTMLView: UIViewRepresentable {
     let resource: TerminalPreviewStaticHTMLResource
+    let reloadGeneration: UInt
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(resource: resource)
+        Coordinator(
+            resource: resource,
+            reloadGeneration: reloadGeneration
+        )
     }
 
     func makeUIView(context: Context) -> WKWebView {
@@ -541,7 +551,14 @@ struct TerminalPreviewStaticHTMLView: UIViewRepresentable {
         return webView
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {}
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        reloadTerminalPreviewWebView(
+            webView,
+            ifRequested: reloadGeneration,
+            lastGeneration: &context.coordinator.reloadGeneration,
+            fallbackURL: resource.entryURL
+        )
+    }
 
     static func makeWebView(
         schemeHandler: TerminalPreviewStaticHTMLSchemeHandler
@@ -553,6 +570,7 @@ struct TerminalPreviewStaticHTMLView: UIViewRepresentable {
             forURLScheme: TerminalPreviewStaticHTMLResource.scheme
         )
         let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.allowsBackForwardNavigationGestures = true
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = .clear
@@ -562,14 +580,17 @@ struct TerminalPreviewStaticHTMLView: UIViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let schemeHandler: TerminalPreviewStaticHTMLSchemeHandler
         private let policy: TerminalPreviewWebLinkPolicy
+        fileprivate var reloadGeneration: UInt
 
         init(
             resource: TerminalPreviewStaticHTMLResource,
+            reloadGeneration: UInt = 0,
             openExternalURL: @escaping @MainActor (URL) -> Void = {
                 UIApplication.shared.open($0)
             }
         ) {
             self.schemeHandler = resource.makeSchemeHandler()
+            self.reloadGeneration = reloadGeneration
             self.policy = TerminalPreviewWebLinkPolicy(
                 allowsNavigation: { url in
                     url.scheme == TerminalPreviewStaticHTMLResource.scheme

--- a/RemuxApp/Sources/Preview/TerminalPreviewView.swift
+++ b/RemuxApp/Sources/Preview/TerminalPreviewView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TerminalPreviewView: View {
     @ObservedObject var session: TerminalPreviewSession
     let terminalTheme: TerminalTheme
+    @State private var webReloadGeneration: UInt = 0
 
     var body: some View {
         NavigationStack {
@@ -12,18 +13,15 @@ struct TerminalPreviewView: View {
                 .navigationTitle(session.currentCandidate?.filename ?? "Preview")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItem(placement: .topBarLeading) {
+                    ToolbarItem(placement: .cancellationAction) {
                         Button(action: session.close) {
-                            HStack(spacing: 5) {
-                                Image(systemName: "chevron.left")
-                                    .font(.body.weight(.semibold))
-                                Text("Terminal")
-                            }
+                            Image(systemName: "xmark")
                         }
-                        .accessibilityIdentifier("terminal.preview.back")
+                        .accessibilityLabel("Close Preview")
+                        .accessibilityIdentifier("terminal.preview.close")
                     }
                     ToolbarItem(placement: .topBarTrailing) {
-                        Button(action: session.refresh) {
+                        Button(action: refreshPreview) {
                             Image(systemName: "arrow.clockwise")
                         }
                         .accessibilityLabel("Refresh")
@@ -66,9 +64,15 @@ struct TerminalPreviewView: View {
                 case .file(let file):
                     GhosttyQuickLookPreview(resource: file)
                 case .staticHTML(let html):
-                    TerminalPreviewStaticHTMLView(resource: html)
+                    TerminalPreviewStaticHTMLView(
+                        resource: html,
+                        reloadGeneration: webReloadGeneration
+                    )
                 case .liveWeb(let liveWeb):
-                    TerminalPreviewLiveWebView(resource: liveWeb)
+                    TerminalPreviewLiveWebView(
+                        resource: liveWeb,
+                        reloadGeneration: webReloadGeneration
+                    )
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -84,7 +88,7 @@ struct TerminalPreviewView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                Button("Retry", action: session.refresh)
+                Button("Retry", action: session.restart)
                     .buttonStyle(.borderedProminent)
                     .tint(terminalTheme.terminalChromeStyle.accent)
                     .accessibilityIdentifier("terminal.preview.retry")
@@ -92,6 +96,20 @@ struct TerminalPreviewView: View {
             .padding(28)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .accessibilityIdentifier("terminal.preview.failure")
+        }
+    }
+
+    private func refreshPreview() {
+        switch session.state {
+        case .ready(_, let resource):
+            switch resource {
+            case .file:
+                session.restart()
+            case .staticHTML, .liveWeb:
+                webReloadGeneration &+= 1
+            }
+        case .idle, .loading, .failed:
+            session.restart()
         }
     }
 }

--- a/RemuxAppTests/TerminalPreviewLiveWebTests.swift
+++ b/RemuxAppTests/TerminalPreviewLiveWebTests.swift
@@ -5,6 +5,13 @@ import XCTest
 @testable import Remux
 
 final class TerminalPreviewLiveWebTests: XCTestCase {
+    @MainActor
+    func testWebViewEnablesBackForwardNavigationGestures() {
+        let webView = TerminalPreviewLiveWebView.makeWebView()
+
+        XCTAssertTrue(webView.allowsBackForwardNavigationGestures)
+    }
+
     func testClientRoutesLocalhostTargetsToLiveWeb() async throws {
         let client = TerminalPreviewClient(
             loadFile: { _ in throw LiveWebRouteError.file },

--- a/RemuxAppTests/TerminalPreviewSessionTests.swift
+++ b/RemuxAppTests/TerminalPreviewSessionTests.swift
@@ -120,7 +120,7 @@ final class TerminalPreviewSessionTests: XCTestCase {
             if case .failed = session.state { return true }
             return false
         }
-        session.refresh()
+        session.restart()
         try await waitUntil("retry did not become ready") {
             if case .ready = session.state { return true }
             return false
@@ -162,7 +162,7 @@ final class TerminalPreviewSessionTests: XCTestCase {
             if case .failed = session.state { return true }
             return false
         }
-        session.refresh()
+        session.restart()
         try await waitUntil("retry did not become ready") {
             if case .ready = session.state { return true }
             return false

--- a/RemuxAppTests/TerminalPreviewStaticHTMLTests.swift
+++ b/RemuxAppTests/TerminalPreviewStaticHTMLTests.swift
@@ -152,6 +152,43 @@ final class TerminalPreviewStaticHTMLTests: XCTestCase {
     }
 
     @MainActor
+    func testSchemeHandlerUsesEntryMetadataOnlyForFirstRequest() async throws {
+        let metadataPresence = StaticHTMLMetadataPresenceRecorder()
+        let entryMetadata = RemuxSFTPFileMetadata(
+            size: 5,
+            permissions: nil,
+            modificationDate: nil
+        )
+        let resource = try TerminalPreviewStaticHTMLResource(
+            remotePath: "/srv/app/index.html",
+            entryMetadata: entryMetadata,
+            readLease: TerminalPreviewStaticHTMLReadLease(
+                stream: { _, metadata, onMetadata, onChunk in
+                    await metadataPresence.record(metadata != nil)
+                    try await onMetadata(metadata ?? entryMetadata)
+                    try await onChunk(Data("index".utf8))
+                },
+                close: {}
+            )
+        )
+        let handler = resource.makeSchemeHandler()
+        let firstTask = StaticHTMLSchemeTaskSpy(url: resource.entryURL)
+        let secondTask = StaticHTMLSchemeTaskSpy(url: resource.entryURL)
+
+        handler.webView(WKWebView(), start: firstTask)
+        try await waitUntil("first scheme task did not finish") {
+            firstTask.finishCount == 1
+        }
+        handler.webView(WKWebView(), start: secondTask)
+        try await waitUntil("second scheme task did not finish") {
+            secondTask.finishCount == 1
+        }
+
+        let recordedPresence = await metadataPresence.values()
+        XCTAssertEqual(recordedPresence, [true, false])
+    }
+
+    @MainActor
     func testStoppedSchemeTaskReceivesNothingAfterStopReturns() async throws {
         let entered = StaticHTMLTestGate()
         let release = StaticHTMLTestGate()
@@ -237,6 +274,7 @@ final class TerminalPreviewStaticHTMLTests: XCTestCase {
         let webView = TerminalPreviewStaticHTMLView.makeWebView(
             schemeHandler: resource.makeSchemeHandler()
         )
+        XCTAssertTrue(webView.allowsBackForwardNavigationGestures)
         webView.load(URLRequest(url: resource.entryURL))
 
         try await waitUntil(
@@ -415,6 +453,18 @@ private actor StaticHTMLCloseCounter {
 
     func value() -> Int {
         count
+    }
+}
+
+private actor StaticHTMLMetadataPresenceRecorder {
+    private var recordedValues: [Bool] = []
+
+    func record(_ value: Bool) {
+        recordedValues.append(value)
+    }
+
+    func values() -> [Bool] {
+        recordedValues
     }
 }
 

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -1795,13 +1795,14 @@ final class RemuxAppUITests: XCTestCase {
         ))
         fflush(stdout)
 
-        let back = app.buttons["terminal.preview.back"].firstMatch
-        XCTAssertTrue(back.waitForExistence(timeout: 5))
+        let close = app.buttons["terminal.preview.close"].firstMatch
+        XCTAssertTrue(close.waitForExistence(timeout: 5))
+        XCTAssertEqual(close.label, "Close Preview")
         let previewCloseStarted = ProcessInfo.processInfo.systemUptime
-        back.tap()
+        close.tap()
         XCTAssertTrue(
-            waitForElementToDisappear(back, timeout: 5),
-            "Back should return directly to the retained terminal."
+            waitForElementToDisappear(close, timeout: 5),
+            "Close should return directly to the retained terminal."
         )
         print(String(
             format: "REMUX_PREVIEW_CLOSE_MS %.1f",
@@ -1833,15 +1834,15 @@ final class RemuxAppUITests: XCTestCase {
         print("REMUX_PREVIEW_RAPID_DISMISS_BEGIN")
         fflush(stdout)
         rapidPreview.tap()
-        let rapidBack = app.buttons["terminal.preview.back"].firstMatch
+        let rapidClose = app.buttons["terminal.preview.close"].firstMatch
         XCTAssertTrue(
-            rapidBack.waitForExistence(timeout: 2),
+            rapidClose.waitForExistence(timeout: 2),
             "Preview chrome should appear immediately while the file is loading."
         )
-        rapidBack.tap()
+        rapidClose.tap()
         XCTAssertTrue(
-            waitForElementToDisappear(rapidBack, timeout: 5),
-            "Immediate Back should return to the retained terminal."
+            waitForElementToDisappear(rapidClose, timeout: 5),
+            "Immediate Close should return to the retained terminal."
         )
         waitForLiveTerminalInputReady(timeout: 10)
         XCTAssertTrue(
@@ -1901,6 +1902,22 @@ final class RemuxAppUITests: XCTestCase {
                 ) != nil else {
                     return
                 }
+                if scenario.name == "static-html-relative-assets"
+                    || scenario.name == "live-localhost" {
+                    let firstLoad = app.staticTexts["Reload count 1"].firstMatch
+                    XCTAssertTrue(
+                        firstLoad.waitForExistence(timeout: 10),
+                        "\(scenario.token) should execute its first page load."
+                    )
+                    let refresh = app.buttons["terminal.preview.refresh"].firstMatch
+                    XCTAssertTrue(refresh.waitForExistence(timeout: 5))
+                    refresh.tap()
+                    XCTAssertTrue(
+                        app.staticTexts["Reload count 2"].firstMatch
+                            .waitForExistence(timeout: 10),
+                        "Refresh should reload \(scenario.token) in the existing web view."
+                    )
+                }
             } else {
                 XCTAssertTrue(
                     scenarioFailure.exists,
@@ -1909,10 +1926,10 @@ final class RemuxAppUITests: XCTestCase {
                 XCTAssertFalse(scenarioContent.exists)
             }
 
-            let scenarioBack = app.buttons["terminal.preview.back"].firstMatch
-            XCTAssertTrue(scenarioBack.waitForExistence(timeout: 5))
-            scenarioBack.tap()
-            XCTAssertTrue(waitForElementToDisappear(scenarioBack, timeout: 5))
+            let scenarioClose = app.buttons["terminal.preview.close"].firstMatch
+            XCTAssertTrue(scenarioClose.waitForExistence(timeout: 5))
+            scenarioClose.tap()
+            XCTAssertTrue(waitForElementToDisappear(scenarioClose, timeout: 5))
             waitForLiveTerminalInputReady(timeout: 10)
             XCTAssertTrue(waitForSoftwareKeyboardOnScreen(timeout: 10))
         }

--- a/scripts/remux_live_ui_test_with_cleanup.sh
+++ b/scripts/remux_live_ui_test_with_cleanup.sh
@@ -437,8 +437,10 @@ cat >"$html_path" <<'PREVIEW_HTML'
 PREVIEW_HTML
 cat >"$script_path" <<'PREVIEW_JS'
 document.addEventListener('DOMContentLoaded', function () {
+  var reloadCount = Number(sessionStorage.getItem('remuxReloadCount') || '0') + 1;
+  sessionStorage.setItem('remuxReloadCount', String(reloadCount));
   var banner = document.createElement('p');
-  banner.textContent = 'JavaScript executed';
+  banner.textContent = 'Reload count ' + reloadCount;
   banner.style.color = '#f8fafc';
   banner.style.font = '600 20px -apple-system, sans-serif';
   document.body.appendChild(banner);


### PR DESCRIPTION
## Summary

- Replace the misleading “‹ Terminal” control with an accessible Close button.
- Enable back/forward swipe gestures in static HTML and localhost web previews.
- Reload ready web previews in place instead of rebuilding their resources.
- Keep full preview restart behavior for files, loading states, and failed-state Retry.
- Refresh static HTML metadata after the initial request so reloads use the current remote file size.

## Why

Terminal Preview is a full-screen overlay, not a navigation-stack push. The previous chevron looked like both a system back button and browser history control, but tapping it closed the entire preview and, for localhost, tore down the SSH forward.

The refresh button also rebuilt the complete preview resource. That was unnecessary for common cases such as a dev server finishing startup, restarting, or serving updated content. Reloading the existing `WKWebView` preserves its navigation history and active preview transport while still retrying the current page.

If WebKit has no reloadable page after an initial load failure, Refresh falls back to loading the preview URL directly.

## Testing

- Focused `TerminalPreviewSession`, `TerminalPreviewLiveWeb`, and `TerminalPreviewStaticHTML` test suites.
- Live SSH regression coverage on both the iOS Simulator and a physical iPhone, covering:
  - accessible Close behavior
  - immediate dismissal while loading
  - static HTML and relative resources
  - localhost forwarding and in-place reload
  - missing-file failure handling
  - keyboard and terminal restoration
  - terminal selection and window interaction
- Static HTML and localhost fixtures advance a `sessionStorage` counter from 1 to 2 after Refresh, proving that the existing web view reloads in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable refresh behavior for live web and HTML terminal previews without restarting the active preview.
  - Enabled back and forward navigation gestures in web previews.
  - Added visible reload-count feedback for file previews.

- **Bug Fixes**
  - Improved preview reload fallback behavior when a direct reload is unavailable.
  - Updated retry actions to restart previews consistently.
  - Replaced the toolbar Back control with a clearer Close Preview action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->