### PR TITLE
Update SSH dependencies for Preview close fix

### DIFF
--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -1460,7 +1460,7 @@
 			repositoryURL = "https://github.com/h3nock/Citadel.git";
 			requirement = {
 				kind = revision;
-				revision = 1d0eadd81d0a521b00ede6663c8b3301f5fc252e;
+				revision = 0697b32db78dab5adaae5aaba1d2749838986a26;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Remux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Remux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/h3nock/Citadel.git",
       "state" : {
-        "revision" : "1d0eadd81d0a521b00ede6663c8b3301f5fc252e"
+        "revision" : "0697b32db78dab5adaae5aaba1d2749838986a26"
       }
     },
     {
@@ -77,7 +77,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/h3nock/swift-nio-ssh.git",
       "state" : {
-        "revision" : "7588777b8f6439efa1a33117f86cb2729abd864c"
+        "revision" : "77c4207edc36c30dc5fc5ebac0a0d496e8314448"
       }
     },
     {

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
 packages:
   Citadel:
     url: https://github.com/h3nock/Citadel.git
-    revision: 1d0eadd81d0a521b00ede6663c8b3301f5fc252e
+    revision: 0697b32db78dab5adaae5aaba1d2749838986a26
 targets:
   Remux:
     type: application


### PR DESCRIPTION
## Summary

- pin Citadel to merged commit `0697b32db78dab5adaae5aaba1d2749838986a26`
- resolve swift-nio-ssh at merged commit `77c4207edc36c30dc5fc5ebac0a0d496e8314448`
- prevent the SSH window-adjust assertion that could leave Preview loading and terminal panes disabled after closing localhost Preview

## Dependencies

- h3nock/swift-nio-ssh#1
- h3nock/Citadel#1

## Validation

- physical iPhone validation of the dependency fix: 27/27 Preview opens reached ready, with every initiated listener and remote-channel teardown completing
- final merged dependency chain builds successfully in Remux
- Remux test suite: 962 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an underlying project component to improve compatibility and stability.
  * No changes to the app’s user-facing features, workflows, or behavior.
  * No new settings, interface changes, or public functionality were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->