### PR TITLE
add a global multipane zoom preference

### DIFF
--- a/RemuxApp/Sources/App/RemuxAppDependencies.swift
+++ b/RemuxApp/Sources/App/RemuxAppDependencies.swift
@@ -331,11 +331,11 @@ struct RemuxAppDependencies: Sendable {
         return RemuxAppDependencies(
             profileRepository: InMemoryConnectionProfileRepository(),
             settingsRepository: InMemoryTerminalSettingsRepository(
-                settings: TerminalSettings(
-                    fontSize: nil,
-                    theme: .ghosttyDefault,
-                    zoomMultipaneWindowsByDefault: deviceDefaultZoomMultipaneWindows
-                )
+                settings: {
+                    var settings = TerminalSettings.default
+                    settings.zoomMultipaneWindowsByDefault = deviceDefaultZoomMultipaneWindows
+                    return settings
+                }()
             ),
             shortcutRepository: InMemoryShortcutRepository(),
             credentialStore: InMemorySSHCredentialStore(),

--- a/RemuxApp/Sources/App/RemuxAppDependencies.swift
+++ b/RemuxApp/Sources/App/RemuxAppDependencies.swift
@@ -1,6 +1,7 @@
 @preconcurrency import Citadel
 import Foundation
 import NIOCore
+import UIKit
 
 enum RemuxConnectionTimeouts {
     static let terminalSSHConnect: TimeAmount = .seconds(10)
@@ -90,6 +91,7 @@ struct RemuxAppDependencies: Sendable {
         self.debugConnectionSeeder = debugConnectionSeeder
     }
 
+    @MainActor
     static func launch() -> Result<RemuxAppDependencies, Error> {
         Result {
 #if DEBUG || REMUX_LIVE_UI_TESTING
@@ -101,6 +103,7 @@ struct RemuxAppDependencies: Sendable {
         }
     }
 
+    @MainActor
     static func live() throws -> RemuxAppDependencies {
 #if DEBUG || REMUX_LIVE_UI_TESTING
         let environment = ProcessInfo.processInfo.environment
@@ -125,7 +128,10 @@ struct RemuxAppDependencies: Sendable {
         let trustedHostStore = TrustedHostStore(rootURL: root)
         return RemuxAppDependencies(
             profileRepository: FileBackedConnectionProfileRepository(rootURL: root),
-            settingsRepository: FileBackedTerminalSettingsRepository(rootURL: root),
+            settingsRepository: FileBackedTerminalSettingsRepository(
+                rootURL: root,
+                defaultZoomMultipaneWindows: deviceDefaultZoomMultipaneWindows
+            ),
             shortcutRepository: FileBackedShortcutRepository(rootURL: root),
             credentialStore: credentialStore,
             trustedHostStore: trustedHostStore,
@@ -310,6 +316,7 @@ struct RemuxAppDependencies: Sendable {
         }
     }
 
+    @MainActor
     static func uiTesting() throws -> RemuxAppDependencies {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("RemuxUITesting", isDirectory: true)
@@ -323,7 +330,13 @@ struct RemuxAppDependencies: Sendable {
 
         return RemuxAppDependencies(
             profileRepository: InMemoryConnectionProfileRepository(),
-            settingsRepository: InMemoryTerminalSettingsRepository(),
+            settingsRepository: InMemoryTerminalSettingsRepository(
+                settings: TerminalSettings(
+                    fontSize: nil,
+                    theme: .ghosttyDefault,
+                    zoomMultipaneWindowsByDefault: deviceDefaultZoomMultipaneWindows
+                )
+            ),
             shortcutRepository: InMemoryShortcutRepository(),
             credentialStore: InMemorySSHCredentialStore(),
             trustedHostStore: trustedHostStore,
@@ -341,6 +354,11 @@ struct RemuxAppDependencies: Sendable {
             sshConnectionPrewarmer: { _, _, _ in
             }
         )
+    }
+
+    @MainActor
+    private static var deviceDefaultZoomMultipaneWindows: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
     }
 
     private static func uiTestingTransportChunks() -> [Data] {
@@ -462,7 +480,11 @@ private actor InMemoryConnectionProfileRepository: ConnectionProfileRepository {
 }
 
 private actor InMemoryTerminalSettingsRepository: TerminalSettingsRepository {
-    private var settings = TerminalSettings.default
+    private var settings: TerminalSettings
+
+    init(settings: TerminalSettings = .default) {
+        self.settings = settings
+    }
 
     func loadSettings() async throws -> TerminalSettings {
         settings

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -262,7 +262,7 @@ private struct RemuxWorkspaceShell: View {
             ConnectionLibraryView(
                 snapshot: model.library,
                 activeSessions: model.activeSessions,
-                terminalSettings: model.terminalSettings,
+                terminalSettings: terminalSettingsBinding,
                 onAddServer: model.beginNewServer,
                 onAddWorkspace: { serverID in
                     Task { await model.beginNewWorkspace(for: serverID) }
@@ -291,17 +291,23 @@ private struct RemuxWorkspaceShell: View {
                 },
                 onDeleteWorkspace: { workspaceID in
                     Task { await model.deleteWorkspace(workspaceID) }
-                },
-                onSettingsChange: { settings in
-                    Task {
-                        await model.updateTerminalSettings { current in
-                            current = settings
-                        }
-                    }
                 }
             )
         }
         .zIndex(2)
+    }
+
+    private var terminalSettingsBinding: Binding<TerminalSettings> {
+        Binding(
+            get: { model.terminalSettings },
+            set: { settings in
+                Task {
+                    await model.updateTerminalSettings { current in
+                        current = settings
+                    }
+                }
+            }
+        )
     }
 
     private func traceSessionOpenTap(_ workspaceID: SavedWorkspace.ID) {
@@ -463,7 +469,7 @@ private struct ConnectionLibraryView: View {
 
     let snapshot: ConnectionLibrarySnapshot
     let activeSessions: [ActiveTerminalSession]
-    let terminalSettings: TerminalSettings
+    @Binding var terminalSettings: TerminalSettings
     let onAddServer: () -> Void
     let onAddWorkspace: (SavedServer.ID) -> Void
     let onEditServer: (SavedServer.ID) -> Void
@@ -473,7 +479,6 @@ private struct ConnectionLibraryView: View {
     let onDisconnectActiveSession: (SavedWorkspace.ID) -> Void
     let onDeleteServer: (SavedServer.ID) -> Void
     let onDeleteWorkspace: (SavedWorkspace.ID) -> Void
-    let onSettingsChange: (TerminalSettings) -> Void
 
     @State private var showsAllConnectedSessions = false
     @State private var showsAllRecentSessions = false
@@ -504,10 +509,7 @@ private struct ConnectionLibraryView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 NavigationLink {
-                    TerminalSettingsView(
-                        initialSettings: terminalSettings,
-                        onChange: onSettingsChange
-                    )
+                    TerminalSettingsView(settings: $terminalSettings)
                 } label: {
                     Image(systemName: "gearshape")
                 }
@@ -1234,15 +1236,12 @@ private func serverSummary(
 }
 
 private struct TerminalSettingsView: View {
+    @Binding private var sourceSettings: TerminalSettings
     @State private var settings: TerminalSettings
-    let onChange: (TerminalSettings) -> Void
 
-    init(
-        initialSettings: TerminalSettings,
-        onChange: @escaping (TerminalSettings) -> Void
-    ) {
-        _settings = State(initialValue: initialSettings)
-        self.onChange = onChange
+    init(settings: Binding<TerminalSettings>) {
+        _sourceSettings = settings
+        _settings = State(initialValue: settings.wrappedValue)
     }
 
     var body: some View {
@@ -1284,6 +1283,24 @@ private struct TerminalSettingsView: View {
             .libraryHomeListRowSurface()
 
             Section {
+                Toggle(
+                    "Zoom multipane windows",
+                    isOn: zoomMultipaneWindowsByDefaultBinding
+                )
+                .tint(LibraryHomePalette.controlAccent)
+                .accessibilityIdentifier("settings.zoom-multipane-windows-by-default")
+            } header: {
+                Text("Windows & Panes")
+            } footer: {
+                Text(
+                    "Automatically zooms the active pane while letting you override "
+                        + "individual windows from Panes. Remux cleans up these zooms "
+                        + "when it closes normally."
+                )
+            }
+            .libraryHomeListRowSurface()
+
+            Section {
                 Toggle("Allow older RSA host keys", isOn: allowInsecureRSAHostKeysBinding)
                     .tint(LibraryHomePalette.controlAccent)
                     .accessibilityIdentifier("settings.allow-insecure-rsa")
@@ -1306,6 +1323,13 @@ private struct TerminalSettingsView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
         .accessibilityIdentifier("settings.form")
+        .onAppear {
+            settings = sourceSettings
+        }
+        .onChange(of: sourceSettings) { previousSettings, updatedSettings in
+            guard settings == previousSettings else { return }
+            settings = updatedSettings
+        }
     }
 
     private var useDefaultFontBinding: Binding<Bool> {
@@ -1313,7 +1337,7 @@ private struct TerminalSettingsView: View {
             get: { settings.fontSize == nil },
             set: { useDefault in
                 settings.fontSize = useDefault ? nil : TerminalSettings.defaultExplicitFontSize
-                onChange(settings)
+                sourceSettings = settings
             }
         )
     }
@@ -1323,7 +1347,7 @@ private struct TerminalSettingsView: View {
             get: { Double(settings.fontSize ?? TerminalSettings.defaultExplicitFontSize) },
             set: { value in
                 settings.fontSize = Float32(value)
-                onChange(settings)
+                sourceSettings = settings
             }
         )
     }
@@ -1333,7 +1357,7 @@ private struct TerminalSettingsView: View {
             get: { settings.theme },
             set: { value in
                 settings.theme = value
-                onChange(settings)
+                sourceSettings = settings
             }
         )
     }
@@ -1343,7 +1367,17 @@ private struct TerminalSettingsView: View {
             get: { settings.allowInsecureRSAHostKeys },
             set: { value in
                 settings.allowInsecureRSAHostKeys = value
-                onChange(settings)
+                sourceSettings = settings
+            }
+        )
+    }
+
+    private var zoomMultipaneWindowsByDefaultBinding: Binding<Bool> {
+        Binding(
+            get: { settings.zoomMultipaneWindowsByDefault },
+            set: { value in
+                settings.zoomMultipaneWindowsByDefault = value
+                sourceSettings = settings
             }
         )
     }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1293,9 +1293,8 @@ private struct TerminalSettingsView: View {
                 Text("Windows & Panes")
             } footer: {
                 Text(
-                    "Automatically zooms the active pane while letting you override "
-                        + "individual windows from Panes. Remux cleans up these zooms "
-                        + "when it closes normally."
+                    "Applies to all windows. Override any window from Panes. Remux normally "
+                        + "clears its zooms when closing; otherwise, use prefix + z."
                 )
             }
             .libraryHomeListRowSurface()

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1293,8 +1293,8 @@ private struct TerminalSettingsView: View {
                 Text("Windows & Panes")
             } footer: {
                 Text(
-                    "Applies to all windows. Override any window from Panes. Remux normally "
-                        + "clears its zooms when closing; otherwise, use prefix + z."
+                    "You can override this per window from Panes. Remux normally clears zooms "
+                        + "it applied when closing. If one remains on the server, use prefix + z."
                 )
             }
             .libraryHomeListRowSurface()

--- a/RemuxApp/Sources/Domain/TerminalSettings.swift
+++ b/RemuxApp/Sources/Domain/TerminalSettings.swift
@@ -139,20 +139,27 @@ struct TerminalSettings: Equatable, Codable, Sendable {
     /// Defaults to `false` when absent from persisted settings.
     var allowInsecureRSAHostKeys: Bool
 
+    /// The zoom state applied to multipane windows when a Remux session starts
+    /// or this global preference changes.
+    var zoomMultipaneWindowsByDefault: Bool
+
     init(
         fontSize: Float32?,
         theme: TerminalTheme,
-        allowInsecureRSAHostKeys: Bool = false
+        allowInsecureRSAHostKeys: Bool = false,
+        zoomMultipaneWindowsByDefault: Bool = false
     ) {
         self.fontSize = Self.normalizedFontSize(fontSize)
         self.theme = theme
         self.allowInsecureRSAHostKeys = allowInsecureRSAHostKeys
+        self.zoomMultipaneWindowsByDefault = zoomMultipaneWindowsByDefault
     }
 
     private enum CodingKeys: String, CodingKey {
         case fontSize
         case theme
         case allowInsecureRSAHostKeys
+        case zoomMultipaneWindowsByDefault
     }
 
     // Custom decoding keeps older persisted settings (written before these keys
@@ -162,7 +169,11 @@ struct TerminalSettings: Equatable, Codable, Sendable {
         self.init(
             fontSize: try container.decodeIfPresent(Float32.self, forKey: .fontSize),
             theme: try container.decodeIfPresent(TerminalTheme.self, forKey: .theme) ?? .ghosttyDefault,
-            allowInsecureRSAHostKeys: try container.decodeIfPresent(Bool.self, forKey: .allowInsecureRSAHostKeys) ?? false
+            allowInsecureRSAHostKeys: try container.decodeIfPresent(Bool.self, forKey: .allowInsecureRSAHostKeys) ?? false,
+            zoomMultipaneWindowsByDefault: try container.decodeIfPresent(
+                Bool.self,
+                forKey: .zoomMultipaneWindowsByDefault
+            ) ?? decoder.userInfo[.terminalSettingsDefaultMultipaneZoom] as? Bool ?? false
         )
     }
 
@@ -196,4 +207,10 @@ struct TerminalSettings: Equatable, Codable, Sendable {
 
         return String(format: "%.2f", value)
     }
+}
+
+extension CodingUserInfoKey {
+    static let terminalSettingsDefaultMultipaneZoom = CodingUserInfoKey(
+        rawValue: "terminalSettingsDefaultMultipaneZoom"
+    )!
 }

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -2046,6 +2046,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             event: "ui.select.queued",
             fields: ["target_uuid": id.uuidString]
         )
+        dismissSelectionSheet()
+        refocusSystemKeyboardIfActive()
     }
 
     private func closeTmuxPaneFromSelectionSheet(_ id: UUID, topLevelID: UUID) {

--- a/RemuxApp/Sources/Persistence/TerminalSettingsRepository.swift
+++ b/RemuxApp/Sources/Persistence/TerminalSettingsRepository.swift
@@ -7,13 +7,27 @@ protocol TerminalSettingsRepository: Sendable {
 
 actor FileBackedTerminalSettingsRepository: TerminalSettingsRepository {
     private let store: JSONFileStore<TerminalSettings>
+    private let defaultSettings: TerminalSettings
 
-    init(rootURL: URL) {
-        self.store = JSONFileStore(fileURL: rootURL.appendingPathComponent("terminal-settings.json"))
+    init(
+        rootURL: URL,
+        defaultZoomMultipaneWindows: Bool = false
+    ) {
+        defaultSettings = TerminalSettings(
+            fontSize: nil,
+            theme: .ghosttyDefault,
+            zoomMultipaneWindowsByDefault: defaultZoomMultipaneWindows
+        )
+        let decoder = JSONDecoder()
+        decoder.userInfo[.terminalSettingsDefaultMultipaneZoom] = defaultZoomMultipaneWindows
+        self.store = JSONFileStore(
+            fileURL: rootURL.appendingPathComponent("terminal-settings.json"),
+            decoder: decoder
+        )
     }
 
     func loadSettings() async throws -> TerminalSettings {
-        try await store.load(defaultValue: [.default]).first ?? .default
+        try await store.load(defaultValue: [defaultSettings]).first ?? defaultSettings
     }
 
     func saveSettings(_ settings: TerminalSettings) async throws {

--- a/RemuxApp/Sources/Persistence/TerminalSettingsRepository.swift
+++ b/RemuxApp/Sources/Persistence/TerminalSettingsRepository.swift
@@ -13,11 +13,9 @@ actor FileBackedTerminalSettingsRepository: TerminalSettingsRepository {
         rootURL: URL,
         defaultZoomMultipaneWindows: Bool = false
     ) {
-        defaultSettings = TerminalSettings(
-            fontSize: nil,
-            theme: .ghosttyDefault,
-            zoomMultipaneWindowsByDefault: defaultZoomMultipaneWindows
-        )
+        var defaultSettings = TerminalSettings.default
+        defaultSettings.zoomMultipaneWindowsByDefault = defaultZoomMultipaneWindows
+        self.defaultSettings = defaultSettings
         let decoder = JSONDecoder()
         decoder.userInfo[.terminalSettingsDefaultMultipaneZoom] = defaultZoomMultipaneWindows
         self.store = JSONFileStore(

--- a/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
+++ b/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
@@ -118,6 +118,7 @@ final class TmuxScreenModel: ObservableObject {
         self.session = session
         terminalScreenAdapter.activate(
             session: session,
+            zoomMultipaneWindowsByDefault: currentTerminalSettings.zoomMultipaneWindowsByDefault,
             initialViewportHandler: { [weak self] size, scale in
                 self?.prepareInitialViewport(size: size, scale: scale)
             },
@@ -302,6 +303,9 @@ final class TmuxScreenModel: ObservableObject {
     /// before each retained pane surface re-snapshots it in place.
     func applyTerminalSettings(_ settings: TerminalSettings) throws {
         guard settings != currentTerminalSettings else { return }
+        terminalScreenAdapter.setZoomMultipaneWindowsByDefault(
+            settings.zoomMultipaneWindowsByDefault
+        )
         guard !settings.hasSameTerminalAppearance(as: currentTerminalSettings) else {
             currentTerminalSettings = settings
             return

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -164,7 +164,6 @@ final class TmuxSessionController: @unchecked Sendable {
         var onTopology: @Sendable (TopologySnapshot) -> Void = { _ in }
         var onPaneRemoved: @Sendable (TmuxPaneID) -> Void = { _ in }
         var onPaneTerminal: @Sendable (RetainedPaneTerminal) -> Void = { _ in }
-        var onPanePhaseChanged: @Sendable (TmuxPaneID, PaneInfo.Phase) -> Void = { _, _ in }
         var onActivePaneChanged: @Sendable (TmuxPaneID) -> Void = { _ in }
         var onPaneSurfaceFailed: @Sendable (TmuxPaneID) -> Void = { _ in }
         var onRequestFailed: @Sendable (Request) -> Void = { _ in }
@@ -179,11 +178,20 @@ final class TmuxSessionController: @unchecked Sendable {
         }
     }
 
-    private enum NavigationIntent: Equatable {
+    private enum NavigationIntent {
         case pane(TmuxPaneID)
         case window(TmuxWindowID, preferredPaneID: TmuxPaneID?)
-        case zoom(TmuxPaneID, desired: Bool, refreshPaneAfterChange: Bool)
-        case unzoomWindows([TmuxWindowID], refreshPanesAfterChange: Bool)
+        case zoom(
+            TmuxPaneID,
+            desired: Bool,
+            onZoomSubmitted: @Sendable (TmuxWindowID) -> Void
+        )
+    }
+
+    private struct WindowZoomIntent {
+        let windowIDs: [TmuxWindowID]
+        let desired: Bool
+        let onZoomSubmitted: @Sendable ([TmuxWindowID]) -> Void
     }
 
     private enum OutstandingRequest {
@@ -194,15 +202,6 @@ final class TmuxSessionController: @unchecked Sendable {
         case trackedInput(@Sendable (Bool) -> Void)
     }
 
-    private struct DesiredPaneRefresh {
-        let failureRequest: Request
-    }
-
-    private enum PaneRefreshState {
-        case deferred(DesiredPaneRefresh)
-        case inFlight(followUp: DesiredPaneRefresh?)
-    }
-
     let queue: DispatchQueue
 
     private let callbacks: Callbacks
@@ -211,11 +210,10 @@ final class TmuxSessionController: @unchecked Sendable {
     private var topology: TopologySnapshot?
     private var clientSize: ClientSize?
     private var retainedPaneIDs: Set<TmuxPaneID> = []
-    private var refreshStateByPaneID: [TmuxPaneID: PaneRefreshState] = [:]
     private var surfacesByPaneID: [TmuxPaneID: TerminalSurfaceHandle] = [:]
     private var requestsByToken: [UInt64: OutstandingRequest] = [:]
-    private var zoomPreservingCloseRefreshByWindowID: [TmuxWindowID: TmuxPaneID] = [:]
     private var deferredNavigationIntent: NavigationIntent?
+    private var deferredWindowZoomIntent: WindowZoomIntent?
     private var successfulMutationRequiredAfterRevision: UInt64?
     private var topologyRevision: UInt64 = 0
     private var outboundSink: (@Sendable (Data) -> Void)?
@@ -304,8 +302,8 @@ final class TmuxSessionController: @unchecked Sendable {
             guard !shuttingDown else { return }
             failOutstandingPaneDirectoryQueries(with: .sessionUnavailable)
             failOutstandingTrackedInput()
-            zoomPreservingCloseRefreshByWindowID.removeAll()
             deferredNavigationIntent = nil
+            deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
             guard case .closed = state else {
                 publishState(.detached(.transportClosed))
@@ -322,8 +320,8 @@ final class TmuxSessionController: @unchecked Sendable {
             guard !shuttingDown else { return }
             failOutstandingPaneDirectoryQueries(with: .sessionUnavailable)
             failOutstandingTrackedInput()
-            zoomPreservingCloseRefreshByWindowID.removeAll()
             deferredNavigationIntent = nil
+            deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
             guard case .closed = state else {
                 publishState(.detached(nil))
@@ -341,13 +339,12 @@ final class TmuxSessionController: @unchecked Sendable {
             requestsByToken.removeAll()
             directoryQueries.forEach { $0(.failure(.sessionUnavailable)) }
             trackedInputCompletions.forEach { $0(false) }
-            zoomPreservingCloseRefreshByWindowID.removeAll()
             deferredNavigationIntent = nil
+            deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
             topology = nil
             clientSize = nil
             retainedPaneIDs.removeAll()
-            refreshStateByPaneID.removeAll()
             assert(surfacesByPaneID.isEmpty, "terminal surfaces must unregister before client free")
             surfacesByPaneID.removeAll()
             if let client {
@@ -419,8 +416,8 @@ final class TmuxSessionController: @unchecked Sendable {
         case GHOSTTY_TMUX_ACTION_EXIT:
             failOutstandingPaneDirectoryQueries(with: .sessionUnavailable)
             failOutstandingTrackedInput()
-            zoomPreservingCloseRefreshByWindowID.removeAll()
             deferredNavigationIntent = nil
+            deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
             let exit = action.value.exit
             let detail = decodeTmuxString(exit.detail)
@@ -485,10 +482,8 @@ final class TmuxSessionController: @unchecked Sendable {
 
         for paneID in removed {
             retainedPaneIDs.remove(paneID)
-            refreshStateByPaneID.removeValue(forKey: paneID)
             surfacesByPaneID.removeValue(forKey: paneID)
         }
-        refreshZoomPreservingCloseSuccessorIfReady(in: snapshot)
         let didBecomeReady = state != .ready
         state = .ready
         DispatchQueue.main.async {
@@ -496,23 +491,12 @@ final class TmuxSessionController: @unchecked Sendable {
             for paneID in removed { self.callbacks.onPaneRemoved(paneID) }
             self.callbacks.onTopology(snapshot)
         }
-        admitDeferredNavigationIfPossible()
+        admitDeferredMutationsIfPossible()
     }
 
     private func handlePaneChanged(_ paneID: TmuxPaneID) {
         preconditionOnWriterQueue()
         guard let client else { return }
-
-        let completedRefresh: Bool
-        let refreshFollowUp: DesiredPaneRefresh?
-        if case .inFlight(let followUp) = refreshStateByPaneID[paneID] {
-            completedRefresh = true
-            refreshFollowUp = followUp
-            refreshStateByPaneID.removeValue(forKey: paneID)
-        } else {
-            completedRefresh = false
-            refreshFollowUp = nil
-        }
 
         if retainedPaneIDs.insert(paneID).inserted {
             var terminal: ghostty_terminal_t?
@@ -528,7 +512,6 @@ final class TmuxSessionController: @unchecked Sendable {
             }
             let handoff = RetainedPaneTerminal(paneID: paneID, handle: terminal)
             DispatchQueue.main.async { self.callbacks.onPaneTerminal(handoff) }
-            retryDeferredPaneRefreshIfNeeded(paneID, notifyPhaseChange: true)
             return
         }
 
@@ -539,23 +522,6 @@ final class TmuxSessionController: @unchecked Sendable {
                 DispatchQueue.main.async { self.callbacks.onPaneSurfaceFailed(paneID) }
                 return
             }
-        }
-
-        if completedRefresh {
-            if let followUp = refreshFollowUp {
-                refreshStateByPaneID[paneID] = .deferred(followUp)
-                retryDeferredPaneRefreshIfNeeded(paneID, notifyPhaseChange: false)
-            }
-            guard refreshStateByPaneID[paneID] != nil else {
-                DispatchQueue.main.async {
-                    self.callbacks.onPanePhaseChanged(paneID, .live)
-                }
-                if activePaneID(in: topology) == paneID {
-                    DispatchQueue.main.async { self.callbacks.onActivePaneChanged(paneID) }
-                }
-                return
-            }
-            return
         }
 
         if activePaneID(in: topology) == paneID {
@@ -601,24 +567,15 @@ final class TmuxSessionController: @unchecked Sendable {
                 )
             }
         case GHOSTTY_TMUX_COMMAND_SKIPPED:
-            if request == .closePane {
-                zoomPreservingCloseRefreshByWindowID.removeAll()
-            }
             break
         case GHOSTTY_TMUX_COMMAND_ERROR_BLOCK:
             _ = decodeTmuxString(completion.body)
-            if request == .closePane {
-                zoomPreservingCloseRefreshByWindowID.removeAll()
-            }
             DispatchQueue.main.async { self.callbacks.onRequestFailed(request) }
         default:
-            if request == .closePane {
-                zoomPreservingCloseRefreshByWindowID.removeAll()
-            }
             DispatchQueue.main.async { self.callbacks.onRequestFailed(request) }
         }
         clearSatisfiedMutationBarrier()
-        admitDeferredNavigationIfPossible()
+        admitDeferredMutationsIfPossible()
     }
 
     // MARK: Renderer registration and lifetime fence
@@ -833,25 +790,27 @@ final class TmuxSessionController: @unchecked Sendable {
     func requestSetPaneZoomed(
         paneID: TmuxPaneID,
         zoomed: Bool,
-        refreshPaneAfterChange: Bool = true
+        onZoomSubmitted: @escaping @Sendable (TmuxWindowID) -> Void = { _ in }
     ) {
         queue.async { [self] in
             submitNavigation(.zoom(
                 paneID,
                 desired: zoomed,
-                refreshPaneAfterChange: refreshPaneAfterChange
+                onZoomSubmitted: onZoomSubmitted
             ))
         }
     }
 
-    func requestSetWindowsUnzoomed(
+    func requestSetWindowsZoomed(
         windowIDs: [TmuxWindowID],
-        refreshPanesAfterChange: Bool
+        zoomed: Bool,
+        onZoomSubmitted: @escaping @Sendable ([TmuxWindowID]) -> Void = { _ in }
     ) {
         queue.async { [self] in
-            submitNavigation(.unzoomWindows(
-                windowIDs,
-                refreshPanesAfterChange: refreshPanesAfterChange
+            submitWindowZoom(WindowZoomIntent(
+                windowIDs: windowIDs,
+                desired: zoomed,
+                onZoomSubmitted: onZoomSubmitted
             ))
         }
     }
@@ -881,6 +840,21 @@ final class TmuxSessionController: @unchecked Sendable {
         evaluateNavigation(intent, drainOutbound: true)
     }
 
+    private func submitWindowZoom(_ intent: WindowZoomIntent) {
+        preconditionOnWriterQueue()
+        guard !awaitingTopologyMutationSettlement else {
+            deferredWindowZoomIntent = intent
+            return
+        }
+        deferredWindowZoomIntent = nil
+        enqueueWindowsZoom(
+            intent.windowIDs,
+            desired: intent.desired,
+            onZoomSubmitted: intent.onZoomSubmitted,
+            drainOutbound: true
+        )
+    }
+
     private func clearSatisfiedMutationBarrier() {
         preconditionOnWriterQueue()
         guard let requiredRevision = successfulMutationRequiredAfterRevision,
@@ -889,11 +863,20 @@ final class TmuxSessionController: @unchecked Sendable {
         successfulMutationRequiredAfterRevision = nil
     }
 
-    private func admitDeferredNavigationIfPossible() {
+    private func admitDeferredMutationsIfPossible() {
         preconditionOnWriterQueue()
-        guard !awaitingTopologyMutationSettlement,
-              let deferredNavigationIntent
-        else { return }
+        guard !awaitingTopologyMutationSettlement else { return }
+        if let deferredWindowZoomIntent {
+            self.deferredWindowZoomIntent = nil
+            enqueueWindowsZoom(
+                deferredWindowZoomIntent.windowIDs,
+                desired: deferredWindowZoomIntent.desired,
+                onZoomSubmitted: deferredWindowZoomIntent.onZoomSubmitted,
+                drainOutbound: false
+            )
+            guard !awaitingTopologyMutationSettlement else { return }
+        }
+        guard let deferredNavigationIntent else { return }
         self.deferredNavigationIntent = nil
         // Native command admission is callback-safe. Outbound consume is not;
         // the enclosing pump drains once after feed returns.
@@ -916,17 +899,11 @@ final class TmuxSessionController: @unchecked Sendable {
                 preferredPaneID: preferredPaneID,
                 drainOutbound: drainOutbound
             )
-        case .zoom(let paneID, let desired, let refreshPaneAfterChange):
+        case .zoom(let paneID, let desired, let onZoomSubmitted):
             enqueueSetPaneZoomed(
                 paneID,
                 desired: desired,
-                refreshPaneAfterChange: refreshPaneAfterChange,
-                drainOutbound: drainOutbound
-            )
-        case .unzoomWindows(let windowIDs, let refreshPanesAfterChange):
-            enqueueWindowsUnzoom(
-                windowIDs,
-                refreshPanesAfterChange: refreshPanesAfterChange,
+                onZoomSubmitted: onZoomSubmitted,
                 drainOutbound: drainOutbound
             )
         }
@@ -935,7 +912,7 @@ final class TmuxSessionController: @unchecked Sendable {
     private func enqueueSetPaneZoomed(
         _ paneID: TmuxPaneID,
         desired: Bool,
-        refreshPaneAfterChange: Bool,
+        onZoomSubmitted: @Sendable (TmuxWindowID) -> Void,
         drainOutbound: Bool
     ) {
         guard let topology,
@@ -949,52 +926,45 @@ final class TmuxSessionController: @unchecked Sendable {
             $0.windowID == window.id && $0.id != paneID
         }
         guard (!desired || hasSibling), window.zoomed != desired else { return }
-        let command = "resize-pane -Z -t %\(paneID.rawValue)"
-        if refreshPaneAfterChange {
-            submitPanePresentationCommandOnWriter(
-                command: command,
-                request: .zoomPane,
-                paneID: paneID,
-                drainOutbound: drainOutbound
-            )
-        } else {
-            submitCommandOnWriter(
-                command: command,
-                request: .zoomPane,
-                drainOutbound: drainOutbound
-            )
-        }
+        guard admitCommandOnWriter(
+            command: "resize-pane -Z -t %\(paneID.rawValue)",
+            request: .zoomPane
+        ) else { return }
+        if desired { onZoomSubmitted(window.id) }
+        if drainOutbound { _ = self.drainOutbound() }
     }
 
-    private func enqueueWindowsUnzoom(
+    private func enqueueWindowsZoom(
         _ windowIDs: [TmuxWindowID],
-        refreshPanesAfterChange: Bool,
+        desired: Bool,
+        onZoomSubmitted: @Sendable ([TmuxWindowID]) -> Void,
         drainOutbound: Bool
     ) {
         guard let topology else {
             reportRequestFailure(.zoomPane)
             return
         }
-        let targets = windowIDs.compactMap { windowID -> (TmuxWindowID, TmuxPaneID)? in
+        let targets = windowIDs.compactMap { windowID -> (TmuxWindowID, String)? in
             guard let window = topology.windows.first(where: { $0.id == windowID }),
-                  window.zoomed,
+                  window.zoomed != desired,
                   let paneID = window.activePaneID
             else { return nil }
-            return (windowID, paneID)
-        }
-        guard !targets.isEmpty else { return }
-
-        let commands = targets.map { windowID, _ in
-            "resize-pane -Z -t @\(windowID.rawValue)"
-        }
-        guard admitCommandGroupOnWriter(commands: commands, request: .zoomPane) else {
-            return
-        }
-        if refreshPanesAfterChange {
-            for (_, paneID) in targets {
-                _ = admitPaneRefresh(paneID, failureRequest: .zoomPane)
+            let hasSibling = topology.panes.contains {
+                $0.windowID == windowID && $0.id != paneID
             }
+            guard !desired || hasSibling else { return nil }
+            let command = desired
+                ? "resize-pane -Z -t %\(paneID.rawValue)"
+                : "resize-pane -Z -t @\(windowID.rawValue)"
+            return (windowID, command)
         }
+        guard !targets.isEmpty,
+              admitCommandGroupOnWriter(
+                  commands: targets.map(\.1),
+                  request: .zoomPane
+              )
+        else { return }
+        if desired { onZoomSubmitted(targets.map(\.0)) }
         if drainOutbound { _ = self.drainOutbound() }
     }
 
@@ -1026,21 +996,11 @@ final class TmuxSessionController: @unchecked Sendable {
             "kill-pane -t %\(paneID.rawValue)",
             "resize-pane -Z -t @\(window.id.rawValue)",
         ]
-        if let activePaneID = window.activePaneID, activePaneID != paneID {
-            submitPanePresentationCommandGroupOnWriter(
-                commands: commands,
-                request: .closePane,
-                paneID: activePaneID,
-                drainOutbound: true
-            )
-            return
-        }
-
-        guard admitCommandGroupOnWriter(commands: commands, request: .closePane) else {
-            return
-        }
-        zoomPreservingCloseRefreshByWindowID[window.id] = paneID
-        _ = drainOutbound()
+        submitCommandGroupOnWriter(
+            commands: commands,
+            request: .closePane,
+            drainOutbound: true
+        )
     }
 
     private func enqueueWindowClosure(_ windowID: TmuxWindowID) {
@@ -1056,30 +1016,6 @@ final class TmuxSessionController: @unchecked Sendable {
             request: .closeWindow,
             drainOutbound: true
         )
-    }
-
-    private func refreshZoomPreservingCloseSuccessorIfReady(
-        in topology: TopologySnapshot
-    ) {
-        preconditionOnWriterQueue()
-        for (windowID, deletedPaneID) in zoomPreservingCloseRefreshByWindowID {
-            guard let window = topology.windows.first(where: { $0.id == windowID }) else {
-                zoomPreservingCloseRefreshByWindowID.removeValue(forKey: windowID)
-                continue
-            }
-            let panes = topology.panes.filter { $0.windowID == windowID }
-            if panes.count <= 1 {
-                zoomPreservingCloseRefreshByWindowID.removeValue(forKey: windowID)
-                continue
-            }
-            guard !panes.contains(where: { $0.id == deletedPaneID }),
-                  window.zoomed,
-                  let activePaneID = window.activePaneID
-            else { continue }
-
-            zoomPreservingCloseRefreshByWindowID.removeValue(forKey: windowID)
-            _ = admitPaneRefresh(activePaneID, failureRequest: .closePane)
-        }
     }
 
     private func enqueuePaneSelection(
@@ -1107,20 +1043,11 @@ final class TmuxSessionController: @unchecked Sendable {
         let command = window.zoomed
             ? "select-pane -Z -t %\(paneID.rawValue)"
             : "select-pane -t %\(paneID.rawValue)"
-        if window.zoomed {
-            submitPanePresentationCommandOnWriter(
-                command: command,
-                request: .selectPane,
-                paneID: paneID,
-                drainOutbound: drainOutbound
-            )
-        } else {
-            submitCommandOnWriter(
-                command: command,
-                request: .selectPane,
-                drainOutbound: drainOutbound
-            )
-        }
+        submitCommandOnWriter(
+            command: command,
+            request: .selectPane,
+            drainOutbound: drainOutbound
+        )
     }
 
     private func enqueueWindowSelection(
@@ -1142,20 +1069,11 @@ final class TmuxSessionController: @unchecked Sendable {
             let command = window.zoomed
                 ? "select-pane -Z -t %\(paneID.rawValue)"
                 : "select-pane -t %\(paneID.rawValue)"
-            if window.zoomed {
-                submitPanePresentationCommandOnWriter(
-                    command: command,
-                    request: .selectWindow,
-                    paneID: paneID,
-                    drainOutbound: drainOutbound
-                )
-            } else {
-                submitCommandOnWriter(
-                    command: command,
-                    request: .selectWindow,
-                    drainOutbound: drainOutbound
-                )
-            }
+            submitCommandOnWriter(
+                command: command,
+                request: .selectWindow,
+                drainOutbound: drainOutbound
+            )
             return
         }
 
@@ -1173,11 +1091,6 @@ final class TmuxSessionController: @unchecked Sendable {
             zoomed: window.zoomed
         )
 
-        let paneToRefreshAfterGeometryChange = window.zoomed
-            && paneID != window.activePaneID
-            ? paneID
-            : nil
-
         if commands.count == 1 {
             submitCommandOnWriter(
                 command: commands[0],
@@ -1185,20 +1098,11 @@ final class TmuxSessionController: @unchecked Sendable {
                 drainOutbound: drainOutbound
             )
         } else {
-            if let paneToRefreshAfterGeometryChange {
-                submitPanePresentationCommandGroupOnWriter(
-                    commands: commands,
-                    request: .selectWindow,
-                    paneID: paneToRefreshAfterGeometryChange,
-                    drainOutbound: drainOutbound
-                )
-            } else {
-                submitCommandGroupOnWriter(
-                    commands: commands,
-                    request: .selectWindow,
-                    drainOutbound: drainOutbound
-                )
-            }
+            submitCommandGroupOnWriter(
+                commands: commands,
+                request: .selectWindow,
+                drainOutbound: drainOutbound
+            )
         }
     }
 
@@ -1262,20 +1166,6 @@ final class TmuxSessionController: @unchecked Sendable {
         drainOutbound: Bool
     ) {
         guard admitCommandOnWriter(command: command, request: request) else { return }
-        if drainOutbound { _ = self.drainOutbound() }
-    }
-
-    private func submitPanePresentationCommandOnWriter(
-        command: String,
-        request: Request,
-        paneID: TmuxPaneID,
-        drainOutbound: Bool
-    ) {
-        guard admitCommandOnWriter(command: command, request: request) else { return }
-        _ = admitPaneRefresh(
-            paneID,
-            failureRequest: request
-        )
         if drainOutbound { _ = self.drainOutbound() }
     }
 
@@ -1366,20 +1256,6 @@ final class TmuxSessionController: @unchecked Sendable {
         if drainOutbound { _ = self.drainOutbound() }
     }
 
-    private func submitPanePresentationCommandGroupOnWriter(
-        commands: [String],
-        request: Request,
-        paneID: TmuxPaneID,
-        drainOutbound: Bool
-    ) {
-        guard admitCommandGroupOnWriter(commands: commands, request: request) else { return }
-        _ = admitPaneRefresh(
-            paneID,
-            failureRequest: request
-        )
-        if drainOutbound { _ = self.drainOutbound() }
-    }
-
     private func admitCommandGroupOnWriter(commands: [String], request: Request) -> Bool {
         preconditionOnWriterQueue()
         guard let client, outboundSink != nil, !shuttingDown else {
@@ -1430,64 +1306,6 @@ final class TmuxSessionController: @unchecked Sendable {
         }
     }
 
-    @discardableResult
-    private func admitPaneRefresh(
-        _ paneID: TmuxPaneID,
-        failureRequest: Request,
-        notifyPhaseChange: Bool = true
-    ) -> Bool {
-        preconditionOnWriterQueue()
-        let desired = DesiredPaneRefresh(failureRequest: failureRequest)
-
-        if case .inFlight = refreshStateByPaneID[paneID] {
-            refreshStateByPaneID[paneID] = .inFlight(
-                followUp: desired
-            )
-            return false
-        }
-
-        if case .deferred = refreshStateByPaneID[paneID] {
-            refreshStateByPaneID[paneID] = .deferred(desired)
-            return false
-        }
-
-        guard let client, outboundSink != nil, !shuttingDown else {
-            reportRequestFailure(failureRequest)
-            return false
-        }
-        let result = ghostty_tmux_client_refresh_pane(client, paneID.rawValue)
-        switch result {
-        case GHOSTTY_TMUX_RESULT_OK:
-            refreshStateByPaneID[paneID] = .inFlight(followUp: nil)
-            if notifyPhaseChange {
-                DispatchQueue.main.async {
-                    self.callbacks.onPanePhaseChanged(paneID, .hydrating)
-                }
-            }
-            return true
-        case GHOSTTY_TMUX_RESULT_NOT_READY:
-            refreshStateByPaneID[paneID] = .deferred(desired)
-            return false
-        default:
-            reportImmediateFailure(result, request: failureRequest)
-            return false
-        }
-    }
-
-    private func retryDeferredPaneRefreshIfNeeded(
-        _ paneID: TmuxPaneID,
-        notifyPhaseChange: Bool
-    ) {
-        preconditionOnWriterQueue()
-        guard case .deferred(let desired) = refreshStateByPaneID[paneID] else { return }
-        refreshStateByPaneID.removeValue(forKey: paneID)
-        _ = admitPaneRefresh(
-            paneID,
-            failureRequest: desired.failureRequest,
-            notifyPhaseChange: notifyPhaseChange
-        )
-    }
-
     // MARK: Helpers
 
     private func publishState(_ next: SessionState) {
@@ -1502,8 +1320,8 @@ final class TmuxSessionController: @unchecked Sendable {
         guard !shuttingDown else { return }
         failOutstandingPaneDirectoryQueries(with: .sessionUnavailable)
         failOutstandingTrackedInput()
-        zoomPreservingCloseRefreshByWindowID.removeAll()
         deferredNavigationIntent = nil
+        deferredWindowZoomIntent = nil
         successfulMutationRequiredAfterRevision = nil
         switch result {
         case GHOSTTY_TMUX_RESULT_OUT_OF_MEMORY:

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -195,7 +195,11 @@ final class TmuxSessionController: @unchecked Sendable {
     }
 
     private enum OutstandingRequest {
-        case action(Request, topologyRevisionAtSubmission: UInt64)
+        case action(
+            Request,
+            topologyRevisionAtSubmission: UInt64,
+            onSuccess: (@Sendable () -> Void)?
+        )
         case paneCurrentDirectory(
             @Sendable (Result<String, PaneCurrentDirectoryError>) -> Void
         )
@@ -543,11 +547,12 @@ final class TmuxSessionController: @unchecked Sendable {
         case .paneCurrentDirectory(let completionHandler):
             completionHandler(paneCurrentDirectoryResult(for: completion))
             return
-        case .action(let request, let topologyRevisionAtSubmission):
+        case .action(let request, let topologyRevisionAtSubmission, let onSuccess):
             handleActionCompletion(
                 completion,
                 request: request,
-                topologyRevisionAtSubmission: topologyRevisionAtSubmission
+                topologyRevisionAtSubmission: topologyRevisionAtSubmission,
+                onSuccess: onSuccess
             )
         }
     }
@@ -555,7 +560,8 @@ final class TmuxSessionController: @unchecked Sendable {
     private func handleActionCompletion(
         _ completion: ghostty_tmux_command_completion_s,
         request: Request,
-        topologyRevisionAtSubmission: UInt64
+        topologyRevisionAtSubmission: UInt64,
+        onSuccess: (@Sendable () -> Void)?
     ) {
         preconditionOnWriterQueue()
         switch completion.status {
@@ -566,6 +572,7 @@ final class TmuxSessionController: @unchecked Sendable {
                     topologyRevisionAtSubmission
                 )
             }
+            onSuccess?()
         case GHOSTTY_TMUX_COMMAND_SKIPPED:
             break
         case GHOSTTY_TMUX_COMMAND_ERROR_BLOCK:
@@ -748,7 +755,12 @@ final class TmuxSessionController: @unchecked Sendable {
         enqueue(command: "new-window", request: .newWindow)
     }
 
-    func requestSplit(paneID: TmuxPaneID, direction: SplitDirection, zoom: Bool) {
+    func requestSplit(
+        paneID: TmuxPaneID,
+        direction: SplitDirection,
+        zoom: Bool,
+        onZoomCreated: (@Sendable () -> Void)? = nil
+    ) {
         let flags = switch direction {
         case .left: "-h -b"
         case .right: "-h"
@@ -758,7 +770,8 @@ final class TmuxSessionController: @unchecked Sendable {
         let zoomFlag = zoom ? " -Z" : ""
         enqueue(
             command: "split-window \(flags)\(zoomFlag) -t %\(paneID.rawValue)",
-            request: .splitPane
+            request: .splitPane,
+            onSuccess: onZoomCreated
         )
     }
 
@@ -1108,7 +1121,7 @@ final class TmuxSessionController: @unchecked Sendable {
 
     private var hasOutstandingTopologyMutation: Bool {
         requestsByToken.values.contains {
-            guard case .action(let request, _) = $0 else { return false }
+            guard case .action(let request, _, _) = $0 else { return false }
             return requestMutatesTopology(request)
         }
     }
@@ -1146,16 +1159,29 @@ final class TmuxSessionController: @unchecked Sendable {
         ]
     }
 
-    private func enqueue(command: String, request: Request) {
+    private func enqueue(
+        command: String,
+        request: Request,
+        onSuccess: (@Sendable () -> Void)? = nil
+    ) {
         queue.async { [self] in
-            enqueueOnWriter(command: command, request: request)
+            enqueueOnWriter(
+                command: command,
+                request: request,
+                onSuccess: onSuccess
+            )
         }
     }
 
-    private func enqueueOnWriter(command: String, request: Request) {
+    private func enqueueOnWriter(
+        command: String,
+        request: Request,
+        onSuccess: (@Sendable () -> Void)?
+    ) {
         submitCommandOnWriter(
             command: command,
             request: request,
+            onSuccess: onSuccess,
             drainOutbound: true
         )
     }
@@ -1163,13 +1189,22 @@ final class TmuxSessionController: @unchecked Sendable {
     private func submitCommandOnWriter(
         command: String,
         request: Request,
+        onSuccess: (@Sendable () -> Void)? = nil,
         drainOutbound: Bool
     ) {
-        guard admitCommandOnWriter(command: command, request: request) else { return }
+        guard admitCommandOnWriter(
+            command: command,
+            request: request,
+            onSuccess: onSuccess
+        ) else { return }
         if drainOutbound { _ = self.drainOutbound() }
     }
 
-    private func admitCommandOnWriter(command: String, request: Request) -> Bool {
+    private func admitCommandOnWriter(
+        command: String,
+        request: Request,
+        onSuccess: (@Sendable () -> Void)? = nil
+    ) -> Bool {
         preconditionOnWriterQueue()
         guard let client, outboundSink != nil, !shuttingDown else {
             reportRequestFailure(request)
@@ -1182,7 +1217,8 @@ final class TmuxSessionController: @unchecked Sendable {
         }
         requestsByToken[token] = .action(
             request,
-            topologyRevisionAtSubmission: topologyRevision
+            topologyRevisionAtSubmission: topologyRevision,
+            onSuccess: onSuccess
         )
         return true
     }
@@ -1283,7 +1319,8 @@ final class TmuxSessionController: @unchecked Sendable {
         for token in tokens {
             requestsByToken[token] = .action(
                 request,
-                topologyRevisionAtSubmission: topologyRevision
+                topologyRevisionAtSubmission: topologyRevision,
+                onSuccess: nil
             )
         }
         return true

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -23,13 +23,19 @@ struct TmuxMultipaneZoomDefaultPolicy {
     ) -> [TmuxWindowID] {
         var targets: [TmuxWindowID] = []
 
-        for window in topology.windows where !resolvedWindowIDs.contains(window.id) {
+        for window in topology.windows {
             var paneCount = 0
             for pane in topology.panes where pane.windowID == window.id {
                 paneCount += 1
                 if paneCount == 2 { break }
             }
-            guard paneCount == 2, window.activePaneID != nil else { continue }
+            guard paneCount == 2 else {
+                resolvedWindowIDs.remove(window.id)
+                continue
+            }
+            guard !resolvedWindowIDs.contains(window.id),
+                  window.activePaneID != nil
+            else { continue }
 
             resolvedWindowIDs.insert(window.id)
             if window.zoomed != isEnabled {
@@ -934,10 +940,28 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
         else {
             return .missingTarget(.focusedPane)
         }
+        let hasSibling = topology.panes.contains {
+            $0.windowID == window.id && $0.id != pane.id
+        }
+        let appliesDefaultZoom = !hasSibling
+            && !window.zoomed
+            && multipaneZoomDefault.isEnabled
+        let onZoomCreated: (@Sendable () -> Void)?
+        if appliesDefaultZoom {
+            let windowID = window.id
+            onZoomCreated = { [weak self] in
+                DispatchQueue.main.async {
+                    self?.pendingZoomOwnershipWindowIDs.insert(windowID)
+                }
+            }
+        } else {
+            onZoomCreated = nil
+        }
         controller.requestSplit(
             paneID: activeManagedPaneID,
             direction: TmuxSessionController.SplitDirection(actionDirection: direction),
-            zoom: window.zoomed
+            zoom: window.zoomed || appliesDefaultZoom,
+            onZoomCreated: onZoomCreated
         )
         return .queued
     }

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -3,6 +3,51 @@ import CoreGraphics
 import Foundation
 import GhosttyKit
 
+struct TmuxMultipaneZoomDefaultPolicy {
+    var isEnabled = false
+    private var resolvedWindowIDs: Set<TmuxWindowID> = []
+
+    init(isEnabled: Bool = false) {
+        self.isEnabled = isEnabled
+    }
+
+    mutating func setEnabled(_ enabled: Bool) -> Bool {
+        guard enabled != isEnabled else { return false }
+        isEnabled = enabled
+        resolvedWindowIDs.removeAll(keepingCapacity: true)
+        return true
+    }
+
+    mutating func windowIDsNeedingChange(
+        in topology: TmuxSessionController.TopologySnapshot
+    ) -> [TmuxWindowID] {
+        var targets: [TmuxWindowID] = []
+
+        for window in topology.windows where !resolvedWindowIDs.contains(window.id) {
+            var paneCount = 0
+            for pane in topology.panes where pane.windowID == window.id {
+                paneCount += 1
+                if paneCount == 2 { break }
+            }
+            guard paneCount == 2, window.activePaneID != nil else { continue }
+
+            resolvedWindowIDs.insert(window.id)
+            if window.zoomed != isEnabled {
+                targets.append(window.id)
+            }
+        }
+        return targets
+    }
+
+    mutating func recordWindowChoice(_ windowID: TmuxWindowID) {
+        resolvedWindowIDs.insert(windowID)
+    }
+
+    mutating func reset() {
+        resolvedWindowIDs.removeAll(keepingCapacity: false)
+    }
+}
+
 
 /// Presents the new tmux session stack (`TmuxTerminalSession`) through the
 /// `GhosttyTerminalScreenModeling` boundary so `GhosttySurfaceScreen` — the
@@ -35,8 +80,9 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
     private var latestViewportMeasurement: GhosttyTerminalViewportMeasurement?
     private var cachedTopologySnapshot = GhosttyRuntimeSurfaceTopologySnapshot.empty
     private var ownedZoomWindowIDs: Set<TmuxWindowID> = []
-    private var pendingZoomOwnershipWindowID: TmuxWindowID?
-    private var pendingOwnedZoomPreservationWindowID: TmuxWindowID?
+    private var pendingZoomOwnershipWindowIDs: Set<TmuxWindowID> = []
+    private var pendingOwnedZoomPreservation: (windowID: TmuxWindowID, paneID: TmuxPaneID)?
+    private var multipaneZoomDefault = TmuxMultipaneZoomDefaultPolicy()
     private var panePreviewCache = TmuxPanePreviewImageCache(
         byteLimit: TmuxTerminalScreenAdapter.panePreviewCacheByteLimit
     )
@@ -51,11 +97,13 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
     /// session is created.
     func activate(
         session: TmuxTerminalSession,
+        zoomMultipaneWindowsByDefault: Bool = false,
         initialViewportHandler: @escaping (CGSize, CGFloat) -> Void,
         viewportStabilityHandler: @escaping (Bool) -> Void
     ) {
         self.session = session
         self.controller = session.controller
+        multipaneZoomDefault.isEnabled = zoomMultipaneWindowsByDefault
         self.initialViewportHandler = initialViewportHandler
         self.viewportStabilityHandler = viewportStabilityHandler
 
@@ -76,11 +124,12 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
                 self.latestTopology = topology
                 if let topology {
                     self.reconcileZoomOwnership(with: topology)
+                    self.applyMultipaneZoomDefaultIfNeeded(to: topology)
                     self.reconcilePanePreviewCache(with: topology)
                 } else {
                     self.ownedZoomWindowIDs.removeAll()
-                    self.pendingZoomOwnershipWindowID = nil
-                    self.pendingOwnedZoomPreservationWindowID = nil
+                    self.pendingZoomOwnershipWindowIDs.removeAll()
+                    self.pendingOwnedZoomPreservation = nil
                     self.clearPanePreviewCache(reason: "topology-unavailable")
                 }
                 self.rebuildTopologySnapshot()
@@ -114,15 +163,17 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
                     self?.cancelPendingPaneFocus()
                 }
                 if request == .zoomPane {
-                    self?.pendingZoomOwnershipWindowID = nil
+                    self?.pendingZoomOwnershipWindowIDs.removeAll()
                 }
                 if request == .closePane,
                    let self,
-                   let windowID = pendingOwnedZoomPreservationWindowID {
-                    pendingOwnedZoomPreservationWindowID = nil
-                    if latestTopology?.windows.first(where: { $0.id == windowID })?.zoomed
+                   let preservation = pendingOwnedZoomPreservation {
+                    pendingOwnedZoomPreservation = nil
+                    if latestTopology?.windows.first(where: {
+                        $0.id == preservation.windowID
+                    })?.zoomed
                         != true {
-                        ownedZoomWindowIDs.remove(windowID)
+                        ownedZoomWindowIDs.remove(preservation.windowID)
                     }
                 }
                 self?.presentCommandFailure(for: request)
@@ -138,8 +189,9 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
         managedSurfacesByPaneID.removeAll()
         activeManagedSurface = nil
         ownedZoomWindowIDs.removeAll()
-        pendingZoomOwnershipWindowID = nil
-        pendingOwnedZoomPreservationWindowID = nil
+        pendingZoomOwnershipWindowIDs.removeAll()
+        pendingOwnedZoomPreservation = nil
+        multipaneZoomDefault.reset()
         activeManagedPaneID = nil
         pendingFocusedPaneID = nil
         clearPanePreviewCache(reason: "invalidate")
@@ -666,6 +718,7 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
     private func reconcilePanePreviewCache(
         with topology: TmuxSessionController.TopologySnapshot
     ) {
+        guard !panePreviewCache.entries.isEmpty else { return }
         let removedPaneIDs = panePreviewCache.retainOnly(Set(topology.panes.map(\.id)))
         guard !removedPaneIDs.isEmpty else { return }
         GhosttyRuntimeTrace.perf(
@@ -894,17 +947,42 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
               let activeManagedPaneID,
               let topology = latestTopology,
               let activeWindowID = topology.activeWindowID,
-              let activeWindow = topology.windows.first(where: { $0.id == activeWindowID })
+              topology.windows.contains(where: { $0.id == activeWindowID })
         else {
             return .missingTarget(.focusedPane)
         }
-        if zoomed, !activeWindow.zoomed {
-            pendingZoomOwnershipWindowID = activeWindowID
-        } else if !zoomed {
-            pendingZoomOwnershipWindowID = nil
-        }
-        controller.requestSetPaneZoomed(paneID: activeManagedPaneID, zoomed: zoomed)
+        multipaneZoomDefault.recordWindowChoice(activeWindowID)
+        controller.requestSetPaneZoomed(
+            paneID: activeManagedPaneID,
+            zoomed: zoomed,
+            onZoomSubmitted: { [weak self] windowID in
+                DispatchQueue.main.async {
+                    self?.pendingZoomOwnershipWindowIDs.insert(windowID)
+                }
+            }
+        )
         return .queued
+    }
+
+    func setZoomMultipaneWindowsByDefault(_ enabled: Bool) {
+        guard multipaneZoomDefault.setEnabled(enabled), let latestTopology else { return }
+        applyMultipaneZoomDefaultIfNeeded(to: latestTopology)
+    }
+
+    private func applyMultipaneZoomDefaultIfNeeded(
+        to topology: TmuxSessionController.TopologySnapshot
+    ) {
+        let windowIDs = multipaneZoomDefault.windowIDsNeedingChange(in: topology)
+        guard !windowIDs.isEmpty else { return }
+        controller?.requestSetWindowsZoomed(
+            windowIDs: windowIDs,
+            zoomed: multipaneZoomDefault.isEnabled,
+            onZoomSubmitted: { [weak self] windowIDs in
+                DispatchQueue.main.async {
+                    self?.pendingZoomOwnershipWindowIDs.formUnion(windowIDs)
+                }
+            }
+        )
     }
 
     func prepareForSessionShutdown() {
@@ -913,46 +991,47 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
 
     private func attemptOwnedZoomCleanup() {
         var cleanupWindowIDs = ownedZoomWindowIDs
-        if let pendingZoomOwnershipWindowID {
-            cleanupWindowIDs.insert(pendingZoomOwnershipWindowID)
-        }
+        cleanupWindowIDs.formUnion(pendingZoomOwnershipWindowIDs)
         guard !cleanupWindowIDs.isEmpty else { return }
-        controller?.requestSetWindowsUnzoomed(
+        controller?.requestSetWindowsZoomed(
             windowIDs: cleanupWindowIDs.sorted { $0.rawValue < $1.rawValue },
-            refreshPanesAfterChange: false
+            zoomed: false
         )
     }
 
     private func reconcileZoomOwnership(
         with topology: TmuxSessionController.TopologySnapshot
     ) {
-        if let pendingOwnedZoomPreservationWindowID {
+        if let preservation = pendingOwnedZoomPreservation {
             if let window = topology.windows.first(where: {
-                $0.id == pendingOwnedZoomPreservationWindowID
+                $0.id == preservation.windowID
             }) {
-                if window.zoomed {
-                    self.pendingOwnedZoomPreservationWindowID = nil
+                let paneWasRemoved = !topology.panes.contains(where: {
+                    $0.id == preservation.paneID
+                })
+                if paneWasRemoved, window.zoomed {
+                    self.pendingOwnedZoomPreservation = nil
                 }
             } else {
-                self.pendingOwnedZoomPreservationWindowID = nil
-                ownedZoomWindowIDs.remove(pendingOwnedZoomPreservationWindowID)
+                self.pendingOwnedZoomPreservation = nil
+                ownedZoomWindowIDs.remove(preservation.windowID)
             }
         }
 
-        if let pendingZoomOwnershipWindowID {
-            if let window = topology.windows.first(where: {
-                $0.id == pendingZoomOwnershipWindowID
-            }) {
+        var completedOwnershipWindowIDs: Set<TmuxWindowID> = []
+        for windowID in pendingZoomOwnershipWindowIDs {
+            if let window = topology.windows.first(where: { $0.id == windowID }) {
                 if window.zoomed {
-                    ownedZoomWindowIDs.insert(pendingZoomOwnershipWindowID)
-                    self.pendingZoomOwnershipWindowID = nil
+                    ownedZoomWindowIDs.insert(windowID)
+                    completedOwnershipWindowIDs.insert(windowID)
                 }
             } else {
-                self.pendingZoomOwnershipWindowID = nil
+                completedOwnershipWindowIDs.insert(windowID)
             }
         }
+        pendingZoomOwnershipWindowIDs.subtract(completedOwnershipWindowIDs)
 
-        let preservedWindowID = pendingOwnedZoomPreservationWindowID
+        let preservedWindowID = pendingOwnedZoomPreservation?.windowID
         ownedZoomWindowIDs = ownedZoomWindowIDs.filter { windowID in
             windowID == preservedWindowID
                 || topology.windows.first(where: { $0.id == windowID })?.zoomed == true
@@ -969,7 +1048,7 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
            window.zoomed,
            topology.panes.lazy.filter({ $0.windowID == window.id }).count > 2,
            ownedZoomWindowIDs.contains(window.id) {
-            pendingOwnedZoomPreservationWindowID = window.id
+            pendingOwnedZoomPreservation = (window.id, paneID)
         }
         controller.requestClosePane(paneID: paneID)
         return .queued

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -19,7 +19,8 @@ struct TmuxMultipaneZoomDefaultPolicy {
     }
 
     mutating func windowIDsNeedingChange(
-        in topology: TmuxSessionController.TopologySnapshot
+        in topology: TmuxSessionController.TopologySnapshot,
+        includingMatchingWindows: Bool = false
     ) -> [TmuxWindowID] {
         var targets: [TmuxWindowID] = []
 
@@ -38,7 +39,7 @@ struct TmuxMultipaneZoomDefaultPolicy {
             else { continue }
 
             resolvedWindowIDs.insert(window.id)
-            if window.zoomed != isEnabled {
+            if includingMatchingWindows || window.zoomed != isEnabled {
                 targets.append(window.id)
             }
         }
@@ -990,13 +991,20 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
 
     func setZoomMultipaneWindowsByDefault(_ enabled: Bool) {
         guard multipaneZoomDefault.setEnabled(enabled), let latestTopology else { return }
-        applyMultipaneZoomDefaultIfNeeded(to: latestTopology)
+        applyMultipaneZoomDefaultIfNeeded(
+            to: latestTopology,
+            includingMatchingWindows: true
+        )
     }
 
     private func applyMultipaneZoomDefaultIfNeeded(
-        to topology: TmuxSessionController.TopologySnapshot
+        to topology: TmuxSessionController.TopologySnapshot,
+        includingMatchingWindows: Bool = false
     ) {
-        let windowIDs = multipaneZoomDefault.windowIDsNeedingChange(in: topology)
+        let windowIDs = multipaneZoomDefault.windowIDsNeedingChange(
+            in: topology,
+            includingMatchingWindows: includingMatchingWindows
+        )
         guard !windowIDs.isEmpty else { return }
         controller?.requestSetWindowsZoomed(
             windowIDs: windowIDs,

--- a/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalSession.swift
@@ -73,11 +73,6 @@ final class TmuxTerminalSession: ObservableObject {
             onPaneTerminal: { terminal in
                 MainActor.assumeIsolated { relay.target?.handlePaneTerminal(terminal) }
             },
-            onPanePhaseChanged: { paneID, phase in
-                MainActor.assumeIsolated {
-                    relay.target?.handlePanePhaseChanged(paneID, phase: phase)
-                }
-            },
             onActivePaneChanged: { paneID in
                 MainActor.assumeIsolated { relay.target?.handleActivePaneChanged(paneID) }
             },
@@ -238,19 +233,6 @@ final class TmuxTerminalSession: ObservableObject {
 
     private func markPaneLiveAfterTerminalHandoff(_ paneID: TmuxPaneID) {
         livePaneIDs.insert(paneID)
-    }
-
-    private func handlePanePhaseChanged(
-        _ paneID: TmuxPaneID,
-        phase: TmuxSessionController.PaneInfo.Phase
-    ) {
-        switch phase {
-        case .hydrating:
-            livePaneIDs.remove(paneID)
-        case .live:
-            livePaneIDs.insert(paneID)
-        }
-        reconcilePresentationActivity()
     }
 
     private func handleActivePaneChanged(_ paneID: TmuxPaneID) {

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -2998,7 +2998,11 @@ final class RemuxRootModelTests: XCTestCase {
         let originalSession = try XCTUnwrap(harness.model.activeSessions.first)
         let originalKey = TerminalRuntimeAttemptKey(session: originalSession)
         let originalModel = try XCTUnwrap(factory.createdModels[originalKey])
-        let updated = TerminalSettings(fontSize: nil, theme: .remuxLight)
+        let updated = TerminalSettings(
+            fontSize: nil,
+            theme: .remuxLight,
+            zoomMultipaneWindowsByDefault: true
+        )
 
         await harness.model.updateTerminalSettings { settings in
             settings = updated

--- a/RemuxAppTests/TerminalSettingsRepositoryTests.swift
+++ b/RemuxAppTests/TerminalSettingsRepositoryTests.swift
@@ -10,19 +10,68 @@ final class TerminalSettingsRepositoryTests: XCTestCase {
         XCTAssertEqual(settings, .default)
     }
 
+    func testFileBackedRepositoryUsesDeviceMultipaneDefaultWhenUnset() async throws {
+        let repository = FileBackedTerminalSettingsRepository(
+            rootURL: temporaryRoot(),
+            defaultZoomMultipaneWindows: true
+        )
+
+        let settings = try await repository.loadSettings()
+
+        XCTAssertTrue(settings.zoomMultipaneWindowsByDefault)
+    }
+
+    func testFileBackedRepositoryMigratesMissingMultipanePreferenceUsingDeviceDefault() async throws {
+        let root = temporaryRoot()
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data(#"[{"fontSize":10,"theme":"ghosttyDefault"}]"#.utf8).write(
+            to: root.appendingPathComponent("terminal-settings.json")
+        )
+        let repository = FileBackedTerminalSettingsRepository(
+            rootURL: root,
+            defaultZoomMultipaneWindows: true
+        )
+
+        let settings = try await repository.loadSettings()
+
+        XCTAssertTrue(settings.zoomMultipaneWindowsByDefault)
+    }
+
     func testFileBackedRepositoryPersistsSettings() async throws {
         let root = temporaryRoot()
         let repository = FileBackedTerminalSettingsRepository(rootURL: root)
         let saved = TerminalSettings(
             fontSize: 16,
             theme: .remuxLight,
-            allowInsecureRSAHostKeys: true
+            allowInsecureRSAHostKeys: true,
+            zoomMultipaneWindowsByDefault: true
         )
 
         try await repository.saveSettings(saved)
 
         let reloaded = try await FileBackedTerminalSettingsRepository(rootURL: root).loadSettings()
         XCTAssertEqual(reloaded, saved)
+    }
+
+    func testPersistedMultipanePreferenceOverridesTheDeviceDefault() async throws {
+        let root = temporaryRoot()
+        let repository = FileBackedTerminalSettingsRepository(
+            rootURL: root,
+            defaultZoomMultipaneWindows: true
+        )
+        let saved = TerminalSettings(
+            fontSize: nil,
+            theme: .ghosttyDefault,
+            zoomMultipaneWindowsByDefault: false
+        )
+
+        try await repository.saveSettings(saved)
+
+        let reloaded = try await FileBackedTerminalSettingsRepository(
+            rootURL: root,
+            defaultZoomMultipaneWindows: true
+        ).loadSettings()
+        XCTAssertFalse(reloaded.zoomMultipaneWindowsByDefault)
     }
 
     private func temporaryRoot() -> URL {

--- a/RemuxAppTests/TerminalSettingsTests.swift
+++ b/RemuxAppTests/TerminalSettingsTests.swift
@@ -24,9 +24,10 @@ final class TerminalSettingsTests: XCTestCase {
         let settings = try JSONDecoder().decode(TerminalSettings.self, from: data)
 
         XCTAssertFalse(settings.allowInsecureRSAHostKeys)
+        XCTAssertFalse(settings.zoomMultipaneWindowsByDefault)
     }
 
-    func testTerminalAppearanceComparisonIgnoresLegacyRSAHostKeyPolicy() {
+    func testTerminalAppearanceComparisonIgnoresNonAppearanceSettings() {
         let settings = TerminalSettings(fontSize: 13, theme: .remuxDark)
         let rsaOnly = TerminalSettings(
             fontSize: 13,
@@ -35,8 +36,14 @@ final class TerminalSettingsTests: XCTestCase {
         )
         let fontChanged = TerminalSettings(fontSize: 14, theme: .remuxDark)
         let themeChanged = TerminalSettings(fontSize: 13, theme: .remuxLight)
+        let multipaneDefaultChanged = TerminalSettings(
+            fontSize: 13,
+            theme: .remuxDark,
+            zoomMultipaneWindowsByDefault: true
+        )
 
         XCTAssertTrue(settings.hasSameTerminalAppearance(as: rsaOnly))
+        XCTAssertTrue(settings.hasSameTerminalAppearance(as: multipaneDefaultChanged))
         XCTAssertFalse(settings.hasSameTerminalAppearance(as: fontChanged))
         XCTAssertFalse(settings.hasSameTerminalAppearance(as: themeChanged))
     }

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -139,7 +139,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         }
     }
 
-    func testSideBySideNavigationCoalescesAndRefreshesOnEachRevisit() async throws {
+    func testSideBySideNavigationCoalescesOnEachRevisit() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,
             expectedPaneCount: 3
@@ -149,7 +149,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         harness.controller.requestSelectPane(paneID: 2)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -157,14 +157,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.pump(Data(
             ("%window-pane-changed @0 %1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %2",
             paneID: 2,
@@ -172,11 +168,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.pump(Data(
             ("%window-pane-changed @0 %2\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 2,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
@@ -184,7 +176,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         harness.controller.requestSelectPane(paneID: 2)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -192,14 +184,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.pump(Data(
             ("%window-pane-changed @0 %1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %2",
             paneID: 2,
@@ -216,7 +204,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         harness.controller.requestSelectPane(paneID: 0)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -232,14 +220,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
 
         harness.controller.pump(Data(
-            ("%window-pane-changed @0 %1\n"
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+            "%window-pane-changed @0 %1\n".utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %0",
             paneID: 0,
@@ -247,11 +231,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.pump(Data(
             ("%window-pane-changed @0 %0\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 0,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
@@ -266,7 +246,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.requestSelectPane(paneID: 1)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -282,14 +262,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
 
         harness.controller.pump(Data(
-            (responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+            responseBlock(commandNumber: &nextCommandNumber).utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %2",
             paneID: 2,
@@ -305,7 +281,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.requestSelectPane(paneID: 1)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -323,14 +299,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
 
         harness.controller.pump(Data(
-            ("%window-pane-changed @0 %1\n"
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+            "%window-pane-changed @0 %1\n".utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %2",
             paneID: 2,
@@ -347,7 +319,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         harness.controller.requestSelectPane(paneID: 2)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -357,14 +329,14 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             errorBlock(commandNumber: &nextCommandNumber, body: "can't find pane: %1").utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %2",
             paneID: 2,
         )
     }
 
-    func testFailedPresentationRetryKeepsSameTargetRefreshAfterInFlightCompletion() async throws {
+    func testFailedSelectionRetriesTheLatestTarget() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,
             expectedPaneCount: 3
@@ -374,7 +346,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         harness.controller.requestSelectPane(paneID: 1)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -387,29 +359,12 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(
             harness.recorder.takeStrings(),
             ["select-pane -Z -t %1\n"],
-            "the retry executes after the already queued refresh"
+            "the latest selection is retried after the first command fails"
         )
 
         harness.controller.pump(Data(
-            refreshResponseBlocks(
-                paneID: 1,
-                commandNumber: &nextCommandNumber
-            ).utf8
-        ))
-        await drain(harness.controller)
-        let retryRefreshWrites = harness.recorder.takeStrings()
-        XCTAssertEqual(retryRefreshWrites.count, 1)
-        let retryRefresh = try XCTUnwrap(retryRefreshWrites.first)
-        XCTAssertTrue(retryRefresh.hasPrefix("display-message -p -t %1 "))
-        XCTAssertEqual(retryRefresh.components(separatedBy: "capture-pane").count - 1, 4)
-
-        harness.controller.pump(Data(
             ("%window-pane-changed @0 %1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
@@ -455,7 +410,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
                 + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "resize-pane -Z -t %1",
             paneID: 1
@@ -471,24 +426,20 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSetPaneZoomed(paneID: 0, zoomed: false)
         await drain(harness.controller)
 
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "resize-pane -Z -t %0",
             paneID: 0
         )
     }
 
-    func testShutdownUnzoomDoesNotRefreshPaneThatWillBeReleased() async throws {
+    func testShutdownUnzoomSendsOnlyTheTmuxMutation() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.twoPaneSameColumnZoomedWindow,
             expectedPaneCount: 2
         )
 
-        harness.controller.requestSetPaneZoomed(
-            paneID: 0,
-            zoomed: false,
-            refreshPaneAfterChange: false
-        )
+        harness.controller.requestSetPaneZoomed(paneID: 0, zoomed: false)
         await drain(harness.controller)
 
         XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t %0\n"])
@@ -518,9 +469,9 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             expectedPaneCount: 4
         )
 
-        harness.controller.requestSetWindowsUnzoomed(
+        harness.controller.requestSetWindowsZoomed(
             windowIDs: [0, 1],
-            refreshPanesAfterChange: false
+            zoomed: false
         )
         await drain(harness.controller)
 
@@ -530,27 +481,89 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
     }
 
-    func testBackgroundCleanupRefreshesEveryUnzoomedWindowInOneWrite() async throws {
+    func testGlobalDefaultZoomsEveryRequestedMultipaneWindowInOneWrite() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.twoUnzoomedWindows,
+            expectedPaneCount: 4
+        )
+
+        harness.controller.requestSetWindowsZoomed(
+            windowIDs: [0, 1],
+            zoomed: true
+        )
+        await drain(harness.controller)
+
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["resize-pane -Z -t %0 ; resize-pane -Z -t %2\n"]
+        )
+    }
+
+    func testGlobalDefaultSendsNothingWhenEveryWindowAlreadyMatches() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.twoZoomedWindows,
             expectedPaneCount: 4
         )
 
-        harness.controller.requestSetWindowsUnzoomed(
+        harness.controller.requestSetWindowsZoomed(
             windowIDs: [0, 1],
-            refreshPanesAfterChange: true
+            zoomed: true
         )
         await drain(harness.controller)
 
-        let writes = harness.recorder.takeStrings()
-        XCTAssertEqual(writes.count, 1)
-        let write = try XCTUnwrap(writes.first)
-        XCTAssertTrue(write.hasPrefix(
-            "resize-pane -Z -t @0 ; resize-pane -Z -t @1\n"
+        XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
+    }
+
+    func testLatestGlobalZoomSettingRunsAfterAnInFlightZoom() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.twoPaneUnzoomedWindow,
+            expectedPaneCount: 2
+        )
+        var nextCommandNumber = harness.nextCommandNumber
+
+        harness.controller.requestSetWindowsZoomed(windowIDs: [1], zoomed: true)
+        harness.controller.requestSetWindowsZoomed(windowIDs: [1], zoomed: false)
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t %1\n"])
+
+        let layout = "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}"
+        harness.controller.pump(Data(
+            (responseBlock(commandNumber: &nextCommandNumber)
+                + "%layout-change @1 \(layout) b7de,83x44,0,0,1 *Z\n").utf8
         ))
-        XCTAssertTrue(write.contains("display-message -p -t %0 "))
-        XCTAssertTrue(write.contains("display-message -p -t %2 "))
-        XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 8)
+        await drain(harness.controller)
+
+        XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t @1\n"])
+    }
+
+    func testGlobalZoomIsNotDiscardedByLaterPaneNavigation() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.twoPaneUnzoomedWindow,
+            expectedPaneCount: 2
+        )
+        var nextCommandNumber = harness.nextCommandNumber
+
+        harness.controller.requestSelectPane(paneID: 2)
+        harness.controller.requestSetWindowsZoomed(windowIDs: [1], zoomed: true)
+        harness.controller.requestSelectPane(paneID: 1)
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["select-pane -t %2\n"])
+
+        harness.controller.pump(Data(
+            ("%window-pane-changed @1 %2\n"
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
+        ))
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t %2\n"])
+
+        let layout = "9c1f,83x44,0,0{41x44,0,0,1,41x44,42,0,2}"
+        harness.controller.pump(Data(
+            (responseBlock(commandNumber: &nextCommandNumber)
+                + "%layout-change @1 \(layout) b7df,83x44,0,0,2 *Z\n").utf8
+        ))
+        await drain(harness.controller)
+
+        XCTAssertEqual(harness.recorder.takeStrings(), ["select-pane -Z -t %1\n"])
     }
 
     func testWindowNavigationCoalescesRollbackToLatestWindow() async throws {
@@ -585,7 +598,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["select-pane -t %2\n"])
     }
 
-    func testUnzoomedPaneSelectionDoesNotRehydrateOrReplaceTerminal() async throws {
+    func testUnzoomedPaneSelectionDoesNotReplaceTerminal() async throws {
         let lifecycle = ControllerLifecycleRecorder()
         let harness = try await readyController(
             listWindowsBody: Self.twoPaneUnzoomedWindow,
@@ -607,13 +620,10 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
 
-        XCTAssertFalse(
-            lifecycle.phaseChanges.contains { $0.paneID == 2 && $0.phase == .hydrating }
-        )
         XCTAssertEqual(lifecycle.terminalPaneIDs, initialTerminalPaneIDs)
     }
 
-    func testTopBottomRoundTripRefreshesEachFullToSplitGridChange() async throws {
+    func testTopBottomRoundTripUsesOnlySelectionCommands() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.twoPaneSameColumnZoomedWindow,
             expectedPaneCount: 2
@@ -623,7 +633,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestSelectPane(paneID: 1)
         await drain(harness.controller)
 
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %1",
             paneID: 1,
@@ -631,17 +641,13 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.pump(Data(
             ("%window-pane-changed @0 %1\n"
-                + responseBlock(commandNumber: &nextCommandNumber)
-                + refreshResponseBlocks(
-                    paneID: 1,
-                    commandNumber: &nextCommandNumber
-                )).utf8
+                + responseBlock(commandNumber: &nextCommandNumber)).utf8
         ))
         await drain(harness.controller)
 
         harness.controller.requestSelectPane(paneID: 0)
         await drain(harness.controller)
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "select-pane -Z -t %0",
             paneID: 0,
@@ -669,7 +675,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["refresh-client -C 100x40\n"])
     }
 
-    func testClientSizeRevertPublishesWithoutPaneRefresh() async throws {
+    func testClientSizeRevertPublishesEachDistinctSize() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,
             expectedPaneCount: 1
@@ -683,7 +689,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
     }
 
-    func testNewWindowAndSplitCommandsDoNotGainRefreshWork() async throws {
+    func testNewWindowAndSplitSendOnlyTheirTmuxMutations() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,
             expectedPaneCount: 1
@@ -706,7 +712,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["split-window -h -Z -t %0\n"])
     }
 
-    func testZoomedInactivePaneCloseBatchesRezoomAndRefresh() async throws {
+    func testZoomedInactivePaneCloseBatchesDeleteAndRezoom() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,
             expectedPaneCount: 3
@@ -715,14 +721,14 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestClosePane(paneID: 1)
         await drain(harness.controller)
 
-        assertPresentationWrite(
+        assertCommandWrite(
             harness.recorder.takeStrings(),
             command: "kill-pane -t %1 ; resize-pane -Z -t @0",
             paneID: 0
         )
     }
 
-    func testZoomedActivePaneCloseRefreshesTmuxSelectedSuccessor() async throws {
+    func testZoomedActivePaneCloseUsesTmuxSelectedSuccessor() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,
             expectedPaneCount: 3
@@ -743,7 +749,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         ))
         await drain(harness.controller)
 
-        assertPaneRefreshWrite(harness.recorder.takeStrings(), paneID: 1)
+        XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
     }
 
     func testZoomedTwoPaneCloseLeavesSinglePaneUnzoomed() async throws {
@@ -831,7 +837,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["kill-window -t @0\n"])
     }
 
-    func testNotReadyRefreshRetriesOnceAndDrainsAfterInitialPaneChanged() async throws {
+    func testZoomDuringInitialHydrationDoesNotQueueExtraCommands() async throws {
         let harness = try await hydratingController(
             listWindowsBody: Self.twoPaneUnzoomedWindow,
             expectedPaneCount: 2
@@ -841,8 +847,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["resize-pane -Z -t %1\n"],
-            "initial hydration cannot yet accept the refresh"
+            ["resize-pane -Z -t %1\n"]
         )
 
         let hydrationEnd = harness.firstHydrationCommandNumber + harness.hydrationCommandCount
@@ -852,38 +857,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.pump(Data(hydration.utf8))
         await drain(harness.controller)
 
-        let writes = harness.recorder.takeStrings()
-        XCTAssertEqual(writes.count, 1)
-        let write = try XCTUnwrap(writes.first)
-        XCTAssertTrue(write.hasPrefix("display-message -p -t %1 "))
-        XCTAssertEqual(write.components(separatedBy: "capture-pane").count - 1, 4)
-    }
-
-    func testTopologyRemovalClearsDeferredPaneRefresh() async throws {
-        let harness = try await hydratingController(
-            listWindowsBody: Self.twoPaneUnzoomedWindow,
-            expectedPaneCount: 2
-        )
-
-        harness.controller.requestSetPaneZoomed(paneID: 1, zoomed: true)
-        await drain(harness.controller)
-        XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t %1\n"])
-
-        harness.controller.pump(Data("%unlinked-window-close @1\n".utf8))
-        await drain(harness.controller)
         XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
-
-        let hydrationEnd = harness.firstHydrationCommandNumber + harness.hydrationCommandCount
-        let hydration = (harness.firstHydrationCommandNumber..<hydrationEnd)
-            .map { "%begin \($0) \($0) 1\n%end \($0) \($0) 1\n" }
-            .joined()
-        harness.controller.pump(Data(hydration.utf8))
-        await drain(harness.controller)
-        XCTAssertEqual(
-            harness.recorder.takeStrings(),
-            [],
-            "a removed pane must not retry its deferred refresh"
-        )
     }
 
     func testDetachedRequestReportsImmediateFailure() async throws {
@@ -1121,78 +1095,14 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
             + "%end \(commandNumber) \(commandNumber) 1\n"
     }
 
-    private func refreshResponseBlocks(
-        paneID: TmuxPaneID,
-        columns: UInt32 = 83,
-        rows: UInt32 = 44,
-        commandNumber: inout Int
-    ) -> String {
-        let cursorY = rows - 1
-        let state = "%\(paneID.rawValue);\(columns);\(rows);0;0;1;;;;0;"
-            + "4294967295;4294967295;0;1;0;0;0;0;0;0;0;0;;;0;0;\(cursorY);8,16\n"
-        return responseBlock(commandNumber: &commandNumber, body: state)
-            + responseBlock(commandNumber: &commandNumber)
-            + responseBlock(commandNumber: &commandNumber)
-            + responseBlock(commandNumber: &commandNumber)
-            + responseBlock(commandNumber: &commandNumber)
-    }
-
-    private func assertPresentationWrite(
+    private func assertCommandWrite(
         _ writes: [String],
         command: String,
-        paneID: TmuxPaneID,
+        paneID _: TmuxPaneID,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        XCTAssertEqual(writes.count, 1, file: file, line: line)
-        guard let write = writes.first else { return }
-        XCTAssertTrue(
-            write.hasPrefix(command + "\ndisplay-message -p -t %\(paneID.rawValue) "),
-            "presentation must precede refresh in the same outbound write: \(write)",
-            file: file,
-            line: line
-        )
-        let refresh = String(write.dropFirst(command.utf8.count + 1))
-        XCTAssertEqual(
-            refresh.components(separatedBy: "capture-pane").count - 1,
-            4,
-            file: file,
-            line: line
-        )
-        XCTAssertEqual(
-            refresh.components(separatedBy: " ; ").count - 1,
-            4,
-            file: file,
-            line: line
-        )
-    }
-
-    private func assertPaneRefreshWrite(
-        _ writes: [String],
-        paneID: TmuxPaneID,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        XCTAssertEqual(writes.count, 1, file: file, line: line)
-        guard let write = writes.first else { return }
-        XCTAssertTrue(
-            write.hasPrefix("display-message -p -t %\(paneID.rawValue) "),
-            "expected a targeted pane refresh: \(write)",
-            file: file,
-            line: line
-        )
-        XCTAssertEqual(
-            write.components(separatedBy: "capture-pane").count - 1,
-            4,
-            file: file,
-            line: line
-        )
-        XCTAssertEqual(
-            write.components(separatedBy: " ; ").count - 1,
-            4,
-            file: file,
-            line: line
-        )
+        XCTAssertEqual(writes, [command + "\n"], file: file, line: line)
     }
 
     private func errorBlock(commandNumber: inout Int, body: String) -> String {
@@ -1301,6 +1211,22 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         name: "window-1"
     )
 
+    private static let twoUnzoomedWindows = windowRecord(
+        id: 0,
+        active: true,
+        paneID: 0,
+        layout: "607b,83x44,0,0[83x22,0,0,0,83x21,0,23,1]",
+        visibleLayout: "607b,83x44,0,0[83x22,0,0,0,83x21,0,23,1]",
+        name: "window-0"
+    ) + windowRecord(
+        id: 1,
+        active: false,
+        paneID: 2,
+        layout: "4084,83x44,0,0[83x22,0,0,2,83x21,0,23,3]",
+        visibleLayout: "4084,83x44,0,0[83x22,0,0,2,83x21,0,23,3]",
+        name: "window-1"
+    )
+
     private static let onePaneWindow = windowRecord(
         id: 0,
         active: true,
@@ -1374,32 +1300,19 @@ private final class ControllerOutboundRecorder: @unchecked Sendable {
 }
 
 private final class ControllerLifecycleRecorder: @unchecked Sendable {
-    struct PhaseChange: Equatable {
-        let paneID: TmuxPaneID
-        let phase: TmuxSessionController.PaneInfo.Phase
-    }
-
     private let lock = NSLock()
     private var terminals: [TmuxSessionController.RetainedPaneTerminal] = []
-    private var phases: [PhaseChange] = []
 
     var callbacks: TmuxSessionController.Callbacks {
         .init(
             onPaneTerminal: { [self] terminal in
                 lock.withLock { terminals.append(terminal) }
-            },
-            onPanePhaseChanged: { [self] paneID, phase in
-                lock.withLock { phases.append(.init(paneID: paneID, phase: phase)) }
             }
         )
     }
 
     var terminalPaneIDs: [TmuxPaneID] {
         lock.withLock { terminals.map(\.paneID).sorted() }
-    }
-
-    var phaseChanges: [PhaseChange] {
-        lock.withLock { phases }
     }
 }
 

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -712,6 +712,29 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["split-window -h -Z -t %0\n"])
     }
 
+    func testZoomingSplitReportsOwnershipAfterTmuxAcceptsIt() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+        var nextCommandNumber = harness.nextCommandNumber
+        let zoomCreated = expectation(description: "zooming split accepted")
+
+        harness.controller.requestSplit(
+            paneID: 0,
+            direction: .right,
+            zoom: true,
+            onZoomCreated: { zoomCreated.fulfill() }
+        )
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["split-window -h -Z -t %0\n"])
+
+        harness.controller.pump(Data(responseBlock(
+            commandNumber: &nextCommandNumber
+        ).utf8))
+        await fulfillment(of: [zoomCreated], timeout: 1)
+    }
+
     func testZoomedInactivePaneCloseBatchesDeleteAndRezoom() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -151,8 +151,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -162,8 +161,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %2",
-            paneID: 2,
+            command: "select-pane -Z -t %2"
         )
 
         harness.controller.pump(Data(
@@ -178,8 +176,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -189,8 +186,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %2",
-            paneID: 2,
+            command: "select-pane -Z -t %2"
         )
     }
 
@@ -206,8 +202,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -225,8 +220,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %0",
-            paneID: 0,
+            command: "select-pane -Z -t %0"
         )
 
         harness.controller.pump(Data(
@@ -248,8 +242,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data("%window-pane-changed @0 %1\n".utf8))
@@ -267,8 +260,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %2",
-            paneID: 2,
+            command: "select-pane -Z -t %2"
         )
     }
 
@@ -283,8 +275,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -304,8 +295,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %2",
-            paneID: 2,
+            command: "select-pane -Z -t %2"
         )
     }
 
@@ -321,8 +311,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -331,8 +320,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %2",
-            paneID: 2,
+            command: "select-pane -Z -t %2"
         )
     }
 
@@ -348,8 +336,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -412,8 +399,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "resize-pane -Z -t %1",
-            paneID: 1
+            command: "resize-pane -Z -t %1"
         )
     }
 
@@ -428,21 +414,8 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "resize-pane -Z -t %0",
-            paneID: 0
+            command: "resize-pane -Z -t %0"
         )
-    }
-
-    func testShutdownUnzoomSendsOnlyTheTmuxMutation() async throws {
-        let harness = try await readyController(
-            listWindowsBody: Self.twoPaneSameColumnZoomedWindow,
-            expectedPaneCount: 2
-        )
-
-        harness.controller.requestSetPaneZoomed(paneID: 0, zoomed: false)
-        await drain(harness.controller)
-
-        XCTAssertEqual(harness.recorder.takeStrings(), ["resize-pane -Z -t %0\n"])
     }
 
     func testWindowSelectionLeavesZoomedSourceWindowUntouched() async throws {
@@ -635,8 +608,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %1",
-            paneID: 1,
+            command: "select-pane -Z -t %1"
         )
 
         harness.controller.pump(Data(
@@ -649,8 +621,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "select-pane -Z -t %0",
-            paneID: 0,
+            command: "select-pane -Z -t %0"
         )
     }
 
@@ -746,8 +717,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         assertCommandWrite(
             harness.recorder.takeStrings(),
-            command: "kill-pane -t %1 ; resize-pane -Z -t @0",
-            paneID: 0
+            command: "kill-pane -t %1 ; resize-pane -Z -t @0"
         )
     }
 
@@ -1121,7 +1091,6 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
     private func assertCommandWrite(
         _ writes: [String],
         command: String,
-        paneID _: TmuxPaneID,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -176,6 +176,29 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         )
     }
 
+    func testGlobalResetForwardsLatestIntentAgainstStaleMatchingTopology() {
+        var policy = TmuxMultipaneZoomDefaultPolicy()
+        let staleUnzoomedTopology = topology(zoomed: false, paneCount: 2)
+
+        XCTAssertTrue(policy.setEnabled(true))
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(
+                in: staleUnzoomedTopology,
+                includingMatchingWindows: true
+            ),
+            [1]
+        )
+
+        XCTAssertTrue(policy.setEnabled(false))
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(
+                in: staleUnzoomedTopology,
+                includingMatchingWindows: true
+            ),
+            [1]
+        )
+    }
+
     func testGlobalChangeDoesNotSubmitAnAlreadyMatchingWindow() {
         var policy = TmuxMultipaneZoomDefaultPolicy()
         let topology = topology(zoomed: true, paneCount: 2)

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -110,6 +110,124 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         )
     }
 
+    private func topology(
+        windowID: TmuxWindowID = 1,
+        zoomed: Bool,
+        activePaneID: TmuxPaneID? = 10,
+        paneCount: Int
+    ) -> TmuxSessionController.TopologySnapshot {
+        TmuxSessionController.TopologySnapshot(
+            sessionName: "zoom-default-test",
+            windows: [window(
+                id: windowID,
+                active: true,
+                paneID: activePaneID,
+                zoomed: zoomed
+            )],
+            panes: (0..<paneCount).map { offset in
+                pane(
+                    id: TmuxPaneID(UInt64(10 + offset)),
+                    windowID: windowID,
+                    x: UInt32(offset * 40),
+                    width: UInt32(paneCount == 1 ? 80 : 39)
+                )
+            },
+            activeWindowID: windowID
+        )
+    }
+
+    func testMultipaneZoomDefaultTargetsAnUnzoomedWindowOnlyOnce() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+        let topology = topology(zoomed: false, paneCount: 2)
+
+        XCTAssertEqual(policy.windowIDsNeedingChange(in: topology), [1])
+        XCTAssertEqual(policy.windowIDsNeedingChange(in: topology), [])
+    }
+
+    func testMultipaneZoomDefaultUnzoomsAnAlreadyZoomedWindowWhenDisabled() {
+        var policy = TmuxMultipaneZoomDefaultPolicy()
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: true, paneCount: 2)),
+            [1]
+        )
+    }
+
+    func testMultipaneZoomDefaultDoesNotToggleAMatchingWindow() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: true, paneCount: 2)),
+            []
+        )
+    }
+
+    func testChangingGlobalDefaultResetsAResolvedWindow() {
+        var policy = TmuxMultipaneZoomDefaultPolicy()
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            []
+        )
+        XCTAssertTrue(policy.setEnabled(true))
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+    }
+
+    func testGlobalChangeDoesNotSubmitAnAlreadyMatchingWindow() {
+        var policy = TmuxMultipaneZoomDefaultPolicy()
+        let topology = topology(zoomed: true, paneCount: 2)
+
+        XCTAssertTrue(policy.setEnabled(true))
+        XCTAssertEqual(policy.windowIDsNeedingChange(in: topology), [])
+        XCTAssertEqual(policy.windowIDsNeedingChange(in: topology), [])
+    }
+
+    func testMultipaneZoomDefaultWaitsUntilASinglePaneWindowBecomesMultipane() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 1)),
+            []
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+    }
+
+    func testMultipaneZoomDefaultWaitsForAnAuthoritativeActivePane() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(
+                in: topology(zoomed: false, activePaneID: nil, paneCount: 2)
+            ),
+            []
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+    }
+
+    func testPerWindowResolutionLastsUntilGlobalDefaultChanges() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+        policy.recordWindowChoice(1)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            []
+        )
+        XCTAssertTrue(policy.setEnabled(false))
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: true, paneCount: 2)),
+            [1]
+        )
+    }
+
     func testNormalMultipaneViewportProjectsEveryTmuxPaneRectangle() async throws {
         let runtime = try GhosttyKitRuntime()
         let session = makeSession(runtime: runtime)

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -198,6 +198,41 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         )
     }
 
+    func testMultipaneZoomDefaultReappliesAfterReturningToOnePane() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 1)),
+            []
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+    }
+
+    func testReturningToOnePaneEndsThePerWindowChoice() {
+        var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
+        policy.recordWindowChoice(1)
+
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            []
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 1)),
+            []
+        )
+        XCTAssertEqual(
+            policy.windowIDsNeedingChange(in: topology(zoomed: false, paneCount: 2)),
+            [1]
+        )
+    }
+
     func testMultipaneZoomDefaultWaitsForAnAuthoritativeActivePane() {
         var policy = TmuxMultipaneZoomDefaultPolicy(isEnabled: true)
 

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -571,6 +571,16 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Catppuccin Mocha"].waitForExistence(timeout: 2))
     }
 
+    func testFreshPhoneInstallShowsMultipaneZoomDefaultEnabled() {
+        launchSimulatorApp()
+        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
+        app.buttons["library.settings"].tap()
+
+        let zoom = app.switches["settings.zoom-multipane-windows-by-default"]
+        XCTAssertTrue(zoom.waitForExistence(timeout: 2))
+        XCTAssertEqual(zoom.value as? String, "1")
+    }
+
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
         app.launchEnvironment["REMUX_UI_TEST_PUBLIC_KEY_INSTALL_OUTCOME"] = "passwordRequired"
         launchSimulatorApp()


### PR DESCRIPTION
## Context

#49 changed multipane windows from automatic tmux zoom to displaying the complete tmux layout by default. Zoom remained available from Panes, but it had to be enabled separately for every window and session.

That works well when the complete layout is useful, especially on larger screens, but makes dense desktop layouts difficult to use from an iPhone.

Closes #51.

## What changed

Adds a persisted **Zoom multipane windows** setting under **Windows & Panes**.

- Enabled by default on iPhone.
- Disabled by default on iPad, preserving the complete-layout experience.
- Applies to existing multipane windows and windows that become multipane later.
- Changing the global setting replaces temporary per-window choices.
- Zoom can still be overridden per window from Panes for the current app session.
- Returning to a single pane clears that temporary choice. If the window becomes multipane again, the global setting applies.
- Remux continues to make a best-effort cleanup attempt for zooms it created when the app session ends normally.
- Selecting a pane from the Panes sheet now dismisses the sheet.

This gives iPhone users the previous zoomed experience without removing the complete-layout behavior introduced in #49.

## Settings behavior

The preference is persisted app-wide. Existing settings without this value adopt the device default:

- iPhone: Zoom ON
- iPad: Zoom OFF

## Validation

Validated with focused tests, the iOS simulator, and a physical iPhone:

- Device defaults, settings migration, and persistence.
- Enabling and disabling the setting with existing multipane windows.
- Applying the setting when a single-pane window becomes multipane.
- Returning to one pane and splitting again.
- Per-window overrides followed by a global-setting change.
- Split Right and Split Down with Zoom enabled and disabled.
- Switching between windows without losing temporary choices.
- Avoiding redundant zoom commands for windows already in the requested state.
- Normal cleanup of Remux-created zooms.
- Pane selection dismissing the Panes sheet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Zoom multipane windows” terminal preference.
  - Multipane zoom is enabled by default on iPhone and disabled on other devices, with saved preferences preserved.
  - Newly created splits can automatically use the configured zoom behavior.
- **Improvements**
  - Improved pane and window zoom handling during navigation, splitting, and session changes.
  - Selecting a tmux pane now dismisses the selection sheet and restores keyboard focus.
  - Existing settings are migrated safely when the new preference is introduced.
- **Bug Fixes**
  - Improved reliability when panes or windows change during zoom operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->