### PR TITLE
Fix tmux startup resize failure

### DIFF
--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -1254,6 +1254,7 @@ final class RemuxRootModel: ObservableObject {
                 update.workspaceID,
                 in: activeSessions
             ) {
+                claimActiveTmuxViewportIfSelectedAndActive(for: session)
                 let serverID = session.target.server.id
                 let discoveryState = tmuxSessionDiscoveryState(for: serverID)
                 tmuxSessionDiscoveryStates[serverID] = discoveryState
@@ -1292,6 +1293,17 @@ final class RemuxRootModel: ObservableObject {
         terminalScreenModels[TerminalRuntimeAttemptKey(session: session)]?
             .terminalScreenAdapter
             .reclaimActiveTmuxViewport()
+    }
+
+    private func claimActiveTmuxViewportIfSelectedAndActive(
+        for session: ActiveTerminalSession
+    ) {
+        guard currentAppLifecyclePhase == .active,
+              state == .terminal(session.id)
+        else { return }
+        terminalScreenModels[TerminalRuntimeAttemptKey(session: session)]?
+            .terminalScreenAdapter
+            .claimActiveTmuxViewportIfNeeded()
     }
 
     func disconnectActiveSession(_ id: SavedWorkspace.ID) {

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -256,8 +256,8 @@ final class TmuxSessionController: @unchecked Sendable {
     }
 
     /// Construct the native client only after transport.start has opened the
-    /// control channel with the same real viewport. The native initial grid is
-    /// immutable and emits the sole startup refresh-client command.
+    /// control channel. A viewport reported while the transport was opening
+    /// becomes the native initial grid and its sole startup refresh-client.
     func start(
         initialSize: ClientSize,
         completion: @escaping @Sendable (Result<Void, StartError>) -> Void
@@ -267,15 +267,16 @@ final class TmuxSessionController: @unchecked Sendable {
                 completion(.failure(.alreadyStarted))
                 return
             }
-            guard let columns = UInt16(exactly: initialSize.cols),
-                  let rows = UInt16(exactly: initialSize.rows),
+            let startupSize = clientSize ?? initialSize
+            guard let columns = UInt16(exactly: startupSize.cols),
+                  let rows = UInt16(exactly: startupSize.rows),
                   columns > 0,
                   rows > 0
             else {
                 completion(.failure(.invalidInitialGrid))
                 return
             }
-            clientSize = initialSize
+            clientSize = startupSize
 
             var config = ghostty_tmux_client_config_new()
             config.userdata = Unmanaged.passUnretained(self).toOpaque()
@@ -758,6 +759,11 @@ final class TmuxSessionController: @unchecked Sendable {
         }
         let nextSize = ClientSize(cols: cols, rows: rows)
         queue.async { [self] in
+            guard !shuttingDown else { return }
+            guard client != nil else {
+                clientSize = nextSize
+                return
+            }
             var admittedWork = false
             if clientSize != nextSize {
                 guard admitCommandOnWriter(

--- a/RemuxApp/Sources/Tmux/TmuxSessionLink.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionLink.swift
@@ -36,9 +36,9 @@ actor TmuxSessionLink {
         self.outboundContinuation = continuation
     }
 
-    /// Establish the control channel with the real grid, then create the
-    /// native client with that same grid. This order prevents its initial
-    /// refresh/list batch from racing transport opening.
+    /// Establish the control channel before creating the native client. This
+    /// order prevents its initial refresh/list batch from racing transport
+    /// opening; the controller reconciles any newer viewport in its startup.
     func start(viewport: TmuxControlViewport?) async throws {
         guard !stopped else { throw LinkError.stopped }
         guard let viewport else { throw LinkError.missingInitialViewport }

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -646,6 +646,56 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         XCTAssertEqual(harness.recorder.takeStrings(), ["refresh-client -C 100x40\n"])
     }
 
+    func testClientSizeBeforeStartBecomesLatestInitialGrid() async throws {
+        let runtime = try GhosttyKitRuntime()
+        let recorder = ControllerOutboundRecorder()
+        let attaching = expectation(description: "controller started attaching")
+        let controller = TmuxSessionController(
+            callbacks: .init(
+                onState: { state in
+                    if state == .attaching { attaching.fulfill() }
+                },
+                onRequestFailed: { request in
+                    XCTFail("unexpected request failure: \(request)")
+                }
+            )
+        )
+        addTeardownBlock {
+            _ = runtime
+            await withCheckedContinuation { continuation in
+                controller.shutdown { continuation.resume() }
+            }
+        }
+        controller.setOutboundSink { recorder.append($0) }
+        controller.setClientSize(cols: 83, rows: 44, claimActiveViewport: true)
+        controller.setClientSize(cols: 100, rows: 45, claimActiveViewport: true)
+        await drain(controller)
+
+        XCTAssertTrue(recorder.takeStrings().isEmpty)
+
+        try await withCheckedThrowingContinuation { continuation in
+            controller.start(initialSize: .init(cols: 83, rows: 44)) { result in
+                continuation.resume(with: result)
+            }
+        }
+        await fulfillment(of: [attaching], timeout: 1)
+        controller.pump(Data(
+            "%begin 1 1 0\n%end 1 1 0\n%session-changed $42 main\n".utf8
+        ))
+        await drain(controller)
+
+        XCTAssertEqual(
+            recorder.takeStrings(),
+            [
+                "display-message -p '#{version}'\n"
+                    + "refresh-client -C 100x45\n"
+                    + "list-windows -F '#{session_id} #{window_id} #{window_active} "
+                    + "#{pane_id} #{window_width} #{window_height} #{window_layout} "
+                    + "#{window_visible_layout} #{window_name}'\n"
+            ]
+        )
+    }
+
     func testClientSizeRevertPublishesEachDistinctSize() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.onePaneWindow,


### PR DESCRIPTION
## Summary

Fix a startup race that could show `tmux: resize failed` even when the session connected successfully.

Viewport updates received before the native tmux client starts are now retained. The latest viewport becomes the client’s initial grid instead of being sent as a premature resize command.

## Testing

- Added regression coverage for viewport updates during startup.
- Verified the fix against a real tmux session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session startup sizing by applying the latest available viewport dimensions when creating a native client.
  * Preserved size updates received before startup and used them during the initial refresh.
  * Prevented initial refresh and list requests from racing control-channel setup.
  * Synchronized the active terminal viewport when reconnecting or returning to the app.

* **Tests**
  * Added coverage for viewport updates received before session startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->