### PR TITLE
Reclaim the tmux viewport during active Remux use

### DIFF
--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -1108,6 +1108,17 @@ final class RemuxRootModel: ObservableObject {
         for model in models {
             model.handleAppLifecyclePhase(phase)
         }
+
+        guard phase == .active,
+              case .terminal(let selectedID) = state,
+              let session = RemuxActiveSessionCollection.session(
+                  selectedID,
+                  in: activeSessions
+              )
+        else { return }
+        terminalScreenModels[TerminalRuntimeAttemptKey(session: session)]?
+            .terminalScreenAdapter
+            .reclaimActiveTmuxViewport()
     }
 
     func disconnectActiveSession(_ id: SavedWorkspace.ID) {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -1045,6 +1045,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func handleTerminalCoverSelectionChange(_ selected: Bool) {
+        if selected, scenePhase == .active {
+            model.reclaimActiveTmuxViewport()
+        }
         guard terminalCoverPhase.isRestoringKeyboard else { return }
         guard selected else {
             cancelTerminalCoverKeyboardRestoration(reason: "selection")
@@ -1380,6 +1383,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
 
     private func showWindows() {
         guard !composer.isSubmitting else { return }
+        model.claimActiveTmuxViewportIfNeeded()
         guard let projection = model.windowSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.newWindow", event: "ui.showWindows")
         applySelectionSheetPresentation(
@@ -1419,6 +1423,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
 
     private func showPanes() {
         guard !composer.isSubmitting else { return }
+        model.claimActiveTmuxViewportIfNeeded()
         guard let projection = model.selectedPaneSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.splitPane", event: "ui.showPanes")
 
@@ -1731,7 +1736,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         )
         model.prepareInitialViewport(
             size: observation.effectiveSize,
-            scale: displayScale
+            scale: displayScale,
+            claimActiveViewport: isSelected && scenePhase == .active
         )
     }
 
@@ -1943,7 +1949,11 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
             liveSize: terminalViewportCoordinator.latestLiveSize
         )
         if nextEffectiveSize != previousEffectiveSize {
-            model.prepareInitialViewport(size: nextEffectiveSize, scale: displayScale)
+            model.prepareInitialViewport(
+                size: nextEffectiveSize,
+                scale: displayScale,
+                claimActiveViewport: isSelected && scenePhase == .active
+            )
         }
         GhosttyRuntimeTrace.perf(
             "viewport.freeze release kind=\(releaseKind) live=\(terminalViewportCoordinator.latestLiveSize.traceLabel) previousEffective=\(previousEffectiveSize.traceLabel) nextEffective=\(nextEffectiveSize.traceLabel)"

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
@@ -47,13 +47,27 @@ protocol GhosttyTerminalRenderingModeling: ObservableObject {
     var commandFailureEvent: GhosttyTmuxCommandFailureEvent? { get }
     var stateTraceLabel: String { get }
 
-    func prepareInitialViewport(size: CGSize, scale: CGFloat)
+    func prepareInitialViewport(
+        size: CGSize,
+        scale: CGFloat,
+        claimActiveViewport: Bool
+    )
 
     /// Host hint that the terminal viewport is (not) in its settled
     /// shape — false while a transient overlay (software keyboard) is
     /// changing the layout. Engines use it to decide which reported
     /// viewport is safe to carry into a reconnect.
     func setViewportStabilityHint(stable: Bool)
+}
+
+extension GhosttyTerminalRenderingModeling {
+    func prepareInitialViewport(size: CGSize, scale: CGFloat) {
+        prepareInitialViewport(
+            size: size,
+            scale: scale,
+            claimActiveViewport: false
+        )
+    }
 }
 
 @MainActor
@@ -111,6 +125,10 @@ protocol GhosttyTerminalInputModeling: ObservableObject {
 @MainActor
 protocol GhosttyTmuxActionModeling: ObservableObject {
     // MARK: tmux topology actions
+
+    func reclaimActiveTmuxViewport()
+
+    func claimActiveTmuxViewportIfNeeded()
 
     @discardableResult
     func focusTmuxPane(_ id: UUID) -> GhosttyTmuxModelActionOutcome

--- a/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
+++ b/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
@@ -119,8 +119,12 @@ final class TmuxScreenModel: ObservableObject {
         terminalScreenAdapter.activate(
             session: session,
             zoomMultipaneWindowsByDefault: currentTerminalSettings.zoomMultipaneWindowsByDefault,
-            initialViewportHandler: { [weak self] size, scale in
-                self?.prepareInitialViewport(size: size, scale: scale)
+            initialViewportHandler: { [weak self] size, scale, claimActiveViewport in
+                self?.prepareInitialViewport(
+                    size: size,
+                    scale: scale,
+                    claimActiveViewport: claimActiveViewport
+                )
             },
             viewportStabilityHandler: { [weak self] stable in
                 self?.setViewportStability(stable)
@@ -193,7 +197,11 @@ final class TmuxScreenModel: ObservableObject {
         session?.connect(viewport: viewport)
     }
 
-    private func prepareInitialViewport(size: CGSize, scale: CGFloat) {
+    private func prepareInitialViewport(
+        size: CGSize,
+        scale: CGFloat,
+        claimActiveViewport: Bool = false
+    ) {
         guard !stopped else { return }
         guard let runtime else { return }
         lastViewportPointSize = size
@@ -210,10 +218,13 @@ final class TmuxScreenModel: ObservableObject {
             if initialViewport == nil {
                 connect(viewport: measurement.controlViewport)
             } else {
-                _ = submitClientSizeIfChanged(TmuxSessionController.ClientSize(
-                    cols: UInt32(measurement.controlViewport.columns),
-                    rows: UInt32(measurement.controlViewport.rows)
-                ))
+                _ = submitClientSizeIfChanged(
+                    TmuxSessionController.ClientSize(
+                        cols: UInt32(measurement.controlViewport.columns),
+                        rows: UInt32(measurement.controlViewport.rows)
+                    ),
+                    claimActiveViewport: claimActiveViewport
+                )
             }
         } catch {
             startupFailure = String(describing: error)
@@ -226,13 +237,18 @@ final class TmuxScreenModel: ObservableObject {
     /// controller work while the first submission is still pending.
     @discardableResult
     func submitClientSizeIfChanged(
-        _ size: TmuxSessionController.ClientSize
+        _ size: TmuxSessionController.ClientSize,
+        claimActiveViewport: Bool = false
     ) -> Bool {
         guard !stopped, let controller = session?.controller else { return false }
         guard size != lastSubmittedClientSize else { return false }
         lastSubmittedClientSize = size
         if viewportIsStable { lastStableClientSize = size }
-        controller.setClientSize(cols: size.cols, rows: size.rows)
+        controller.setClientSize(
+            cols: size.cols,
+            rows: size.rows,
+            claimActiveViewport: claimActiveViewport
+        )
         return true
     }
 

--- a/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
+++ b/RemuxApp/Sources/Tmux/TmuxScreenModel.swift
@@ -241,9 +241,12 @@ final class TmuxScreenModel: ObservableObject {
         claimActiveViewport: Bool = false
     ) -> Bool {
         guard !stopped, let controller = session?.controller else { return false }
-        guard size != lastSubmittedClientSize else { return false }
-        lastSubmittedClientSize = size
-        if viewportIsStable { lastStableClientSize = size }
+        let sizeChanged = size != lastSubmittedClientSize
+        guard sizeChanged || claimActiveViewport else { return false }
+        if sizeChanged {
+            lastSubmittedClientSize = size
+            if viewportIsStable { lastStableClientSize = size }
+        }
         controller.setClientSize(
             cols: size.cols,
             rows: size.rows,

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -200,6 +200,7 @@ final class TmuxSessionController: @unchecked Sendable {
             topologyRevisionAtSubmission: UInt64,
             onSuccess: (@Sendable () -> Void)?
         )
+        case viewportClaim
         case paneCurrentDirectory(
             @Sendable (Result<String, PaneCurrentDirectoryError>) -> Void
         )
@@ -219,6 +220,7 @@ final class TmuxSessionController: @unchecked Sendable {
     private var deferredNavigationIntent: NavigationIntent?
     private var deferredWindowZoomIntent: WindowZoomIntent?
     private var successfulMutationRequiredAfterRevision: UInt64?
+    private var viewportClaimAwaitingTopology = false
     private var topologyRevision: UInt64 = 0
     private var outboundSink: (@Sendable (Data) -> Void)?
     private var shuttingDown = false
@@ -309,6 +311,7 @@ final class TmuxSessionController: @unchecked Sendable {
             deferredNavigationIntent = nil
             deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
+            viewportClaimAwaitingTopology = false
             guard case .closed = state else {
                 publishState(.detached(.transportClosed))
                 return
@@ -327,6 +330,7 @@ final class TmuxSessionController: @unchecked Sendable {
             deferredNavigationIntent = nil
             deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
+            viewportClaimAwaitingTopology = false
             guard case .closed = state else {
                 publishState(.detached(nil))
                 return
@@ -346,6 +350,7 @@ final class TmuxSessionController: @unchecked Sendable {
             deferredNavigationIntent = nil
             deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
+            viewportClaimAwaitingTopology = false
             topology = nil
             clientSize = nil
             retainedPaneIDs.removeAll()
@@ -423,6 +428,7 @@ final class TmuxSessionController: @unchecked Sendable {
             deferredNavigationIntent = nil
             deferredWindowZoomIntent = nil
             successfulMutationRequiredAfterRevision = nil
+            viewportClaimAwaitingTopology = false
             let exit = action.value.exit
             let detail = decodeTmuxString(exit.detail)
             switch exit.reason {
@@ -483,6 +489,7 @@ final class TmuxSessionController: @unchecked Sendable {
         topology = snapshot
         topologyRevision &+= 1
         clearSatisfiedMutationBarrier()
+        clearSatisfiedViewportClaim()
 
         for paneID in removed {
             retainedPaneIDs.remove(paneID)
@@ -537,6 +544,10 @@ final class TmuxSessionController: @unchecked Sendable {
         preconditionOnWriterQueue()
         guard let outstanding = requestsByToken.removeValue(forKey: completion.token) else { return }
         switch outstanding {
+        case .viewportClaim:
+            viewportClaimAwaitingTopology = completion.status == GHOSTTY_TMUX_COMMAND_SUCCESS
+                && !activeViewportMatchesClientSize
+            return
         case .trackedInput(let completionHandler):
             let succeeded = completion.status == GHOSTTY_TMUX_COMMAND_SUCCESS
             if !succeeded {
@@ -638,6 +649,7 @@ final class TmuxSessionController: @unchecked Sendable {
                 DispatchQueue.main.async { self.callbacks.onRequestFailed(.sendInput) }
                 return
             }
+            _ = admitActiveViewportClaimIfNeeded()
             let result = bytes.withUnsafeBytes { buffer in
                 ghostty_tmux_client_send_pane_input(
                     client,
@@ -701,6 +713,7 @@ final class TmuxSessionController: @unchecked Sendable {
                 completion(false)
                 return
             }
+            _ = admitActiveViewportClaimIfNeeded()
             var token: UInt64 = 0
             let result = bytes.withUnsafeBytes { buffer in
                 let pointer = buffer.bindMemory(to: UInt8.self).baseAddress
@@ -734,25 +747,38 @@ final class TmuxSessionController: @unchecked Sendable {
         return true
     }
 
-    func setClientSize(cols: UInt32, rows: UInt32) {
+    func setClientSize(
+        cols: UInt32,
+        rows: UInt32,
+        claimActiveViewport: Bool = false
+    ) {
         guard cols > 0, rows > 0, cols <= UInt16.max, rows <= UInt16.max else {
             DispatchQueue.main.async { self.callbacks.onRequestFailed(.setClientSize) }
             return
         }
         let nextSize = ClientSize(cols: cols, rows: rows)
         queue.async { [self] in
-            guard clientSize != nextSize else { return }
-            guard admitCommandOnWriter(
-                command: "refresh-client -C \(cols)x\(rows)",
-                request: .setClientSize
-            ) else { return }
-            clientSize = nextSize
-            _ = drainOutbound()
+            var admittedWork = false
+            if clientSize != nextSize {
+                guard admitCommandOnWriter(
+                    command: "refresh-client -C \(cols)x\(rows)",
+                    request: .setClientSize
+                ) else { return }
+                clientSize = nextSize
+                admittedWork = true
+            }
+            if claimActiveViewport, admitActiveViewportClaimIfNeeded() {
+                admittedWork = true
+            }
+            if admittedWork { _ = drainOutbound() }
         }
     }
 
     func requestNewWindow() {
-        enqueue(command: "new-window", request: .newWindow)
+        queue.async { [self] in
+            _ = admitActiveViewportClaimIfNeeded()
+            enqueueOnWriter(command: "new-window", request: .newWindow, onSuccess: nil)
+        }
     }
 
     func requestSplit(
@@ -768,11 +794,14 @@ final class TmuxSessionController: @unchecked Sendable {
         case .down: "-v"
         }
         let zoomFlag = zoom ? " -Z" : ""
-        enqueue(
-            command: "split-window \(flags)\(zoomFlag) -t %\(paneID.rawValue)",
-            request: .splitPane,
-            onSuccess: onZoomCreated
-        )
+        queue.async { [self] in
+            _ = admitActiveViewportClaimIfNeeded()
+            enqueueOnWriter(
+                command: "split-window \(flags)\(zoomFlag) -t %\(paneID.rawValue)",
+                request: .splitPane,
+                onSuccess: onZoomCreated
+            )
+        }
     }
 
     func requestClosePane(paneID: TmuxPaneID) {
@@ -829,7 +858,28 @@ final class TmuxSessionController: @unchecked Sendable {
     }
 
     func requestCopyMode(paneID: TmuxPaneID) {
-        enqueue(command: "copy-mode -t %\(paneID.rawValue)", request: .copyMode)
+        queue.async { [self] in
+            _ = admitActiveViewportClaimIfNeeded()
+            enqueueOnWriter(
+                command: "copy-mode -t %\(paneID.rawValue)",
+                request: .copyMode,
+                onSuccess: nil
+            )
+        }
+    }
+
+    func claimActiveViewportIfNeeded() {
+        queue.async { [self] in
+            guard admitActiveViewportClaimIfNeeded() else { return }
+            _ = drainOutbound()
+        }
+    }
+
+    func reclaimActiveViewport() {
+        queue.async { [self] in
+            guard admitActiveViewportClaim(force: true) else { return }
+            _ = drainOutbound()
+        }
     }
 
     func paneCurrentDirectory(for paneID: TmuxPaneID) async throws -> String {
@@ -874,6 +924,13 @@ final class TmuxSessionController: @unchecked Sendable {
               topologyRevision > requiredRevision
         else { return }
         successfulMutationRequiredAfterRevision = nil
+    }
+
+    private func clearSatisfiedViewportClaim() {
+        preconditionOnWriterQueue()
+        if activeViewportMatchesClientSize {
+            viewportClaimAwaitingTopology = false
+        }
     }
 
     private func admitDeferredMutationsIfPossible() {
@@ -935,10 +992,14 @@ final class TmuxSessionController: @unchecked Sendable {
             reportRequestFailure(.zoomPane)
             return
         }
+        let claimedViewport = admitActiveViewportClaimIfNeeded()
         let hasSibling = topology.panes.contains {
             $0.windowID == window.id && $0.id != paneID
         }
-        guard (!desired || hasSibling), window.zoomed != desired else { return }
+        guard (!desired || hasSibling), window.zoomed != desired else {
+            if claimedViewport, drainOutbound { _ = self.drainOutbound() }
+            return
+        }
         guard admitCommandOnWriter(
             command: "resize-pane -Z -t %\(paneID.rawValue)",
             request: .zoomPane
@@ -994,6 +1055,7 @@ final class TmuxSessionController: @unchecked Sendable {
             reportRequestFailure(.closePane)
             return
         }
+        _ = admitActiveViewportClaimIfNeeded()
 
         let windowPanes = topology.panes.filter { $0.windowID == window.id }
         guard window.zoomed, windowPanes.count > 2 else {
@@ -1024,6 +1086,7 @@ final class TmuxSessionController: @unchecked Sendable {
             reportRequestFailure(.closeWindow)
             return
         }
+        _ = admitActiveViewportClaimIfNeeded()
         submitCommandOnWriter(
             command: "kill-window -t @\(windowID.rawValue)",
             request: .closeWindow,
@@ -1052,7 +1115,11 @@ final class TmuxSessionController: @unchecked Sendable {
             return
         }
 
-        guard window.activePaneID != paneID else { return }
+        let claimedViewport = admitActiveViewportClaimIfNeeded()
+        guard window.activePaneID != paneID else {
+            if claimedViewport, drainOutbound { _ = self.drainOutbound() }
+            return
+        }
         let command = window.zoomed
             ? "select-pane -Z -t %\(paneID.rawValue)"
             : "select-pane -t %\(paneID.rawValue)"
@@ -1077,8 +1144,15 @@ final class TmuxSessionController: @unchecked Sendable {
         }
         let paneID = preferredPaneID ?? window.activePaneID
         if topology.activeWindowID == windowID {
-            guard let paneID else { return }
-            guard window.activePaneID != paneID else { return }
+            let claimedViewport = admitActiveViewportClaimIfNeeded()
+            guard let paneID else {
+                if claimedViewport, drainOutbound { _ = self.drainOutbound() }
+                return
+            }
+            guard window.activePaneID != paneID else {
+                if claimedViewport, drainOutbound { _ = self.drainOutbound() }
+                return
+            }
             let command = window.zoomed
                 ? "select-pane -Z -t %\(paneID.rawValue)"
                 : "select-pane -t %\(paneID.rawValue)"
@@ -1126,6 +1200,25 @@ final class TmuxSessionController: @unchecked Sendable {
         }
     }
 
+    private var hasOutstandingViewportClaim: Bool {
+        requestsByToken.values.contains {
+            guard case .viewportClaim = $0 else { return false }
+            return true
+        }
+    }
+
+    private var activeViewportMatchesClientSize: Bool {
+        guard let clientSize,
+              let topology,
+              let activeWindowID = topology.activeWindowID,
+              let activeWindow = topology.windows.first(where: {
+                  $0.id == activeWindowID
+              })
+        else { return false }
+        return activeWindow.width == clientSize.cols
+            && activeWindow.height == clientSize.rows
+    }
+
     private var awaitingTopologyMutationSettlement: Bool {
         hasOutstandingTopologyMutation
             || successfulMutationRequiredAfterRevision != nil
@@ -1139,6 +1232,50 @@ final class TmuxSessionController: @unchecked Sendable {
         case .copyMode, .setClientSize, .sendInput:
             false
         }
+    }
+
+    @discardableResult
+    private func admitActiveViewportClaimIfNeeded() -> Bool {
+        admitActiveViewportClaim(force: false)
+    }
+
+    @discardableResult
+    private func admitActiveViewportClaim(force: Bool) -> Bool {
+        preconditionOnWriterQueue()
+        guard let client,
+              outboundSink != nil,
+              !shuttingDown,
+              let clientSize,
+              let topology,
+              let activeWindowID = topology.activeWindowID,
+              let activeWindow = topology.windows.first(where: {
+                  $0.id == activeWindowID
+              })
+        else { return false }
+
+        let viewportMatches = activeWindow.width == clientSize.cols
+            && activeWindow.height == clientSize.rows
+        if viewportMatches {
+            viewportClaimAwaitingTopology = false
+            if !force { return false }
+        }
+        guard !viewportClaimAwaitingTopology,
+              !hasOutstandingViewportClaim
+        else { return false }
+
+        let (result, token) = enqueueCommandTokenOnWriter(
+            "select-window -t @\(activeWindowID.rawValue)",
+            client: client
+        )
+        guard result == GHOSTTY_TMUX_RESULT_OK else {
+            if result == GHOSTTY_TMUX_RESULT_CLIENT_FAILED
+                || result == GHOSTTY_TMUX_RESULT_CLOSED {
+                handleClientFailure(result)
+            }
+            return false
+        }
+        requestsByToken[token] = .viewportClaim
+        return true
     }
 
     static func crossWindowSelectionCommands(
@@ -1157,20 +1294,6 @@ final class TmuxSessionController: @unchecked Sendable {
                 ? "select-pane -Z -t %\(preferredPaneID.rawValue)"
                 : "select-pane -t %\(preferredPaneID.rawValue)",
         ]
-    }
-
-    private func enqueue(
-        command: String,
-        request: Request,
-        onSuccess: (@Sendable () -> Void)? = nil
-    ) {
-        queue.async { [self] in
-            enqueueOnWriter(
-                command: command,
-                request: request,
-                onSuccess: onSuccess
-            )
-        }
     }
 
     private func enqueueOnWriter(
@@ -1360,6 +1483,7 @@ final class TmuxSessionController: @unchecked Sendable {
         deferredNavigationIntent = nil
         deferredWindowZoomIntent = nil
         successfulMutationRequiredAfterRevision = nil
+        viewportClaimAwaitingTopology = false
         switch result {
         case GHOSTTY_TMUX_RESULT_OUT_OF_MEMORY:
             publishState(.detached(.outOfMemory))

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -82,7 +82,7 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
     private var activeManagedSurface: GhosttyManagedSurface?
     private var activeManagedPaneID: TmuxPaneID?
     private var pendingFocusedPaneID: TmuxPaneID?
-    private var initialViewportHandler: ((CGSize, CGFloat) -> Void)?
+    private var initialViewportHandler: ((CGSize, CGFloat, Bool) -> Void)?
     private var viewportStabilityHandler: ((Bool) -> Void)?
     private var latestViewportMeasurement: GhosttyTerminalViewportMeasurement?
     private var cachedTopologySnapshot = GhosttyRuntimeSurfaceTopologySnapshot.empty
@@ -105,7 +105,7 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
     func activate(
         session: TmuxTerminalSession,
         zoomMultipaneWindowsByDefault: Bool = false,
-        initialViewportHandler: @escaping (CGSize, CGFloat) -> Void,
+        initialViewportHandler: @escaping (CGSize, CGFloat, Bool) -> Void,
         viewportStabilityHandler: @escaping (Bool) -> Void
     ) {
         self.session = session
@@ -505,8 +505,12 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
 // MARK: - GhosttyTerminalScreenModeling
 
 extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
-    func prepareInitialViewport(size: CGSize, scale: CGFloat) {
-        initialViewportHandler?(size, scale)
+    func prepareInitialViewport(
+        size: CGSize,
+        scale: CGFloat,
+        claimActiveViewport: Bool
+    ) {
+        initialViewportHandler?(size, scale, claimActiveViewport)
     }
 
     var terminalScreenPresentationProjection: GhosttyTerminalScreenPresentationProjection {
@@ -834,6 +838,14 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
     }
 
     // MARK: tmux topology actions
+
+    func reclaimActiveTmuxViewport() {
+        controller?.reclaimActiveViewport()
+    }
+
+    func claimActiveTmuxViewportIfNeeded() {
+        controller?.claimActiveViewportIfNeeded()
+    }
 
     func focusTmuxPane(_ id: UUID) -> GhosttyTmuxModelActionOutcome {
         guard let paneID = identities.paneID(for: id), let controller else {

--- a/RemuxAppTests/TmuxScreenModelForegroundActiveCheckTests.swift
+++ b/RemuxAppTests/TmuxScreenModelForegroundActiveCheckTests.swift
@@ -80,7 +80,7 @@ final class TmuxScreenModelForegroundActiveCheckTests: XCTestCase {
         XCTAssertEqual(closeDispositions, [.reusable])
     }
 
-    func testScreenModelRejectsRepeatedGridBeforeControllerSubmission() async throws {
+    func testScreenModelRejectsRepeatedGridUnlessViewportClaimRequested() async throws {
         let transport = ForegroundInactiveTransport(isActive: true)
         let model = TmuxScreenModel(
             target: makeTarget(),
@@ -100,6 +100,11 @@ final class TmuxScreenModelForegroundActiveCheckTests: XCTestCase {
         }
         XCTAssertEqual(model.carriedClientSize, Self.initialClientSize)
         XCTAssertFalse(model.submitClientSizeIfChanged(Self.initialClientSize))
+        XCTAssertTrue(model.submitClientSizeIfChanged(
+            Self.initialClientSize,
+            claimActiveViewport: true
+        ))
+        XCTAssertEqual(model.carriedClientSize, Self.initialClientSize)
 
         let changed = TmuxSessionController.ClientSize(cols: 52, rows: 31)
         XCTAssertTrue(model.submitClientSizeIfChanged(changed))

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -660,6 +660,142 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         )
     }
 
+    func testActiveViewportClaimDoesNothingWhenWindowMatchesClientSize() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+
+        harness.controller.claimActiveViewportIfNeeded()
+        await drain(harness.controller)
+
+        XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
+    }
+
+    func testExplicitViewportReclaimRunsWhenTopologyStillMatches() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+        var nextCommandNumber = harness.nextCommandNumber
+
+        harness.controller.reclaimActiveViewport()
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["select-window -t @0\n"])
+
+        harness.controller.pump(Data(responseBlock(
+            commandNumber: &nextCommandNumber
+        ).utf8))
+        await drain(harness.controller)
+
+        harness.controller.reclaimActiveViewport()
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["select-window -t @0\n"],
+            "a matching reclaim must not wait for a layout change that tmux will not emit"
+        )
+    }
+
+    func testInputClaimsMismatchedActiveViewportBeforeSendingBytes() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+        var nextCommandNumber = harness.nextCommandNumber
+        let desktopLayout = "d4fd,189x49,0,0,0"
+        harness.controller.pump(Data(
+            "%layout-change @0 \(desktopLayout) \(desktopLayout) *\n".utf8
+        ))
+        await drain(harness.controller)
+
+        XCTAssertTrue(harness.controller.sendInput(paneID: 0, Data("a".utf8)))
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["select-window -t @0\nsend-keys -H -t %0 61\n"]
+        )
+
+        XCTAssertTrue(harness.controller.sendInput(paneID: 0, Data("b".utf8)))
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["send-keys -H -t %0 62\n"],
+            "key repeat must not enqueue duplicate viewport claims"
+        )
+
+        harness.controller.pump(Data(
+            "%layout-change @0 \(desktopLayout) \(desktopLayout) *\n".utf8
+        ))
+        harness.controller.pump(Data(responseBlock(
+            commandNumber: &nextCommandNumber
+        ).utf8))
+        await drain(harness.controller)
+
+        XCTAssertTrue(harness.controller.sendInput(paneID: 0, Data("c".utf8)))
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["send-keys -H -t %0 63\n"],
+            "a command reply must not settle the claim while the viewport still mismatches"
+        )
+
+        let remuxLayout = "b7dd,83x44,0,0,0"
+        harness.controller.pump(Data(
+            "%layout-change @0 \(remuxLayout) \(remuxLayout) *\n".utf8
+        ))
+        harness.controller.pump(Data(
+            "%layout-change @0 \(desktopLayout) \(desktopLayout) *\n".utf8
+        ))
+        await drain(harness.controller)
+
+        XCTAssertTrue(harness.controller.sendInput(paneID: 0, Data("d".utf8)))
+        await drain(harness.controller)
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["select-window -t @0\nsend-keys -H -t %0 64\n"]
+        )
+    }
+
+    func testSelectedViewportResizePublishesRefreshThenClaimInOneWrite() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+
+        harness.controller.setClientSize(
+            cols: 100,
+            rows: 40,
+            claimActiveViewport: true
+        )
+        await drain(harness.controller)
+
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["refresh-client -C 100x40\nselect-window -t @0\n"]
+        )
+    }
+
+    func testActiveViewportClaimPrecedesTopologyActionInOneWrite() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.onePaneWindow,
+            expectedPaneCount: 1
+        )
+        let desktopLayout = "d4fd,189x49,0,0,0"
+        harness.controller.pump(Data(
+            "%layout-change @0 \(desktopLayout) \(desktopLayout) *\n".utf8
+        ))
+        await drain(harness.controller)
+
+        harness.controller.requestNewWindow()
+        await drain(harness.controller)
+
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["select-window -t @0\nnew-window\n"]
+        )
+    }
+
     func testNewWindowAndSplitSendOnlyTheirTmuxMutations() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -292,7 +292,7 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         let adapter = TmuxTerminalScreenAdapter()
         adapter.activate(
             session: session,
-            initialViewportHandler: { _, _ in },
+            initialViewportHandler: { _, _, _ in },
             viewportStabilityHandler: { _ in }
         )
 
@@ -339,7 +339,7 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         let adapter = TmuxTerminalScreenAdapter()
         adapter.activate(
             session: session,
-            initialViewportHandler: { _, _ in },
+            initialViewportHandler: { _, _, _ in },
             viewportStabilityHandler: { _ in }
         )
 
@@ -399,7 +399,7 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         let adapter = TmuxTerminalScreenAdapter()
         adapter.activate(
             session: session,
-            initialViewportHandler: { _, _ in },
+            initialViewportHandler: { _, _, _ in },
             viewportStabilityHandler: { _ in }
         )
 
@@ -448,7 +448,7 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         let adapter = TmuxTerminalScreenAdapter()
         adapter.activate(
             session: session,
-            initialViewportHandler: { _, _ in },
+            initialViewportHandler: { _, _, _ in },
             viewportStabilityHandler: { _ in }
         )
 


### PR DESCRIPTION
## Summary

- Reclaim Remux’s viewport when returning to the foreground or switching back to a retained session.
- Reclaim a mismatched viewport before terminal input and relevant tmux interactions, including opening Windows or Panes.
- Coalesce repeated claims while one is settling and batch the claim with the user action in the same outbound write.
- Publish viewport-size changes and the corresponding claim together without polling or additional tmux queries.

## Testing

- Ran 68 focused controller and adapter tests covering exact outbound bytes, batching, duplicate suppression, command completion, and topology settlement.
- Verified on a physical iPhone.
- Verified end to end in the iOS Simulator against the existing Mac mini tmux session: after a desktop client changed the server window to 189×49, interacting from Remux restored it to 50×41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session recovery when the app returns to the foreground.
  * Kept the active terminal viewport aligned when switching selected terminals or presenting window and pane selectors.
  * Improved viewport handling during resizing, navigation, input, copy mode, and other terminal actions.
  * Added recovery for viewport mismatches and prevented duplicate viewport requests.

* **Tests**
  * Added coverage for viewport claiming, reclaiming, resizing, ordering, and stale responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->