### PR TITLE
polish terminal selector sheets

### DIFF
--- a/RemuxApp/Sources/App/SessionSwitcherView.swift
+++ b/RemuxApp/Sources/App/SessionSwitcherView.swift
@@ -702,8 +702,6 @@ private struct AvailableSessionsBrowserView: View {
 
     var body: some View {
         List {
-            refreshRow
-
             if let failureMessage {
                 Label(failureMessage, systemImage: "exclamationmark.triangle")
                     .foregroundStyle(TerminalSelectionSheetPalette.secondary)
@@ -743,6 +741,26 @@ private struct AvailableSessionsBrowserView: View {
         .navigationTitle("Available Sessions")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Haptic.tap()
+                    onRefresh()
+                } label: {
+                    if isRefreshing {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+                .disabled(isRefreshing)
+                .accessibilityLabel(
+                    isRefreshing ? "Refreshing Sessions" : "Refresh Sessions"
+                )
+                .accessibilityIdentifier("terminal.sessions.available-refresh")
+            }
+        }
         .searchable(
             text: $query,
             placement: .navigationBarDrawer(displayMode: .always),
@@ -750,33 +768,6 @@ private struct AvailableSessionsBrowserView: View {
         )
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .accessibilityIdentifier("terminal.sessions.available-browser-view")
-    }
-
-    private var refreshRow: some View {
-        Button {
-            Haptic.tap()
-            onRefresh()
-        } label: {
-            Label {
-                Text(isRefreshing ? "Checking Available Sessions…" : "Refresh Available Sessions")
-            } icon: {
-                if isRefreshing {
-                    ProgressView()
-                        .controlSize(.small)
-                } else {
-                    Image(systemName: "arrow.clockwise")
-                }
-            }
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(TerminalSelectionSheetPalette.secondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(isRefreshing)
-        .sessionSwitcherListRow(
-            accessibilityIdentifier: "terminal.sessions.available-refresh"
-        )
     }
 
     private var matchingSessions: [AvailableSessionSwitcherItem] {

--- a/RemuxApp/Sources/App/SessionSwitcherView.swift
+++ b/RemuxApp/Sources/App/SessionSwitcherView.swift
@@ -168,7 +168,6 @@ struct SessionSwitcherView: View {
     var body: some View {
         NavigationStack(path: $path) {
             sessionList
-                .toolbar(.hidden, for: .navigationBar)
                 .navigationDestination(for: Route.self) { route in
                     switch route {
                     case .chooseServer:
@@ -200,11 +199,10 @@ struct SessionSwitcherView: View {
     }
 
     private var sessionList: some View {
-        TerminalSelectionSheetScaffold(
-            title: "Sessions",
-            context: sessionCountSummary,
-            closeAccessibilityIdentifier: "terminal.sessions.close"
-        ) {
+        VStack(alignment: .leading, spacing: 8) {
+            TerminalSelectionSheetContextLabel(text: sessionCountSummary)
+                .padding(.horizontal, 16)
+
             List {
                 Section {
                     ForEach(projection.activeSessions) { session in
@@ -255,7 +253,7 @@ struct SessionSwitcherView: View {
                             availableSessionsBrowserRow
                         }
                     } header: {
-                        SessionSwitcherSectionHeader(title: "Available")
+                        availableSessionsHeader
                     }
                 }
             }
@@ -265,40 +263,63 @@ struct SessionSwitcherView: View {
             .animation(.snappy, value: projection.availableSessions.map(\.id))
             .animation(.snappy, value: projection.recentSessions.map(\.id))
             .accessibilityIdentifier("terminal.sessions.list")
-        } actions: {
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             TerminalSelectionSheetActionButton(
                 title: "New Session…",
                 systemName: "plus",
                 accessibilityIdentifier: "terminal.sessions.new",
                 action: newSessionAction
             )
+            .frame(height: TerminalSelectionSheetLayout.actionBarHeight)
+            .padding(.horizontal, 16)
+            .padding(.top, TerminalSelectionSheetLayout.contentToActionsSpacing)
+            .padding(.bottom, TerminalSelectionSheetLayout.actionsBottomPadding)
         }
-        .overlay(alignment: .topTrailing) {
-            refreshButton
-                .padding(.top, 10)
-                .padding(.trailing, 16)
+        .navigationTitle("Sessions")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button {
+                    Haptic.tap()
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                }
+                .accessibilityLabel("Close Sessions")
+                .accessibilityIdentifier("terminal.sessions.close")
+            }
         }
     }
 
-    private var refreshButton: some View {
-        Button {
-            Haptic.tap()
-            onRefresh()
-        } label: {
-            Group {
+    private var availableSessionsHeader: some View {
+        HStack(spacing: 8) {
+            SessionSwitcherSectionHeader(title: "Available")
+
+            Spacer(minLength: 0)
+
+            Button {
+                Haptic.tap()
+                onRefresh()
+            } label: {
                 if isRefreshing {
                     ProgressView()
                         .controlSize(.small)
-                        .tint(TerminalSelectionSheetPalette.primary)
+                        .tint(TerminalSelectionSheetPalette.secondary)
                 } else {
                     Image(systemName: "arrow.clockwise")
                 }
             }
-            .compactCircularChromeButtonLabel()
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(TerminalSelectionSheetPalette.secondary)
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .disabled(isRefreshing)
+            .accessibilityLabel(isRefreshing ? "Refreshing Available Sessions" : "Refresh Available Sessions")
+            .accessibilityIdentifier("terminal.sessions.refresh")
         }
-        .disabled(isRefreshing)
-        .accessibilityLabel(isRefreshing ? "Refreshing Sessions" : "Refresh Sessions")
-        .accessibilityIdentifier("terminal.sessions.refresh")
     }
 
     private var sessionCountSummary: String {
@@ -681,6 +702,8 @@ private struct AvailableSessionsBrowserView: View {
 
     var body: some View {
         List {
+            refreshRow
+
             if let failureMessage {
                 Label(failureMessage, systemImage: "exclamationmark.triangle")
                     .foregroundStyle(TerminalSelectionSheetPalette.secondary)
@@ -720,26 +743,6 @@ private struct AvailableSessionsBrowserView: View {
         .navigationTitle("Available Sessions")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    Haptic.tap()
-                    onRefresh()
-                } label: {
-                    if isRefreshing {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Image(systemName: "arrow.clockwise")
-                    }
-                }
-                .disabled(isRefreshing)
-                .accessibilityLabel(
-                    isRefreshing ? "Refreshing Sessions" : "Refresh Sessions"
-                )
-                .accessibilityIdentifier("terminal.sessions.available-refresh")
-            }
-        }
         .searchable(
             text: $query,
             placement: .navigationBarDrawer(displayMode: .always),
@@ -747,6 +750,33 @@ private struct AvailableSessionsBrowserView: View {
         )
         .searchPresentationToolbarBehavior(.avoidHidingContent)
         .accessibilityIdentifier("terminal.sessions.available-browser-view")
+    }
+
+    private var refreshRow: some View {
+        Button {
+            Haptic.tap()
+            onRefresh()
+        } label: {
+            Label {
+                Text(isRefreshing ? "Checking Available Sessions…" : "Refresh Available Sessions")
+            } icon: {
+                if isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                }
+            }
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(TerminalSelectionSheetPalette.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isRefreshing)
+        .sessionSwitcherListRow(
+            accessibilityIdentifier: "terminal.sessions.available-refresh"
+        )
     }
 
     private var matchingSessions: [AvailableSessionSwitcherItem] {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -493,8 +493,6 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 completeKeyboardDidHide()
             }
             .sheet(item: selectionSheetBinding) { sheet in
-                // Every input to this height is independent of the sheet's
-                // current height: spec tokens and grid math from screen width.
                 selectionSheetContent(sheet)
                     .presentationDetents(
                         [.height(selectionSheetHeight(for: sheet))]
@@ -2074,20 +2072,27 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private func selectionSheetHeight(
         for sheet: GhosttySurfaceSelectionSheet
     ) -> CGFloat {
-        var gridHeight: CGFloat
+        let contentHeight: CGFloat
         switch sheet {
         case .windows:
-            gridHeight = PanePreviewLayout.gridIdealHeight(
+            contentHeight = PanePreviewLayout.gridIdealHeight(
                 itemCount: model.windowSelectionSheetRenderProjection().windows.count,
                 metrics: PanePreviewLayout.windowMetricsForCurrentScreen()
             )
         case .panes(let topLevelID, _):
             let projection = model.paneSelectionSheetRenderProjection(topLevelID: topLevelID)
-            gridHeight = PanePreviewLayout.panePickerMetricsForCurrentScreen(
+            contentHeight = PanePreviewLayout.panePickerMetricsForCurrentScreen(
                 itemCount: projection.paneCount
             ).visibleContentHeight
         }
-        return TerminalSelectionSheetLayout.sheetHeight(gridHeight: gridHeight)
+
+        let width = PanePreviewLayout.currentSheetContentWidth()
+        return TerminalSelectionSheetLayout.sheetHeight(
+            contentHeight: contentHeight,
+            navigationBarHeight: TerminalSelectionSheetLayout.nativeNavigationBarHeight(
+                width: width
+            )
+        )
     }
 
     @ViewBuilder

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -24,6 +24,7 @@ enum GhosttySurfaceSelectionSheet: Identifiable {
 }
 
 struct GhosttyWindowSelectionSheet: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
     @ObservedObject var session: GhosttyPanePreviewSession
     @State private var pendingRemoval: GhosttyWindowRemovalRequest?
@@ -39,26 +40,46 @@ struct GhosttyWindowSelectionSheet: View {
     var body: some View {
         let layout = PanePreviewLayout.windowMetricsForCurrentScreen()
 
-        TerminalSelectionSheetScaffold(
-            title: "Windows",
-            context: "\(sessionName) · \(projection.windows.count) \(projection.windows.count == 1 ? "window" : "windows")",
-            closeAccessibilityIdentifier: "terminal.windows.close"
-        ) {
-            ScrollView(showsIndicators: false) {
-                windowGrid(
-                    windows: projection.windows,
-                    layout: layout
+        NavigationStack {
+            TerminalSelectionSheetContent(
+                context: "\(sessionName) · \(projection.windows.count) \(projection.windows.count == 1 ? "window" : "windows")"
+            ) {
+                ScrollView(showsIndicators: false) {
+                    windowGrid(
+                        windows: projection.windows,
+                        layout: layout
+                    )
+                }
+                .frame(
+                    height: PanePreviewLayout.gridIdealHeight(
+                        itemCount: projection.windows.count,
+                        metrics: layout
+                    )
+                )
+                .accessibilityIdentifier("terminal.windows.scroll")
+                .contentMargins(.horizontal, 16, for: .scrollContent)
+            } actions: {
+                TerminalSelectionSheetActionButton(
+                    title: "New Window",
+                    systemName: "plus",
+                    accessibilityIdentifier: "terminal.window.new",
+                    action: onCreateWindow
                 )
             }
-            .accessibilityIdentifier("terminal.windows.scroll")
-            .contentMargins(.horizontal, 16, for: .scrollContent)
-        } actions: {
-            TerminalSelectionSheetActionButton(
-                title: "New Window",
-                systemName: "plus",
-                accessibilityIdentifier: "terminal.window.new",
-                action: onCreateWindow
-            )
+            .navigationTitle("Windows")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        Haptic.tap()
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close Windows")
+                    .accessibilityIdentifier("terminal.windows.close")
+                }
+            }
         }
         .task(id: session.id) {
             session.reconcile(leafIDs: projection.previewLeafIDs)
@@ -194,6 +215,7 @@ struct GhosttyWindowSelectionSheet: View {
 }
 
 struct GhosttyPaneSelectionSheet: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
     @ObservedObject var session: GhosttyPanePreviewSession
     @State private var pendingRemoval: GhosttyPaneRemovalRequest?
@@ -208,47 +230,61 @@ struct GhosttyPaneSelectionSheet: View {
     let onRemovePane: (UUID) -> Void
 
     var body: some View {
-        TerminalSelectionSheetScaffold(
-            title: "Panes",
-            context: "\(projection.paneCount) \(projection.paneCount == 1 ? "pane" : "panes")",
-            closeAccessibilityIdentifier: "terminal.panes.close"
-        ) {
-            panePicker
-                .padding(.horizontal, 16)
-        } actions: {
-            HStack(spacing: 0) {
-                GhosttyPaneSheetActionButton(
-                    title: "Split",
-                    systemName: "arrow.right",
-                    accessibilityLabel: "Split right",
-                    accessibilityIdentifier: "terminal.pane.split.right",
-                    action: onSplitPane
-                )
+        NavigationStack {
+            TerminalSelectionSheetContent(
+                context: "\(projection.paneCount) \(projection.paneCount == 1 ? "pane" : "panes")"
+            ) {
+                panePicker
+                    .padding(.horizontal, 16)
+            } actions: {
+                HStack(spacing: 0) {
+                    GhosttyPaneSheetActionButton(
+                        title: "Split",
+                        systemName: "arrow.right",
+                        accessibilityLabel: "Split right",
+                        accessibilityIdentifier: "terminal.pane.split.right",
+                        action: onSplitPane
+                    )
 
-                GhosttyPaneSheetControlDivider()
-
-                GhosttyPaneSheetActionButton(
-                    title: "Split",
-                    systemName: "arrow.down",
-                    accessibilityLabel: "Split down",
-                    accessibilityIdentifier: "terminal.pane.split.down",
-                    action: onStackPane
-                )
-
-                if projection.paneCount > 1 {
                     GhosttyPaneSheetControlDivider()
 
-                    GhosttyPaneSheetZoomControl(
-                        isOn: Binding(
-                            get: { projection.isServerZoomed },
-                            set: { zoomed in onSetZoomed(zoomed) }
-                        ),
-                        accent: chromeStyle.accent
+                    GhosttyPaneSheetActionButton(
+                        title: "Split",
+                        systemName: "arrow.down",
+                        accessibilityLabel: "Split down",
+                        accessibilityIdentifier: "terminal.pane.split.down",
+                        action: onStackPane
                     )
+
+                    if projection.paneCount > 1 {
+                        GhosttyPaneSheetControlDivider()
+
+                        GhosttyPaneSheetZoomControl(
+                            isOn: Binding(
+                                get: { projection.isServerZoomed },
+                                set: { zoomed in onSetZoomed(zoomed) }
+                            ),
+                            accent: chromeStyle.accent
+                        )
+                    }
+                }
+                .frame(height: TerminalSelectionSheetLayout.actionBarHeight)
+                .terminalSelectionSheetControlGroupSurface()
+            }
+            .navigationTitle("Panes")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        Haptic.tap()
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close Panes")
+                    .accessibilityIdentifier("terminal.panes.close")
                 }
             }
-            .frame(height: TerminalSelectionSheetLayout.actionBarHeight)
-            .terminalSelectionSheetControlGroupSurface()
         }
         .task(id: session.id) {
             // First-render reconcile closes the gap between tap-time session

--- a/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
+++ b/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
@@ -16,27 +16,35 @@ enum TerminalSelectionSheetPalette {
     }
 }
 
-/// Single source of truth for selector-sheet chrome heights. The scaffold
-/// lays its rows out from these tokens and `sheetHeight` sums the same
-/// tokens for the presentation detent, so the sheet always cleanly fits
-/// its content: the views and the height math cannot drift apart.
+/// Shared selector-sheet content geometry beneath system-owned navigation
+/// chrome. Preview regions own their bounded viewport heights; the sheet
+/// derives its presentation size from this content instead of duplicating
+/// the navigation bar's geometry in detent arithmetic.
 enum TerminalSelectionSheetLayout {
-    static let headerTopPadding: CGFloat = 14
-    static let headerHeight: CGFloat = 36
-    static let headerBottomPadding: CGFloat = 12
+    /// Standard iPhone sheet detents place root content eight points below
+    /// the native navigation bar. Custom-height detents don't inherit that
+    /// inset, so fitted selectors supply the same boundary explicitly.
+    static let navigationToContextSpacing: CGFloat = 8
     static let contextHeight: CGFloat = 16
     static let contextToContentSpacing: CGFloat = 12
     static let contentToActionsSpacing: CGFloat = 16
     static let actionBarHeight: CGFloat = 44
     static let actionsBottomPadding: CGFloat = 8
 
-    /// The `.height()` detent excludes the bottom safe area (verified by
-    /// measurement: adding it produced exactly one safe-area of slack), so
-    /// the sum covers only the content rows the scaffold lays out.
-    static func sheetHeight(gridHeight: CGFloat) -> CGFloat {
-        headerTopPadding + headerHeight + headerBottomPadding
-            + contextHeight + contextToContentSpacing
-            + gridHeight
+    @MainActor
+    static func nativeNavigationBarHeight(width: CGFloat) -> CGFloat {
+        UINavigationBar().sizeThatFits(
+            CGSize(width: width, height: .greatestFiniteMagnitude)
+        ).height
+    }
+
+    static func sheetHeight(
+        contentHeight: CGFloat,
+        navigationBarHeight: CGFloat
+    ) -> CGFloat {
+        navigationBarHeight
+            + navigationToContextSpacing + contextHeight + contextToContentSpacing
+            + contentHeight
             + contentToActionsSpacing + actionBarHeight + actionsBottomPadding
     }
 }
@@ -58,85 +66,24 @@ struct TerminalSelectionSheetContextLabel: View {
     }
 }
 
-extension View {
-    func compactCircularChromeButtonLabel() -> some View {
-        self
-            .font(.system(size: 15, weight: .semibold))
-            .foregroundStyle(TerminalSelectionSheetPalette.primary)
-            .frame(width: 36, height: 36)
-            .background(TerminalSelectionSheetPalette.controlFill, in: Circle())
-            .frame(width: 44, height: 44)
-            .contentShape(Rectangle())
-    }
-}
-
-struct TerminalSelectionSheetCloseButton: View {
-    let title: String
-    let accessibilityIdentifier: String
-    let action: () -> Void
-
-    var body: some View {
-        Button {
-            Haptic.tap()
-            action()
-        } label: {
-            Image(systemName: "xmark")
-                .compactCircularChromeButtonLabel()
-        }
-        .accessibilityLabel("Close \(title)")
-        .accessibilityIdentifier(accessibilityIdentifier)
-    }
-}
-
-/// Shared anatomy for the terminal selector sheets. Owns its header (title
-/// and close button) as plain content — no navigation bar — so the sheet's
-/// natural height is fully defined by views the app controls, which is what
-/// lets fitted presentation size the sheet to its content.
-struct TerminalSelectionSheetScaffold<Content: View, Actions: View>: View {
-    @Environment(\.dismiss) private var dismiss
-
-    let title: String
+/// Shared selector anatomy below a native navigation bar.
+struct TerminalSelectionSheetContent<Content: View, Actions: View>: View {
     let context: String
-    let closeAccessibilityIdentifier: String
     let content: Content
     let actions: Actions
 
     init(
-        title: String,
         context: String,
-        closeAccessibilityIdentifier: String,
         @ViewBuilder content: () -> Content,
         @ViewBuilder actions: () -> Actions
     ) {
-        self.title = title
         self.context = context
-        self.closeAccessibilityIdentifier = closeAccessibilityIdentifier
         self.content = content()
         self.actions = actions()
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                TerminalSelectionSheetCloseButton(
-                    title: title,
-                    accessibilityIdentifier: closeAccessibilityIdentifier,
-                    action: dismiss.callAsFunction
-                )
-
-                Spacer(minLength: 0)
-            }
-            .overlay {
-                Text(title)
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(TerminalSelectionSheetPalette.primary)
-                    .lineLimit(1)
-            }
-            .padding(.horizontal, 16)
-            .frame(height: TerminalSelectionSheetLayout.headerHeight)
-            .padding(.top, TerminalSelectionSheetLayout.headerTopPadding)
-            .padding(.bottom, TerminalSelectionSheetLayout.headerBottomPadding)
-
             VStack(alignment: .leading, spacing: TerminalSelectionSheetLayout.contextToContentSpacing) {
                 TerminalSelectionSheetContextLabel(text: context)
                     .padding(.horizontal, 16)
@@ -153,6 +100,7 @@ struct TerminalSelectionSheetScaffold<Content: View, Actions: View>: View {
                 .padding(.top, TerminalSelectionSheetLayout.contentToActionsSpacing)
                 .padding(.bottom, TerminalSelectionSheetLayout.actionsBottomPadding)
         }
+        .padding(.top, TerminalSelectionSheetLayout.navigationToContextSpacing)
     }
 }
 


### PR DESCRIPTION
## Summary

- Use native navigation chrome across the Sessions, Windows, and Panes sheets.
- Align their context labels and pinned bottom actions consistently.
- Keep fitted Window and Pane sheets within the available screen height, with scrolling when their content exceeds it.
- Place session discovery refresh beside the Available section it affects.

## Testing

- Verified Sessions, Available Sessions, Windows, and Panes on a physical iPhone and the iPhone simulator.
- Verified portrait and landscape layouts, fitted heights, scrolling, navigation, and pinned actions.
- Focused session, discovery, and picker-layout tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated session switching with inline navigation, contextual labels, refresh controls, and a close action.
  * Refreshed selection sheets with native navigation, clearer controls, and improved accessibility.
* **Bug Fixes**
  * Improved selection-sheet sizing across screen dimensions and landscape layouts.
  * Preserved more usable content space by accounting for navigation-bar height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->