### PR TITLE
redesign pane picker with labeled topology

### DIFF
--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		00667DCDFC19B202FCDFF8F7 /* GhosttySurfaceSelectionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA2520FAE4E2D228D25CADB /* GhosttySurfaceSelectionSheet.swift */; };
 		017C744C31F059189FA8E489 /* GhosttyRuntimeSurfaceTopologySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76BB5CC730EB26907A34E42 /* GhosttyRuntimeSurfaceTopologySnapshotTests.swift */; };
+		021F179B9FAE8CD2AACFEA2A /* PaneTopologyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FF4A303A3A5273C1B9EEE3 /* PaneTopologyLayout.swift */; };
 		034B17174ABCC1D1DF36C135 /* GhosttyKeyboardCursorTrackpadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFA7B573241258BA93FCF29 /* GhosttyKeyboardCursorTrackpadTests.swift */; };
 		036AB1FE9FEBF1EF99159FD1 /* ShortcutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9987EA1F7B5FDC3A50ECEA /* ShortcutStore.swift */; };
 		03DF1618812075C8E5C9B353 /* GhosttyTerminalInputCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA264E3527C3F2FC33AF435 /* GhosttyTerminalInputCoordinatorTests.swift */; };
@@ -142,6 +143,7 @@
 		A8D2AAE9BEC8E1557E05FD71 /* TerminalSelectionSheetStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFB3839D169808DACE1125F /* TerminalSelectionSheetStyle.swift */; };
 		AA0449DB0EEBE5F640BF6B79 /* GhosttyTerminalInputCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29658D4FE019C12073CC58BE /* GhosttyTerminalInputCoordinator.swift */; };
 		AB2DBE12494A327FBC54FF9D /* GhosttyScrollDeltaBudgetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09E9400D2638AE72F1CEBFB /* GhosttyScrollDeltaBudgetTests.swift */; };
+		AC84CF9933D6859161CCB2A6 /* PaneTopologyLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F647060CF187F304EA04438 /* PaneTopologyLayoutTests.swift */; };
 		B056E6334A9EFBDB7FA305B3 /* TerminalPreviewCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FB23E143EA43A7AB28A323 /* TerminalPreviewCandidateTests.swift */; };
 		B3BF6CDA8110A71C8BDF0F85 /* GhosttyTmuxPrefixInputBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A510F3E8FC22231ACA4A8A99 /* GhosttyTmuxPrefixInputBuffer.swift */; };
 		B64AE1F77F8F69A612E230AD /* GhosttyTerminalResponderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05107088F3540B7C04D2007 /* GhosttyTerminalResponderViewTests.swift */; };
@@ -315,11 +317,13 @@
 		65F7D40090293C627F8A1800 /* GhosttyComposerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyComposerModel.swift; sourceTree = "<group>"; };
 		66D856D8B9DEB50622FCB367 /* GhosttyTerminalDebugLatencyProbeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalDebugLatencyProbeController.swift; sourceTree = "<group>"; };
 		66FB23E143EA43A7AB28A323 /* TerminalPreviewCandidateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPreviewCandidateTests.swift; sourceTree = "<group>"; };
+		66FF4A303A3A5273C1B9EEE3 /* PaneTopologyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTopologyLayout.swift; sourceTree = "<group>"; };
 		693A617C3861CAF780D14828 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6AA39774D73AE5B6A77D824C /* TerminalSettingsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSettingsRepository.swift; sourceTree = "<group>"; };
 		6B19046A43739DE9328A3612 /* TmuxScreenModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxScreenModel.swift; sourceTree = "<group>"; };
 		6B657FFBCF25A6A1A77FD231 /* GhosttyAttachmentImagePreviewDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentImagePreviewDataTests.swift; sourceTree = "<group>"; };
 		6DFE39E14E057AACAB31247A /* GhosttyComposerDictationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyComposerDictationControllerTests.swift; sourceTree = "<group>"; };
+		6F647060CF187F304EA04438 /* PaneTopologyLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTopologyLayoutTests.swift; sourceTree = "<group>"; };
 		7001FC8A87E77C3617046DA7 /* GhosttyRuntimeTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyRuntimeTrace.swift; sourceTree = "<group>"; };
 		700C6FB2B5DB6D0645B1F5FA /* DebugConnectionProfileSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugConnectionProfileSeeder.swift; sourceTree = "<group>"; };
 		71B734F55FC22090646AD0D2 /* GhosttyPendingAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPendingAttachmentTests.swift; sourceTree = "<group>"; };
@@ -548,6 +552,7 @@
 				0A9F4B4B0260131778AB2BA5 /* GhosttyTmuxPrefixInputBufferTests.swift */,
 				532E9E62CF3E74FEE31F5C05 /* GhosttyTopLevelSurfaceTests.swift */,
 				603A62637F1E7C43FD9A1370 /* PanePreviewLayoutTests.swift */,
+				6F647060CF187F304EA04438 /* PaneTopologyLayoutTests.swift */,
 				01FC67667E36CB7A186EFC68 /* RemuxActiveSessionCollectionTests.swift */,
 				03F3C1F4357FDC042F5B6E5C /* RemuxActiveSessionRuntimeReducerTests.swift */,
 				C7313F7C3049C269572F59B5 /* RemuxLibrarySSHPrewarmCoordinatorTests.swift */,
@@ -764,6 +769,7 @@
 				A510F3E8FC22231ACA4A8A99 /* GhosttyTmuxPrefixInputBuffer.swift */,
 				88095738876B31835109065A /* GhosttyTopLevelSurface.swift */,
 				F4748776DB3A0FEF2A152403 /* PanePreviewLayout.swift */,
+				66FF4A303A3A5273C1B9EEE3 /* PaneTopologyLayout.swift */,
 				E4A946B4CBB7E49BCAA7D52B /* ShortcutCollectionIconView.swift */,
 				60FE6CB3913B2DD433F57472 /* ShortcutExecutor.swift */,
 				BC76333B637D49B9A27CB798 /* ShortcutPalette.swift */,
@@ -987,6 +993,7 @@
 				C004B8CB3BEA6B9F5F7C43BF /* Haptic.swift in Sources */,
 				6959353E0AAA65D244C5B077 /* JSONFileStore.swift in Sources */,
 				69B6BE62C46DCA6C8CA9BFBD /* PanePreviewLayout.swift in Sources */,
+				021F179B9FAE8CD2AACFEA2A /* PaneTopologyLayout.swift in Sources */,
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
 				8AEEBAE61E93788016C85F9F /* RemuxApp.swift in Sources */,
@@ -1100,6 +1107,7 @@
 				DED4088C1635F130FC578C91 /* GhosttyTmuxPrefixInputBufferTests.swift in Sources */,
 				584C4529515F7796EFE407C9 /* GhosttyTopLevelSurfaceTests.swift in Sources */,
 				890ADA9AC6BC01F9D619CAD8 /* PanePreviewLayoutTests.swift in Sources */,
+				AC84CF9933D6859161CCB2A6 /* PaneTopologyLayoutTests.swift in Sources */,
 				1378681F54924A5F33A2EF8C /* RemuxActiveSessionCollectionTests.swift in Sources */,
 				A8ABF8A3A082320C5C11BA70 /* RemuxActiveSessionRuntimeReducerTests.swift in Sources */,
 				338BB72DDA774589D60E8D0D /* RemuxLibrarySSHPrewarmCoordinatorTests.swift in Sources */,

--- a/RemuxApp/Sources/Ghostty/GhosttyPanePreviewSession.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyPanePreviewSession.swift
@@ -64,8 +64,7 @@ final class GhosttyPanePreviewSession: ObservableObject {
     let id = UUID()
     @Published private(set) var imagesByPaneID: [UUID: PreviewState] = [:]
 
-    private let displayScale: CGFloat
-    private let previewAvailableWidth: CGFloat
+    private let pixelBudget: PixelBudget
     private let client: PreviewClient
     private var trackedLeafIDs: [UUID]
     private var refreshTask: Task<Void, Never>?
@@ -76,12 +75,10 @@ final class GhosttyPanePreviewSession: ObservableObject {
 
     init(
         leafIDs: [UUID],
-        scale: CGFloat = PanePreviewLayout.currentScale(),
-        previewAvailableWidth: CGFloat,
+        pixelBudget: PixelBudget,
         client: PreviewClient
     ) {
-        displayScale = scale
-        self.previewAvailableWidth = previewAvailableWidth
+        self.pixelBudget = pixelBudget
         self.client = client
         trackedLeafIDs = Self.unique(leafIDs)
         seedCachedImages(for: trackedLeafIDs)
@@ -119,7 +116,7 @@ final class GhosttyPanePreviewSession: ObservableObject {
         generation &+= 1
         let currentGeneration = generation
         let leafIDs = trackedLeafIDs
-        let budget = pixelBudget()
+        let budget = pixelBudget
         cancelActiveCapture()
         refreshTask?.cancel()
         refreshTask = Task { @MainActor [weak self] in
@@ -166,14 +163,6 @@ final class GhosttyPanePreviewSession: ObservableObject {
                 imagesByPaneID[leafID] = .ready(cached)
             }
         }
-    }
-
-    private func pixelBudget() -> PixelBudget {
-        let dimensions = PanePreviewLayout.windowPhysicalPixelBudget(
-            availableWidth: previewAvailableWidth,
-            scale: displayScale
-        )
-        return PixelBudget(width: dimensions.width, height: dimensions.height)
     }
 
     private static func unique(_ leafIDs: [UUID]) -> [UUID] {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -432,7 +432,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             isComposerPresented: isActiveComposerPresented,
                             onShowSessions: onShowSessions,
                             onShowLibrary: onShowLibrary,
-                            onShowWindows: showWindows,
+                            onShowWindows: {
+                                showWindows(availableSize: screenProxy.size)
+                            },
                             onShowPanes: showPanes,
                             onOpenComposer: openComposer,
                             onToggleKeyboard: toggleKeyboardChrome,
@@ -493,6 +495,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 completeKeyboardDidHide()
             }
             .sheet(item: selectionSheetBinding) { sheet in
+                let windowLayout = PanePreviewLayout.windowMetrics(
+                    availableSize: screenProxy.size
+                )
                 let navigationBarHeight = TerminalSelectionSheetLayout.nativeNavigationBarHeight(
                     width: screenProxy.size.width
                 )
@@ -500,11 +505,24 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                     availableHeight: screenProxy.size.height,
                     navigationBarHeight: navigationBarHeight
                 )
+                let paneTopologySize = PaneTopologyLayout.size(
+                    availableWidth: TerminalSelectionSheetLayout.contentWidth(
+                        availableWidth: screenProxy.size.width
+                    ),
+                    maximumHeight: maximumContentHeight
+                )
                 let contentHeight = selectionSheetContentHeight(
                     for: sheet,
+                    windowLayout: windowLayout,
+                    paneTopologySize: paneTopologySize,
                     maximumContentHeight: maximumContentHeight
                 )
-                selectionSheetContent(sheet, contentHeight: contentHeight)
+                selectionSheetContent(
+                    sheet,
+                    windowLayout: windowLayout,
+                    paneTopologySize: paneTopologySize,
+                    contentHeight: contentHeight
+                )
                     .presentationDetents(
                         [.height(TerminalSelectionSheetLayout.sheetHeight(
                             contentHeight: contentHeight,
@@ -1393,22 +1411,31 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         }
     }
 
-    private func showWindows() {
+    private func showWindows(availableSize: CGSize) {
         guard !composer.isSubmitting else { return }
         model.claimActiveTmuxViewportIfNeeded()
         guard let projection = model.windowSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.newWindow", event: "ui.showWindows")
+        let layout = PanePreviewLayout.windowMetrics(availableSize: availableSize)
         applySelectionSheetPresentation(
-            .windows(
-                makeWindowPreviewSession(leafIDs: projection.previewLeafIDs)
-            )
+            .windows(makeWindowPreviewSession(
+                leafIDs: projection.previewLeafIDs,
+                layout: layout
+            ))
         )
     }
 
-    private func makeWindowPreviewSession(leafIDs: [UUID]) -> GhosttyPanePreviewSession {
-        model.makePanePreviewSession(
+    private func makeWindowPreviewSession(
+        leafIDs: [UUID],
+        layout: PanePreviewLayout.Metrics
+    ) -> GhosttyPanePreviewSession {
+        let dimensions = PanePreviewLayout.windowPhysicalPixelBudget(
+            metrics: layout,
+            scale: displayScale
+        )
+        return model.makePanePreviewSession(
             leafIDs: leafIDs,
-            previewAvailableWidth: PanePreviewLayout.currentSheetContentWidth()
+            pixelBudget: .init(width: dimensions.width, height: dimensions.height)
         )
     }
 
@@ -2077,26 +2104,27 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
 
     private func selectionSheetContentHeight(
         for sheet: GhosttySurfaceSelectionSheet,
+        windowLayout: PanePreviewLayout.Metrics,
+        paneTopologySize: CGSize,
         maximumContentHeight: CGFloat
     ) -> CGFloat {
         switch sheet {
         case .windows:
             return PanePreviewLayout.gridIdealHeight(
                 itemCount: model.windowSelectionSheetRenderProjection().windows.count,
-                metrics: PanePreviewLayout.windowMetricsForCurrentScreen(),
+                metrics: windowLayout,
                 maximumContentHeight: maximumContentHeight
             )
         case .panes:
-            return PaneTopologyLayout.size(
-                availableWidth: PanePreviewLayout.currentSheetContentWidth(),
-                maximumHeight: maximumContentHeight
-            ).height
+            return paneTopologySize.height
         }
     }
 
     @ViewBuilder
     private func selectionSheetContent(
         _ sheet: GhosttySurfaceSelectionSheet,
+        windowLayout: PanePreviewLayout.Metrics,
+        paneTopologySize: CGSize,
         contentHeight: CGFloat
     ) -> some View {
         switch sheet {
@@ -2105,6 +2133,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 session: session,
                 projection: model.windowSelectionSheetRenderProjection(),
                 sessionName: presentation.sessionName,
+                layout: windowLayout,
                 contentHeight: contentHeight,
                 commandFailureMessage: selectionSheetCommandFailureMessage,
                 onCreateWindow: createTmuxWindowFromSelectionSheet,
@@ -2115,7 +2144,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         case .panes(let topLevelID):
             GhosttyPaneSelectionSheet(
                 projection: model.paneSelectionSheetRenderProjection(topLevelID: topLevelID),
-                contentHeight: contentHeight,
+                topologySize: paneTopologySize,
                 commandFailureMessage: selectionSheetCommandFailureMessage,
                 onSplitPane: {
                     splitFocusedTmuxPaneFromSelectionSheet(
@@ -2290,7 +2319,7 @@ enum GhosttyViewportSizing {
 private extension Optional where Wrapped == GhosttySurfaceSelectionSheet {
     var traceLabel: String {
         switch self {
-        case .some(.windows(_)):
+        case .some(.windows):
             return "windows"
         case .some(.panes):
             return "panes"

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -1426,9 +1426,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
 
     private func cancelSelectionSheetPreviewSession(_ sheet: GhosttySurfaceSelectionSheet?) {
         switch sheet {
-        case .windows(let session), .panes(_, let session):
+        case .windows(let session):
             session.cancelAll()
-        case .none:
+        case .panes, .none:
             break
         }
     }
@@ -1439,18 +1439,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
         guard let projection = model.selectedPaneSheetPresentationProjection() else { return }
         GhosttyRuntimeTrace.flowEventIfActive("tmux.splitPane", event: "ui.showPanes")
 
-        // Carry the preview session in the sheet payload itself so the pane
-        // sheet never renders against a separate optional state that may lag
-        // the presentation transaction.
         applySelectionSheetPresentation(
-            .panes(
-                topLevelID: projection.topLevelID,
-                previews: model.makePanePreviewSession(
-                    leafIDs: projection.previewLeafIDs,
-                    previewAvailableWidth: PanePreviewLayout.currentSheetContentWidth()
-                )
-            )
+            .panes(topLevelID: projection.topLevelID)
         )
+        model.refreshTmuxPaneMetadata(inTopLevel: projection.topLevelID)
     }
 
     private func updateSelectionSheetViewportHold(
@@ -2094,13 +2086,11 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 metrics: PanePreviewLayout.windowMetricsForCurrentScreen(),
                 maximumContentHeight: maximumContentHeight
             )
-        case .panes(let topLevelID, _):
-            let projection = model.paneSelectionSheetRenderProjection(topLevelID: topLevelID)
-            return PanePreviewLayout.panePickerMetrics(
-                itemCount: projection.paneCount,
+        case .panes:
+            return PaneTopologyLayout.size(
                 availableWidth: PanePreviewLayout.currentSheetContentWidth(),
-                maximumContentHeight: maximumContentHeight
-            ).visibleContentHeight
+                maximumHeight: maximumContentHeight
+            ).height
         }
     }
 
@@ -2122,9 +2112,8 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 onRemoveWindow: closeTmuxWindowFromSelectionSheet
             )
 
-        case .panes(let topLevelID, let session):
+        case .panes(let topLevelID):
             GhosttyPaneSelectionSheet(
-                session: session,
                 projection: model.paneSelectionSheetRenderProjection(topLevelID: topLevelID),
                 contentHeight: contentHeight,
                 commandFailureMessage: selectionSheetCommandFailureMessage,
@@ -2303,7 +2292,7 @@ private extension Optional where Wrapped == GhosttySurfaceSelectionSheet {
         switch self {
         case .some(.windows(_)):
             return "windows"
-        case .some(.panes(_, _)):
+        case .some(.panes):
             return "panes"
         case .none:
             return "none"

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -6,7 +6,7 @@ enum GhosttySurfaceSelectionSheet: Identifiable {
 
     var id: String {
         switch self {
-        case .windows(_):
+        case .windows:
             "windows"
         case .panes(let topLevelID):
             "panes-\(topLevelID.uuidString)"
@@ -15,7 +15,7 @@ enum GhosttySurfaceSelectionSheet: Identifiable {
 
     var paneTopLevelIDForTopologyValidation: UUID? {
         switch self {
-        case .windows(_):
+        case .windows:
             nil
         case .panes(let topLevelID):
             topLevelID
@@ -32,6 +32,7 @@ struct GhosttyWindowSelectionSheet: View {
 
     let projection: GhosttyWindowSelectionSheetRenderProjection
     let sessionName: String
+    let layout: PanePreviewLayout.Metrics
     let contentHeight: CGFloat
     let commandFailureMessage: String?
     let onCreateWindow: (() -> Void)?
@@ -39,8 +40,6 @@ struct GhosttyWindowSelectionSheet: View {
     let onRemoveWindow: (UUID) -> Void
 
     var body: some View {
-        let layout = PanePreviewLayout.windowMetricsForCurrentScreen()
-
         NavigationStack {
             TerminalSelectionSheetContent(
                 context: "\(sessionName) · \(projection.windows.count) \(projection.windows.count == 1 ? "window" : "windows")"
@@ -53,7 +52,11 @@ struct GhosttyWindowSelectionSheet: View {
                 }
                 .frame(height: contentHeight)
                 .accessibilityIdentifier("terminal.windows.scroll")
-                .contentMargins(.horizontal, 16, for: .scrollContent)
+                .contentMargins(
+                    .horizontal,
+                    TerminalSelectionSheetLayout.horizontalContentPadding,
+                    for: .scrollContent
+                )
             } actions: {
                 TerminalSelectionSheetActionButton(
                     title: "New Window",
@@ -217,7 +220,7 @@ struct GhosttyPaneSelectionSheet: View {
     @State private var pendingContextAction: GhosttyPaneRemovalRequest?
 
     let projection: GhosttyPaneSelectionSheetRenderProjection
-    let contentHeight: CGFloat
+    let topologySize: CGSize
     let commandFailureMessage: String?
     let onSplitPane: (() -> Void)?
     let onStackPane: (() -> Void)?
@@ -231,7 +234,10 @@ struct GhosttyPaneSelectionSheet: View {
                 context: "\(projection.paneCount) \(projection.paneCount == 1 ? "pane" : "panes")"
             ) {
                 panePicker
-                    .padding(.horizontal, 16)
+                    .padding(
+                        .horizontal,
+                        TerminalSelectionSheetLayout.horizontalContentPadding
+                    )
             } actions: {
                 HStack(spacing: 0) {
                     GhosttyPaneSheetActionButton(
@@ -316,11 +322,7 @@ struct GhosttyPaneSelectionSheet: View {
     }
 
     private var panePicker: some View {
-        let topologySize = PaneTopologyLayout.size(
-            availableWidth: PanePreviewLayout.currentSheetContentWidth(),
-            maximumHeight: contentHeight
-        )
-        return GhosttyPaneTopologyDiagram(
+        GhosttyPaneTopologyDiagram(
             panes: projection.panes,
             selectedPaneID: projection.selectedPaneID,
             size: topologySize,

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -676,7 +676,7 @@ private struct GhosttyPaneTopologyDiagram: View {
                     accessibilityIdentifier: "terminal.pane.remove.\(pane.id.uuidString)",
                     action: { onRemove(pane) }
                 )
-                .padding(2)
+                .padding(4)
                 .transition(.scale(scale: 0.92).combined(with: .opacity))
             }
         }
@@ -694,7 +694,6 @@ private struct GhosttyPaneTopologyDiagram: View {
                     lineWidth: selected ? 2 : 1
                 )
         }
-        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
     }
 
     private func directoryName(

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceSelectionSheet.swift
@@ -2,14 +2,14 @@ import SwiftUI
 
 enum GhosttySurfaceSelectionSheet: Identifiable {
     case windows(GhosttyPanePreviewSession)
-    case panes(topLevelID: UUID, previews: GhosttyPanePreviewSession)
+    case panes(topLevelID: UUID)
 
     var id: String {
         switch self {
         case .windows(_):
             "windows"
-        case .panes(let topLevelID, let previews):
-            "panes-\(topLevelID.uuidString)-\(previews.id.uuidString)"
+        case .panes(let topLevelID):
+            "panes-\(topLevelID.uuidString)"
         }
     }
 
@@ -17,7 +17,7 @@ enum GhosttySurfaceSelectionSheet: Identifiable {
         switch self {
         case .windows(_):
             nil
-        case .panes(let topLevelID, _):
+        case .panes(let topLevelID):
             topLevelID
         }
     }
@@ -213,7 +213,6 @@ struct GhosttyWindowSelectionSheet: View {
 struct GhosttyPaneSelectionSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.ghosttyTerminalChromeStyle) private var chromeStyle
-    @ObservedObject var session: GhosttyPanePreviewSession
     @State private var pendingRemoval: GhosttyPaneRemovalRequest?
     @State private var pendingContextAction: GhosttyPaneRemovalRequest?
 
@@ -283,19 +282,7 @@ struct GhosttyPaneSelectionSheet: View {
                 }
             }
         }
-        .task(id: session.id) {
-            // First-render reconcile closes the gap between tap-time session
-            // creation and the sheet's initial body render. If pane
-            // membership changed during presentation, the session must align
-            // immediately with the leaf IDs the sheet is actually showing.
-            session.reconcile(leafIDs: projection.previewLeafIDs)
-            await Task.yield()
-            guard !Task.isCancelled else { return }
-            GhosttyRuntimeTrace.perf("panePreview.presentation activate kind=panes")
-            session.startRefreshing()
-        }
-        .onChange(of: projection.previewLeafIDs) { _, newValue in
-            session.reconcile(leafIDs: newValue)
+        .onChange(of: projection.panes.map(\.id)) { _, newValue in
             if let pendingContextAction, !newValue.contains(pendingContextAction.id) {
                 self.pendingContextAction = nil
             }
@@ -329,126 +316,30 @@ struct GhosttyPaneSelectionSheet: View {
     }
 
     private var panePicker: some View {
-        let metrics = PanePreviewLayout.panePickerMetrics(
-            itemCount: projection.paneCount,
+        let topologySize = PaneTopologyLayout.size(
             availableWidth: PanePreviewLayout.currentSheetContentWidth(),
-            maximumContentHeight: contentHeight
+            maximumHeight: contentHeight
         )
-        let topology = paneTopologyMetrics(
-            size: GhosttyPaneTopologyDiagram.contentSize(for: metrics.topologySize)
-        )
-        let panesByID = Dictionary(uniqueKeysWithValues: projection.panes.map { ($0.id, $0) })
-        let orderedPanes = topology?.orderedPaneIDs.compactMap { panesByID[$0] }
-            ?? projection.panes
-        let displayIndices = Dictionary(
-            uniqueKeysWithValues: orderedPanes.enumerated().map { ($0.element.id, $0.offset + 1) }
-        )
-
-        return VStack(spacing: metrics.sectionSpacing) {
-            GhosttyPaneTopologyDiagram(
-                panes: orderedPanes,
-                selectedPaneID: projection.selectedPaneID,
-                layout: topology,
-                displayIndices: displayIndices,
-                size: metrics.topologySize,
-                accent: chromeStyle.selectedStroke,
-                onSelect: { paneID in
-                    Haptic.selection()
-                    pendingContextAction = nil
-                    onSelect(paneID)
-                }
-            )
-
-            if !orderedPanes.isEmpty {
-                ScrollView(showsIndicators: false) {
-                    LazyVGrid(
-                        columns: Array(
-                            repeating: GridItem(
-                                .fixed(metrics.cardSize.width),
-                                spacing: metrics.gridSpacing
-                            ),
-                            count: metrics.columnCount
-                        ),
-                        alignment: .center,
-                        spacing: metrics.gridSpacing
-                    ) {
-                        ForEach(orderedPanes) { pane in
-                            paneCard(
-                                pane,
-                                displayIndex: displayIndices[pane.id] ?? 1,
-                                size: metrics.cardSize
-                            )
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .top)
-                }
-                .frame(height: metrics.cardViewportHeight(itemCount: projection.paneCount))
-                .accessibilityIdentifier("terminal.panes.scroll")
-            }
-        }
-        .frame(height: metrics.visibleContentHeight, alignment: .top)
-        .accessibilityIdentifier("terminal.panes.picker")
-    }
-
-    private func paneCard(
-        _ pane: GhosttyPaneSelectionSheetRenderProjection.Pane,
-        displayIndex: Int,
-        size: CGSize
-    ) -> some View {
-        let request = removalRequest(for: pane)
-
-        return ZStack(alignment: .topTrailing) {
-            Button {
+        return GhosttyPaneTopologyDiagram(
+            panes: projection.panes,
+            selectedPaneID: projection.selectedPaneID,
+            size: topologySize,
+            accent: chromeStyle.selectedStroke,
+            pendingRemovalPaneID: pendingContextAction?.id,
+            onSelect: { paneID in
                 Haptic.selection()
                 pendingContextAction = nil
-                onSelect(pane.id)
-            } label: {
-                GhosttyPanePreviewCard(
-                    displayIndex: displayIndex,
-                    isSelected: pane.isSelected,
-                    state: session.imagesByPaneID[pane.id],
-                    size: size,
-                    chromeStyle: chromeStyle
-                )
+                onSelect(paneID)
+            },
+            onLongPress: { pane in
+                Haptic.warning()
+                pendingContextAction = removalRequest(for: pane)
+            },
+            onRemove: { pane in
+                performRemoval(removalRequest(for: pane))
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("terminal.pane.tile.\(pane.id.uuidString)")
-            .highPriorityGesture(
-                LongPressGesture(minimumDuration: 0.42, maximumDistance: 18)
-                    .onEnded { _ in
-                        Haptic.warning()
-                        pendingContextAction = request
-                    }
-            )
-            .allowsHitTesting(pendingContextAction?.id != pane.id)
-
-            if pendingContextAction?.id == pane.id {
-                GhosttySelectionContextActionButton(
-                    title: "Remove Pane",
-                    accessibilityIdentifier: "terminal.pane.remove.\(pane.id.uuidString)",
-                    action: { performRemoval(request) }
-                )
-                .padding(4)
-                .transition(.scale(scale: 0.92).combined(with: .opacity))
-                .zIndex(1)
-            }
-        }
-        .frame(width: size.width, height: size.height)
-        .animation(.spring(response: 0.24, dampingFraction: 0.82), value: pendingContextAction?.id)
-        .accessibilityAction(named: Text("Remove Pane")) {
-            Haptic.warning()
-            pendingContextAction = request
-        }
-    }
-
-    private func paneTopologyMetrics(
-        size: CGSize
-    ) -> PanePreviewLayout.TopologyMetrics? {
-        let topologyPanes = projection.panes.compactMap { pane in
-            pane.frame.map { PanePreviewLayout.TopologyPane(id: pane.id, frame: $0) }
-        }
-        guard topologyPanes.count == projection.panes.count else { return nil }
-        return PanePreviewLayout.topologyMetrics(panes: topologyPanes, size: size)
+        )
+        .frame(height: topologySize.height, alignment: .top)
     }
 
     private func removalRequest(
@@ -663,53 +554,6 @@ private struct GhosttyWindowSelectionTile: View {
     }
 }
 
-private struct GhosttyPanePreviewCard: View {
-    let displayIndex: Int
-    let isSelected: Bool
-    let state: GhosttyPanePreviewSession.PreviewState?
-    let size: CGSize
-    let chromeStyle: GhosttyTerminalChromeStyle
-
-    var body: some View {
-        previewSurface(size: size)
-            .frame(width: size.width, height: size.height)
-            .terminalSelectionTileChrome(isSelected: isSelected, chromeStyle: chromeStyle)
-            .overlay(alignment: .topLeading) {
-                GhosttyPreviewIndexBadge(
-                    displayIndex: displayIndex,
-                    isSelected: isSelected,
-                    chromeStyle: chromeStyle
-                )
-                    .padding(8)
-            }
-            .contentShape(Rectangle())
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityValue(state.accessibilityValue)
-            .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
-    }
-
-    private var accessibilityLabel: String {
-        isSelected ? "Pane \(displayIndex), selected" : "Pane \(displayIndex)"
-    }
-
-    @ViewBuilder
-    private func previewSurface(size: CGSize) -> some View {
-        switch state {
-        case .ready(let preview):
-            Image(decorative: preview.image, scale: PanePreviewLayout.currentScale())
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: size.width, height: size.height)
-                .clipped()
-
-        case .pending, .none, .failed:
-            Color.black.opacity(0.30)
-                .frame(width: size.width, height: size.height)
-        }
-    }
-}
-
 private struct GhosttyPreviewIndexBadge: View {
     let displayIndex: Int
     let isSelected: Bool
@@ -747,11 +591,12 @@ private struct GhosttyPaneTopologyDiagram: View {
 
     let panes: [GhosttyPaneSelectionSheetRenderProjection.Pane]
     let selectedPaneID: UUID?
-    let layout: PanePreviewLayout.TopologyMetrics?
-    let displayIndices: [UUID: Int]
     let size: CGSize
     let accent: Color
+    let pendingRemovalPaneID: UUID?
     let onSelect: (UUID) -> Void
+    let onLongPress: (GhosttyPaneSelectionSheetRenderProjection.Pane) -> Void
+    let onRemove: (GhosttyPaneSelectionSheetRenderProjection.Pane) -> Void
 
     static func contentSize(for outerSize: CGSize) -> CGSize {
         CGSize(
@@ -760,65 +605,30 @@ private struct GhosttyPaneTopologyDiagram: View {
         )
     }
 
-    var body: some View {
-        Canvas { context, _ in
-            guard let layout else { return }
-            for pane in panes {
-                guard let frame = layout.frame(for: pane.id) else { continue }
-                let tile = frame.insetBy(dx: Self.tileInset, dy: Self.tileInset)
-                let radius = min(6, min(tile.width, tile.height) * 0.18)
-                let path = Path(roundedRect: tile, cornerRadius: max(1, radius))
-                let selected = pane.id == selectedPaneID
-                context.fill(
-                    path,
-                    with: .color(
-                        selected
-                            ? accent.opacity(0.24)
-                            : TerminalSelectionSheetPalette.row.opacity(0.84)
-                    )
-                )
-                context.stroke(
-                    path,
-                    with: .color(selected ? accent : TerminalSelectionSheetPalette.stroke),
-                    lineWidth: selected ? 2 : 1
-                )
-
-                if let displayIndex = displayIndices[pane.id] {
-                    let labelSize = min(16, max(10, min(tile.width, tile.height) * 0.34))
-                    let label = context.resolve(
-                        Text("\(displayIndex)")
-                            .font(.system(size: labelSize, weight: .bold, design: .rounded))
-                            .foregroundStyle(
-                                selected ? accent : TerminalSelectionSheetPalette.primary
-                            )
-                    )
-                    context.draw(
-                        label,
-                        at: CGPoint(x: tile.midX, y: tile.midY),
-                        anchor: .center
-                    )
-                }
-            }
+    private var layout: PaneTopologyLayout.Frames? {
+        let topologyPanes = panes.compactMap { pane in
+            pane.frame.map { PaneTopologyLayout.Pane(id: pane.id, frame: $0) }
         }
-        .frame(width: Self.contentSize(for: size).width, height: Self.contentSize(for: size).height)
-        .overlay(alignment: .topLeading) {
+        guard topologyPanes.count == panes.count else { return nil }
+        return PaneTopologyLayout.frames(
+            panes: topologyPanes,
+            size: Self.contentSize(for: size)
+        )
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
             if let layout {
                 ForEach(panes) { pane in
                     if let frame = layout.frame(for: pane.id) {
                         let tile = frame.insetBy(dx: Self.tileInset, dy: Self.tileInset)
-                        Button {
-                            onSelect(pane.id)
-                        } label: {
-                            Color.clear
-                                .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .frame(width: tile.width, height: tile.height)
-                        .offset(x: tile.minX, y: tile.minY)
+                        paneTile(for: pane, size: tile.size)
+                            .position(x: tile.midX, y: tile.midY)
                     }
                 }
             }
         }
+        .frame(width: Self.contentSize(for: size).width, height: Self.contentSize(for: size).height)
         .padding(Self.contentInset)
         .frame(width: size.width, height: size.height)
         .background(
@@ -829,8 +639,108 @@ private struct GhosttyPaneTopologyDiagram: View {
             RoundedRectangle(cornerRadius: Self.outerCornerRadius, style: .continuous)
                 .strokeBorder(TerminalSelectionSheetPalette.stroke, lineWidth: 1)
         }
-        .accessibilityIdentifier("terminal.panes.topology")
-        .accessibilityHidden(true)
+        .animation(.spring(response: 0.24, dampingFraction: 0.82), value: pendingRemovalPaneID)
+    }
+
+    private func paneTile(
+        for pane: GhosttyPaneSelectionSheetRenderProjection.Pane,
+        size: CGSize
+    ) -> some View {
+        let selected = pane.id == selectedPaneID
+        let radius = max(1, min(6, min(size.width, size.height) * 0.18))
+
+        return ZStack(alignment: .topTrailing) {
+            Button {
+                onSelect(pane.id)
+            } label: {
+                paneLabel(for: pane, size: size)
+            }
+            .buttonStyle(.plain)
+            .highPriorityGesture(
+                LongPressGesture(minimumDuration: 0.42, maximumDistance: 18)
+                    .onEnded { _ in onLongPress(pane) }
+            )
+            .allowsHitTesting(pendingRemovalPaneID != pane.id)
+            .accessibilityIdentifier("terminal.pane.tile.\(pane.id.uuidString)")
+            .accessibilityLabel(accessibilityLabel(for: pane))
+            .accessibilityAddTraits(selected ? .isSelected : [])
+            .accessibilityAction(named: Text("Remove Pane")) {
+                onLongPress(pane)
+            }
+
+            if pendingRemovalPaneID == pane.id {
+                GhosttySelectionContextActionButton(
+                    title: "Remove Pane",
+                    accessibilityIdentifier: "terminal.pane.remove.\(pane.id.uuidString)",
+                    action: { onRemove(pane) }
+                )
+                .padding(2)
+                .transition(.scale(scale: 0.92).combined(with: .opacity))
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .background(
+            selected
+                ? accent.opacity(0.24)
+                : TerminalSelectionSheetPalette.row.opacity(0.84),
+            in: RoundedRectangle(cornerRadius: radius, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .strokeBorder(
+                    selected ? accent : TerminalSelectionSheetPalette.stroke,
+                    lineWidth: selected ? 2 : 1
+                )
+        }
+        .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+    }
+
+    private func directoryName(
+        _ pane: GhosttyPaneSelectionSheetRenderProjection.Pane
+    ) -> String {
+        guard !pane.tmuxCurrentPath.isEmpty else { return "—" }
+        let name = (pane.tmuxCurrentPath as NSString).lastPathComponent
+        return name.isEmpty ? pane.tmuxCurrentPath : name
+    }
+
+    private func paneLabel(
+        for pane: GhosttyPaneSelectionSheetRenderProjection.Pane,
+        size: CGSize
+    ) -> some View {
+        VStack(spacing: 2) {
+            Text(directoryName(pane))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(
+                    pane.id == selectedPaneID
+                        ? accent
+                        : TerminalSelectionSheetPalette.primary
+                )
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Text(commandName(for: pane))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(TerminalSelectionSheetPalette.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .multilineTextAlignment(.center)
+        .frame(width: max(0, size.width - 16))
+        .frame(width: size.width, height: size.height, alignment: .center)
+        .clipped()
+        .contentShape(Rectangle())
+    }
+
+    private func commandName(
+        for pane: GhosttyPaneSelectionSheetRenderProjection.Pane
+    ) -> String {
+        pane.tmuxCurrentCommand.isEmpty ? "—" : pane.tmuxCurrentCommand
+    }
+
+    private func accessibilityLabel(
+        for pane: GhosttyPaneSelectionSheetRenderProjection.Pane
+    ) -> String {
+        "\(directoryName(pane)), \(commandName(for: pane))"
     }
 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalPresentationProjector.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalPresentationProjector.swift
@@ -413,6 +413,8 @@ struct GhosttyTerminalViewportPresentationProjection: Equatable {
         let normalFrame: GhosttyTerminalGridRect
         let visibleFrame: GhosttyTerminalGridRect?
         let isFocused: Bool
+        let tmuxCurrentCommand: String
+        let tmuxCurrentPath: String
     }
 
     static let empty = GhosttyTerminalViewportPresentationProjection(
@@ -461,7 +463,6 @@ struct GhosttyWindowSheetPresentationProjection: Equatable, Sendable {
 
 struct GhosttyPaneSheetPresentationProjection: Equatable, Sendable {
     let topLevelID: UUID
-    let previewLeafIDs: [UUID]
 }
 
 struct GhosttyPaneSelectionSheetTopologyProjection: Equatable, Sendable {
@@ -488,17 +489,16 @@ struct GhosttyWindowSelectionSheetRenderProjection: Equatable, Sendable {
 struct GhosttyPaneSelectionSheetRenderProjection: Equatable, Sendable {
     struct Pane: Identifiable, Equatable, Sendable {
         let id: UUID
-        let isSelected: Bool
         let frame: GhosttyTerminalGridRect?
+        let tmuxCurrentCommand: String
+        let tmuxCurrentPath: String
     }
 
-    let topLevelID: UUID
     let panes: [Pane]
     let selectedPaneID: UUID?
-    let previewLeafIDs: [UUID]
-    let paneCount: Int
-    let windowGrid: GhosttyTerminalGridSize?
     let isServerZoomed: Bool
+
+    var paneCount: Int { panes.count }
 }
 
 @MainActor
@@ -643,10 +643,7 @@ enum GhosttyTerminalPresentationProjector {
     ) -> GhosttyPaneSheetPresentationProjection? {
         guard let topLevel = snapshot.selectedTopLevel else { return nil }
 
-        return GhosttyPaneSheetPresentationProjection(
-            topLevelID: topLevel.id,
-            previewLeafIDs: topLevel.leafIDs
-        )
+        return GhosttyPaneSheetPresentationProjection(topLevelID: topLevel.id)
     }
 
     static func paneCount(
@@ -713,12 +710,8 @@ enum GhosttyTerminalPresentationProjector {
     ) -> GhosttyPaneSelectionSheetRenderProjection {
         guard let topLevel = snapshot.topLevels.first(where: { $0.id == topLevelID }) else {
             return GhosttyPaneSelectionSheetRenderProjection(
-                topLevelID: topLevelID,
                 panes: [],
                 selectedPaneID: nil,
-                previewLeafIDs: [],
-                paneCount: 0,
-                windowGrid: nil,
                 isServerZoomed: false
             )
         }
@@ -726,25 +719,21 @@ enum GhosttyTerminalPresentationProjector {
         let selectedPaneID = viewport?.focusedSurfaceID.flatMap { focusedID in
             topLevel.leafIDs.contains(focusedID) ? focusedID : nil
         } ?? topLevel.resolvedFocusedLeafID
-        let paneCount = topLevel.leafIDs.count
         let viewportPanesByID = Dictionary(
             uniqueKeysWithValues: (viewport?.panes ?? []).map { ($0.id, $0) }
         )
         let panes = topLevel.leafIDs.map { paneID in
             GhosttyPaneSelectionSheetRenderProjection.Pane(
                 id: paneID,
-                isSelected: paneID == selectedPaneID,
-                frame: viewportPanesByID[paneID]?.normalFrame
+                frame: viewportPanesByID[paneID]?.normalFrame,
+                tmuxCurrentCommand: viewportPanesByID[paneID]?.tmuxCurrentCommand ?? "",
+                tmuxCurrentPath: viewportPanesByID[paneID]?.tmuxCurrentPath ?? ""
             )
         }
 
         return GhosttyPaneSelectionSheetRenderProjection(
-            topLevelID: topLevelID,
             panes: panes,
             selectedPaneID: selectedPaneID,
-            previewLeafIDs: topLevel.leafIDs,
-            paneCount: paneCount,
-            windowGrid: viewport?.windowGrid,
             isServerZoomed: viewport?.isServerZoomed ?? false
         )
     }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
@@ -178,7 +178,7 @@ protocol GhosttyTmuxActionModeling: ObservableObject {
 protocol GhosttyTmuxSelectionModeling: ObservableObject {
     func makePanePreviewSession(
         leafIDs: [UUID],
-        previewAvailableWidth: CGFloat
+        pixelBudget: GhosttyPanePreviewSession.PixelBudget
     ) -> GhosttyPanePreviewSession
 
     // MARK: Selection sheets

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalScreenModeling.swift
@@ -130,6 +130,8 @@ protocol GhosttyTmuxActionModeling: ObservableObject {
 
     func claimActiveTmuxViewportIfNeeded()
 
+    func refreshTmuxPaneMetadata(inTopLevel id: UUID)
+
     @discardableResult
     func focusTmuxPane(_ id: UUID) -> GhosttyTmuxModelActionOutcome
 

--- a/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
+++ b/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
@@ -4,18 +4,17 @@ import UIKit
 /// Single source of truth for window-preview geometry and capture budgets.
 ///
 /// Used by:
-/// - `GhosttyPanePreviewSession` for the local image budget
+/// - the screen when creating a preview session
 /// - the window selection sheet for preview placement
 ///
-/// Capture once per session at session-init time. Rotation while a selection
-/// sheet is open does not justify reissuing previews; we keep the originally
-/// requested image regardless.
+/// Capture resolves once when the picker opens. Rendering and sheet sizing use
+/// the live available size, so rotation updates the grid without recapturing
+/// the existing 4:3 preview images.
 enum PanePreviewLayout {
     struct Metrics: Equatable {
         let columnCount: Int
         let tilePointSize: CGSize
-        /// Snapshot budget remains independent from the visual card size.
-        /// Card chrome can change without increasing renderer work.
+        /// Terminal image size inside the card, before display scaling.
         let capturePointSize: CGSize
         let gridSpacing: CGFloat
 
@@ -60,50 +59,44 @@ enum PanePreviewLayout {
         return min(heightWithPeek, fullHeight, budget)
     }
 
-    private static let defaultSheetContentWidth: CGFloat = 361
-    private static let sheetHorizontalPadding: CGFloat = 32
     private static let defaultPreviewAspectRatio: CGFloat = 4.0 / 3.0
     private static let previewCaptureHorizontalInset: CGFloat = 8
-    private static let previewCardHeightRatio: CGFloat = 1.10
+    private static let portraitCardHeightRatio: CGFloat = 1.10
+    private static let landscapeCardHeightRatio: CGFloat = 3.0 / 4.0
 
-    /// Window grid uses a fixed two-column layout. The "New Window" affordance
-    /// is a fixed sheet action, not a trailing grid cell, so dense sessions can
-    /// scroll windows without hiding the create command.
-    private static let windowGridColumnCount: Int = 2
+    /// The "New Window" affordance is a fixed sheet action, not a trailing grid
+    /// cell, so dense sessions can scroll without hiding the create command.
+    private static let portraitColumnCount: Int = 2
+    private static let landscapeColumnCount: Int = 3
     private static let windowGridSpacing: CGFloat = 10
 
-    /// Display scale captured once at session init. Avoids touching
-    /// UIScreen.main during request construction or rendering.
+    /// Fallback image scale for previews rendered outside an environment-backed
+    /// screen view.
     @MainActor
     static func currentScale() -> CGFloat {
         let scale = UIScreen.main.scale
         return scale.isFinite && scale > 0 ? scale : 1
     }
 
-    @MainActor
-    static func currentSheetContentWidth() -> CGFloat {
-        let width = UIScreen.main.bounds.width - sheetHorizontalPadding
-        return width.isFinite && width > 0 ? width : defaultSheetContentWidth
-    }
-
-    @MainActor
-    static func windowMetricsForCurrentScreen() -> Metrics {
-        windowMetrics(availableWidth: currentSheetContentWidth())
-    }
-
     static func windowMetrics(
-        availableWidth: CGFloat
+        availableSize: CGSize
     ) -> Metrics {
-        let safeAvailableWidth = max(availableWidth, 1)
-        let columnCount = windowGridColumnCount
+        let contentWidth = TerminalSelectionSheetLayout.contentWidth(
+            availableWidth: availableSize.width
+        )
+        let usesLandscapeLayout = availableSize.width > availableSize.height
+        let columnCount = usesLandscapeLayout ? landscapeColumnCount : portraitColumnCount
+        let cardHeightRatio = usesLandscapeLayout
+            ? landscapeCardHeightRatio
+            : portraitCardHeightRatio
         let totalGridSpacing = CGFloat(columnCount - 1) * windowGridSpacing
         let tileWidth = max(
             1,
-            floor((safeAvailableWidth - totalGridSpacing) / CGFloat(columnCount))
+            floor((contentWidth - totalGridSpacing) / CGFloat(columnCount))
         )
         let captureWidth = max(1, tileWidth - previewCaptureHorizontalInset * 2)
         let captureHeight = ceil(captureWidth / defaultPreviewAspectRatio)
-        let tileHeight = ceil(tileWidth * previewCardHeightRatio)
+        let tileHeight = ceil(tileWidth * cardHeightRatio)
         return .init(
             columnCount: columnCount,
             tilePointSize: CGSize(width: tileWidth, height: tileHeight),
@@ -113,10 +106,9 @@ enum PanePreviewLayout {
     }
 
     static func windowPhysicalPixelBudget(
-        availableWidth: CGFloat,
+        metrics: Metrics,
         scale: CGFloat
     ) -> (width: UInt32, height: UInt32) {
-        let metrics = windowMetrics(availableWidth: availableWidth)
         let safeScale = max(scale, 1)
         let widthPx = (metrics.capturePointSize.width * safeScale).rounded(.up)
         let heightPx = (metrics.capturePointSize.height * safeScale).rounded(.up)

--- a/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
+++ b/RemuxApp/Sources/Ghostty/PanePreviewLayout.swift
@@ -1,53 +1,16 @@
 import CoreGraphics
 import UIKit
 
-/// Single source of truth for terminal preview geometry and capture budgets.
+/// Single source of truth for window-preview geometry and capture budgets.
 ///
 /// Used by:
 /// - `GhosttyPanePreviewSession` for the local image budget
-/// - the window and pane selection sheets for preview placement
+/// - the window selection sheet for preview placement
 ///
 /// Capture once per session at session-init time. Rotation while a selection
 /// sheet is open does not justify reissuing previews; we keep the originally
 /// requested image regardless.
 enum PanePreviewLayout {
-    struct TopologyPane: Equatable {
-        let id: UUID
-        let frame: GhosttyTerminalGridRect
-    }
-
-    struct TopologyMetrics: Equatable {
-        let framesByPaneID: [UUID: CGRect]
-        let orderedPaneIDs: [UUID]
-
-        func frame(for paneID: UUID) -> CGRect? {
-            framesByPaneID[paneID]
-        }
-    }
-
-    struct PanePickerMetrics: Equatable {
-        let topologySize: CGSize
-        let cardSize: CGSize
-        let columnCount: Int
-        let gridSpacing: CGFloat
-        let sectionSpacing: CGFloat
-        let visibleContentHeight: CGFloat
-
-        func gridHeight(itemCount: Int) -> CGFloat {
-            guard itemCount > 0 else { return 0 }
-            let rows = (itemCount + columnCount - 1) / columnCount
-            return CGFloat(rows) * cardSize.height
-                + CGFloat(rows - 1) * gridSpacing
-        }
-
-        func cardViewportHeight(itemCount: Int) -> CGFloat {
-            min(
-                gridHeight(itemCount: itemCount),
-                max(1, visibleContentHeight - topologySize.height - sectionSpacing)
-            )
-        }
-    }
-
     struct Metrics: Equatable {
         let columnCount: Int
         let tilePointSize: CGSize
@@ -109,10 +72,6 @@ enum PanePreviewLayout {
     private static let windowGridColumnCount: Int = 2
     private static let windowGridSpacing: CGFloat = 10
 
-    private static let panePickerColumnCount: Int = 2
-    private static let panePickerGridSpacing: CGFloat = 10
-    private static let panePickerSectionSpacing: CGFloat = 12
-
     /// Display scale captured once at session init. Avoids touching
     /// UIScreen.main during request construction or rendering.
     @MainActor
@@ -125,63 +84,6 @@ enum PanePreviewLayout {
     static func currentSheetContentWidth() -> CGFloat {
         let width = UIScreen.main.bounds.width - sheetHorizontalPadding
         return width.isFinite && width > 0 ? width : defaultSheetContentWidth
-    }
-
-    static func panePickerMetrics(
-        itemCount: Int,
-        availableWidth: CGFloat,
-        maximumContentHeight: CGFloat
-    ) -> PanePickerMetrics {
-        let safeWidth = max(1, availableWidth)
-        let totalGridSpacing = CGFloat(panePickerColumnCount - 1) * panePickerGridSpacing
-        let cardWidth = max(
-            1,
-            floor((safeWidth - totalGridSpacing) / CGFloat(panePickerColumnCount))
-        )
-        let cardHeight = ceil(cardWidth * previewCardHeightRatio)
-        let topologyHeight = min(112, max(88, safeWidth * 0.28))
-        let topologySize = CGSize(width: safeWidth, height: topologyHeight)
-        let rows = max(0, (itemCount + panePickerColumnCount - 1) / panePickerColumnCount)
-        let fullGridHeight: CGFloat = if rows == 0 {
-            0
-        } else {
-            CGFloat(rows) * cardHeight
-                + CGFloat(rows - 1) * panePickerGridSpacing
-        }
-        let fullContentHeight = topologyHeight
-            + (rows == 0 ? 0 : panePickerSectionSpacing + fullGridHeight)
-
-        return PanePickerMetrics(
-            topologySize: topologySize,
-            cardSize: CGSize(width: cardWidth, height: cardHeight),
-            columnCount: panePickerColumnCount,
-            gridSpacing: panePickerGridSpacing,
-            sectionSpacing: panePickerSectionSpacing,
-            visibleContentHeight: min(max(0, maximumContentHeight), fullContentHeight)
-        )
-    }
-
-    static func topologyMetrics(
-        panes: [TopologyPane],
-        size: CGSize
-    ) -> TopologyMetrics? {
-        guard size.width.isFinite, size.width > 0,
-              size.height.isFinite, size.height > 0,
-              let topology = PaneTopology(panes: panes)
-        else { return nil }
-
-        var framesByPaneID: [UUID: CGRect] = [:]
-        topology.place(
-            in: CGRect(origin: .zero, size: size),
-            framesByPaneID: &framesByPaneID
-        )
-        var orderedPaneIDs: [UUID] = []
-        orderedPaneIDs.reserveCapacity(panes.count)
-        topology.appendPaneIDs(to: &orderedPaneIDs)
-        return TopologyMetrics(
-            framesByPaneID: framesByPaneID,
-            orderedPaneIDs: orderedPaneIDs
-        )
     }
 
     @MainActor
@@ -230,137 +132,4 @@ enum PanePreviewLayout {
         return max(1, UInt32(clamped))
     }
 
-    private indirect enum PaneTopology {
-        case pane(UUID)
-        case split(Axis, PaneTopology, PaneTopology)
-
-        enum Axis {
-            case horizontal
-            case vertical
-        }
-
-        init?(panes: [TopologyPane]) {
-            guard !panes.isEmpty else { return nil }
-            if panes.count == 1 {
-                self = .pane(panes[0].id)
-                return
-            }
-
-            if let groups = Self.partition(panes, axis: .horizontal),
-               let first = PaneTopology(panes: groups.0),
-               let second = PaneTopology(panes: groups.1) {
-                self = .split(.horizontal, first, second)
-                return
-            }
-            if let groups = Self.partition(panes, axis: .vertical),
-               let first = PaneTopology(panes: groups.0),
-               let second = PaneTopology(panes: groups.1) {
-                self = .split(.vertical, first, second)
-                return
-            }
-            return nil
-        }
-
-        private var paneCount: Int {
-            switch self {
-            case .pane:
-                1
-            case .split(_, let first, let second):
-                first.paneCount + second.paneCount
-            }
-        }
-
-        func place(
-            in frame: CGRect,
-            framesByPaneID: inout [UUID: CGRect]
-        ) {
-            switch self {
-            case .pane(let id):
-                framesByPaneID[id] = frame
-
-            case .split(let axis, let first, let second):
-                let firstFraction = CGFloat(first.paneCount) / CGFloat(paneCount)
-                let firstFrame: CGRect
-                let secondFrame: CGRect
-                switch axis {
-                case .horizontal:
-                    let firstWidth = frame.width * firstFraction
-                    firstFrame = CGRect(
-                        x: frame.minX,
-                        y: frame.minY,
-                        width: firstWidth,
-                        height: frame.height
-                    )
-                    secondFrame = CGRect(
-                        x: firstFrame.maxX,
-                        y: frame.minY,
-                        width: frame.width - firstWidth,
-                        height: frame.height
-                    )
-
-                case .vertical:
-                    let firstHeight = frame.height * firstFraction
-                    firstFrame = CGRect(
-                        x: frame.minX,
-                        y: frame.minY,
-                        width: frame.width,
-                        height: firstHeight
-                    )
-                    secondFrame = CGRect(
-                        x: frame.minX,
-                        y: firstFrame.maxY,
-                        width: frame.width,
-                        height: frame.height - firstHeight
-                    )
-                }
-                first.place(in: firstFrame, framesByPaneID: &framesByPaneID)
-                second.place(in: secondFrame, framesByPaneID: &framesByPaneID)
-            }
-        }
-
-        func appendPaneIDs(to paneIDs: inout [UUID]) {
-            switch self {
-            case .pane(let id):
-                paneIDs.append(id)
-            case .split(_, let first, let second):
-                first.appendPaneIDs(to: &paneIDs)
-                second.appendPaneIDs(to: &paneIDs)
-            }
-        }
-
-        private static func partition(
-            _ panes: [TopologyPane],
-            axis: Axis
-        ) -> ([TopologyPane], [TopologyPane])? {
-            let sorted = panes.sorted {
-                axis == .horizontal
-                    ? $0.frame.x < $1.frame.x
-                    : $0.frame.y < $1.frame.y
-            }
-            for index in 1..<sorted.count {
-                let first = Array(sorted[..<index])
-                let second = Array(sorted[index...])
-                let firstEnd = first.map {
-                    axis == .horizontal ? $0.maxX : $0.maxY
-                }.max() ?? 0
-                let secondStart = second.map {
-                    axis == .horizontal ? $0.frame.x : $0.frame.y
-                }.min() ?? 0
-                if firstEnd < UInt64(secondStart) {
-                    return (first, second)
-                }
-            }
-            return nil
-        }
-    }
-}
-
-private extension PanePreviewLayout.TopologyPane {
-    var maxX: UInt64 {
-        UInt64(frame.x) + UInt64(frame.columns)
-    }
-
-    var maxY: UInt64 {
-        UInt64(frame.y) + UInt64(frame.rows)
-    }
 }

--- a/RemuxApp/Sources/Ghostty/PaneTopologyLayout.swift
+++ b/RemuxApp/Sources/Ghostty/PaneTopologyLayout.swift
@@ -1,0 +1,168 @@
+import CoreGraphics
+import Foundation
+
+/// Normalizes tmux pane geometry into equal-weight topology tiles.
+enum PaneTopologyLayout {
+    struct Pane: Equatable {
+        let id: UUID
+        let frame: GhosttyTerminalGridRect
+    }
+
+    struct Frames: Equatable {
+        let byPaneID: [UUID: CGRect]
+
+        func frame(for paneID: UUID) -> CGRect? {
+            byPaneID[paneID]
+        }
+    }
+
+    static func size(
+        availableWidth: CGFloat,
+        maximumHeight: CGFloat
+    ) -> CGSize {
+        let width = max(1, availableWidth)
+        let height = min(max(0, maximumHeight), ceil(width * 0.75))
+        return CGSize(width: width, height: height)
+    }
+
+    static func frames(
+        panes: [Pane],
+        size: CGSize
+    ) -> Frames? {
+        guard size.width.isFinite, size.width > 0,
+              size.height.isFinite, size.height > 0,
+              let topology = Topology(panes: panes)
+        else { return nil }
+
+        var framesByPaneID: [UUID: CGRect] = [:]
+        topology.place(
+            in: CGRect(origin: .zero, size: size),
+            framesByPaneID: &framesByPaneID
+        )
+        return Frames(byPaneID: framesByPaneID)
+    }
+
+    private indirect enum Topology {
+        case pane(UUID)
+        case split(Axis, Topology, Topology)
+
+        enum Axis {
+            case horizontal
+            case vertical
+        }
+
+        init?(panes: [Pane]) {
+            guard !panes.isEmpty else { return nil }
+            if panes.count == 1 {
+                self = .pane(panes[0].id)
+                return
+            }
+
+            if let groups = Self.partition(panes, axis: .horizontal),
+               let first = Topology(panes: groups.0),
+               let second = Topology(panes: groups.1) {
+                self = .split(.horizontal, first, second)
+                return
+            }
+            if let groups = Self.partition(panes, axis: .vertical),
+               let first = Topology(panes: groups.0),
+               let second = Topology(panes: groups.1) {
+                self = .split(.vertical, first, second)
+                return
+            }
+            return nil
+        }
+
+        private var paneCount: Int {
+            switch self {
+            case .pane:
+                1
+            case .split(_, let first, let second):
+                first.paneCount + second.paneCount
+            }
+        }
+
+        func place(
+            in frame: CGRect,
+            framesByPaneID: inout [UUID: CGRect]
+        ) {
+            switch self {
+            case .pane(let id):
+                framesByPaneID[id] = frame
+
+            case .split(let axis, let first, let second):
+                let firstFraction = CGFloat(first.paneCount) / CGFloat(paneCount)
+                let firstFrame: CGRect
+                let secondFrame: CGRect
+                switch axis {
+                case .horizontal:
+                    let firstWidth = frame.width * firstFraction
+                    firstFrame = CGRect(
+                        x: frame.minX,
+                        y: frame.minY,
+                        width: firstWidth,
+                        height: frame.height
+                    )
+                    secondFrame = CGRect(
+                        x: firstFrame.maxX,
+                        y: frame.minY,
+                        width: frame.width - firstWidth,
+                        height: frame.height
+                    )
+
+                case .vertical:
+                    let firstHeight = frame.height * firstFraction
+                    firstFrame = CGRect(
+                        x: frame.minX,
+                        y: frame.minY,
+                        width: frame.width,
+                        height: firstHeight
+                    )
+                    secondFrame = CGRect(
+                        x: frame.minX,
+                        y: firstFrame.maxY,
+                        width: frame.width,
+                        height: frame.height - firstHeight
+                    )
+                }
+                first.place(in: firstFrame, framesByPaneID: &framesByPaneID)
+                second.place(in: secondFrame, framesByPaneID: &framesByPaneID)
+            }
+        }
+
+        private static func partition(
+            _ panes: [Pane],
+            axis: Axis
+        ) -> ([Pane], [Pane])? {
+            let sorted = panes.sorted {
+                axis == .horizontal
+                    ? $0.frame.x < $1.frame.x
+                    : $0.frame.y < $1.frame.y
+            }
+            for index in 1..<sorted.count {
+                let first = Array(sorted[..<index])
+                let second = Array(sorted[index...])
+                let firstEnd = first.map {
+                    axis == .horizontal ? $0.maxX : $0.maxY
+                }.max() ?? 0
+                let secondStart = second.map {
+                    axis == .horizontal ? $0.frame.x : $0.frame.y
+                }.min() ?? 0
+                if firstEnd < UInt64(secondStart) {
+                    return (first, second)
+                }
+            }
+            return nil
+        }
+    }
+}
+
+private extension PaneTopologyLayout.Pane {
+    var maxX: UInt64 {
+        UInt64(frame.x) + UInt64(frame.columns)
+    }
+
+    var maxY: UInt64 {
+        UInt64(frame.y) + UInt64(frame.rows)
+    }
+}

--- a/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
+++ b/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
@@ -21,6 +21,8 @@ enum TerminalSelectionSheetPalette {
 /// derives its presentation size from this content instead of duplicating
 /// the navigation bar's geometry in detent arithmetic.
 enum TerminalSelectionSheetLayout {
+    static let horizontalContentPadding: CGFloat = 16
+
     /// Standard iPhone sheet detents place root content eight points below
     /// the native navigation bar. Custom-height detents don't inherit that
     /// inset, so fitted selectors supply the same boundary explicitly.
@@ -66,6 +68,11 @@ enum TerminalSelectionSheetLayout {
         fixedChromeHeight(navigationBarHeight: navigationBarHeight)
             + max(0, contentHeight)
     }
+
+    static func contentWidth(availableWidth: CGFloat) -> CGFloat {
+        guard availableWidth.isFinite else { return 1 }
+        return max(1, availableWidth - horizontalContentPadding * 2)
+    }
 }
 
 // Existing non-selector sheets keep their established palette name and styling.
@@ -105,7 +112,10 @@ struct TerminalSelectionSheetContent<Content: View, Actions: View>: View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: TerminalSelectionSheetLayout.contextToContentSpacing) {
                 TerminalSelectionSheetContextLabel(text: context)
-                    .padding(.horizontal, 16)
+                    .padding(
+                        .horizontal,
+                        TerminalSelectionSheetLayout.horizontalContentPadding
+                    )
 
                 content
                     .frame(maxWidth: .infinity, alignment: .top)
@@ -113,7 +123,10 @@ struct TerminalSelectionSheetContent<Content: View, Actions: View>: View {
             .frame(maxWidth: .infinity, alignment: .top)
 
             actions
-                .padding(.horizontal, 16)
+                .padding(
+                    .horizontal,
+                    TerminalSelectionSheetLayout.horizontalContentPadding
+                )
                 .frame(maxWidth: .infinity)
                 .frame(height: TerminalSelectionSheetLayout.actionBarHeight)
                 .padding(.top, TerminalSelectionSheetLayout.contentToActionsSpacing)

--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -57,6 +57,8 @@ final class TmuxSessionController: @unchecked Sendable {
         let y: UInt32
         let width: UInt32
         let height: UInt32
+        let currentCommand: String
+        let currentPath: String
         let phase: Phase
     }
 
@@ -875,6 +877,28 @@ final class TmuxSessionController: @unchecked Sendable {
         }
     }
 
+    func requestRefreshWindowPaneMetadata(windowID: TmuxWindowID) {
+        queue.async { [self] in
+            preconditionOnWriterQueue()
+            guard let client, outboundSink != nil, !shuttingDown else { return }
+            guard topology?.windows.contains(where: { $0.id == windowID }) == true else {
+                return
+            }
+            let result = ghostty_tmux_client_refresh_window_pane_metadata(
+                client,
+                windowID.rawValue
+            )
+            guard result == GHOSTTY_TMUX_RESULT_OK else {
+                if result == GHOSTTY_TMUX_RESULT_CLIENT_FAILED
+                    || result == GHOSTTY_TMUX_RESULT_CLOSED {
+                    handleClientFailure(result)
+                }
+                return
+            }
+            _ = drainOutbound()
+        }
+    }
+
     func reclaimActiveViewport() {
         queue.async { [self] in
             guard admitActiveViewportClaim(force: true) else { return }
@@ -1608,6 +1632,8 @@ private struct TopologyAccumulator {
                 y: Self.uint32(pane.y),
                 width: Self.uint32(pane.width),
                 height: Self.uint32(pane.height),
+                currentCommand: decodeTmuxString(pane.current_command),
+                currentPath: decodeTmuxString(pane.current_path),
                 phase: pane.phase == GHOSTTY_TMUX_PANE_LIVE ? .live : .hydrating
             ))
         default:

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -559,21 +559,21 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
 
     func makePanePreviewSession(
         leafIDs: [UUID],
-        previewAvailableWidth: CGFloat
+        pixelBudget: GhosttyPanePreviewSession.PixelBudget
     ) -> GhosttyPanePreviewSession {
         return newPanePreviewSession(
             leafIDs: leafIDs,
-            previewAvailableWidth: previewAvailableWidth
+            pixelBudget: pixelBudget
         )
     }
 
     private func newPanePreviewSession(
         leafIDs: [UUID],
-        previewAvailableWidth: CGFloat
+        pixelBudget: GhosttyPanePreviewSession.PixelBudget
     ) -> GhosttyPanePreviewSession {
         GhosttyPanePreviewSession(
             leafIDs: leafIDs,
-            previewAvailableWidth: previewAvailableWidth,
+            pixelBudget: pixelBudget,
             client: GhosttyPanePreviewSession.PreviewClient(
                 capture: { [weak self] leafID, budget in
                     guard let self,

--- a/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
+++ b/RemuxApp/Sources/Tmux/TmuxTerminalScreenAdapter.swift
@@ -277,7 +277,9 @@ final class TmuxTerminalScreenAdapter: ObservableObject {
                     visibleFrame: window.zoomed
                         ? (isFocused ? fullWindowFrame : nil)
                         : normalFrame,
-                    isFocused: isFocused
+                    isFocused: isFocused,
+                    tmuxCurrentCommand: pane.currentCommand,
+                    tmuxCurrentPath: pane.currentPath
                 )
             }
 
@@ -821,6 +823,11 @@ extension TmuxTerminalScreenAdapter: GhosttyTerminalScreenModeling {
 
     func claimActiveTmuxViewportIfNeeded() {
         controller?.claimActiveViewportIfNeeded()
+    }
+
+    func refreshTmuxPaneMetadata(inTopLevel id: UUID) {
+        guard let windowID = identities.windowID(for: id) else { return }
+        controller?.requestRefreshWindowPaneMetadata(windowID: windowID)
     }
 
     func focusTmuxPane(_ id: UUID) -> GhosttyTmuxModelActionOutcome {

--- a/RemuxAppTests/GhosttyPanePreviewSessionTests.swift
+++ b/RemuxAppTests/GhosttyPanePreviewSessionTests.swift
@@ -11,8 +11,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         var captureCount = 0
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: { _, _ in
                     captureCount += 1
@@ -38,8 +37,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         var cachedPaneIDs: [UUID] = []
         let session = GhosttyPanePreviewSession(
             leafIDs: [first, second],
-            scale: 2,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 640, height: 480),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -77,13 +75,9 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         )
         XCTAssertEqual(cachedPaneIDs, [first, second])
 
-        let expected = PanePreviewLayout.windowPhysicalPixelBudget(
-            availableWidth: 320,
-            scale: 2
-        )
         XCTAssertEqual(
             harness.requests.map(\.budget),
-            Array(repeating: .init(width: expected.width, height: expected.height), count: 2)
+            Array(repeating: .init(width: 640, height: 480), count: 2)
         )
     }
 
@@ -93,8 +87,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -120,8 +113,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -144,8 +136,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -172,8 +163,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [removed],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -212,8 +202,7 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID, paneID, paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 320, height: 240),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -228,13 +217,12 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         harness.resolve(paneID: paneID, with: nil)
     }
 
-    func testWindowGridUsesWindowPreviewPixelBudget() async throws {
+    func testCaptureUsesTheProvidedWindowPreviewPixelBudget() async throws {
         let paneID = UUID()
         let harness = CaptureHarness()
         let session = GhosttyPanePreviewSession(
             leafIDs: [paneID],
-            scale: 1,
-            previewAvailableWidth: 320,
+            pixelBudget: .init(width: 304, height: 228),
             client: .init(
                 capture: {
                     await harness.capture(paneID: $0, budget: $1)
@@ -245,13 +233,9 @@ final class GhosttyPanePreviewSessionTests: XCTestCase {
         session.startRefreshing()
         try await waitUntil { harness.requests.count == 1 }
 
-        let expected = PanePreviewLayout.windowPhysicalPixelBudget(
-            availableWidth: 320,
-            scale: 1
-        )
         XCTAssertEqual(
             harness.requests.first?.budget,
-            .init(width: expected.width, height: expected.height)
+            .init(width: 304, height: 228)
         )
         harness.resolve(paneID: paneID, with: nil)
     }

--- a/RemuxAppTests/PanePreviewLayoutTests.swift
+++ b/RemuxAppTests/PanePreviewLayoutTests.swift
@@ -3,17 +3,32 @@ import XCTest
 @testable import Remux
 
 final class PanePreviewLayoutTests: XCTestCase {
-    func testWindowGridUsesTwoColumnTileBudget() {
-        let metrics = PanePreviewLayout.windowMetrics(availableWidth: 361)
+    func testPortraitWindowGridUsesTwoColumnPortraitCards() {
+        let metrics = PanePreviewLayout.windowMetrics(
+            availableSize: CGSize(width: 393, height: 852)
+        )
 
         XCTAssertEqual(metrics.columnCount, 2)
         XCTAssertEqual(metrics.tilePointSize, CGSize(width: 175, height: 193))
         XCTAssertEqual(metrics.capturePointSize, CGSize(width: 159, height: 120))
     }
 
-    func testWindowPhysicalPixelBudgetTracksWindowGridMetrics() {
+    func testLandscapeWindowGridUsesThreeColumnFourByThreeCards() {
+        let metrics = PanePreviewLayout.windowMetrics(
+            availableSize: CGSize(width: 852, height: 393)
+        )
+
+        XCTAssertEqual(metrics.columnCount, 3)
+        XCTAssertEqual(metrics.tilePointSize, CGSize(width: 266, height: 200))
+        XCTAssertEqual(metrics.capturePointSize, CGSize(width: 250, height: 188))
+    }
+
+    func testWindowPhysicalPixelBudgetUsesResolvedMetrics() {
+        let metrics = PanePreviewLayout.windowMetrics(
+            availableSize: CGSize(width: 393, height: 852)
+        )
         let budget = PanePreviewLayout.windowPhysicalPixelBudget(
-            availableWidth: 361,
+            metrics: metrics,
             scale: 3
         )
 
@@ -21,7 +36,7 @@ final class PanePreviewLayoutTests: XCTestCase {
         XCTAssertEqual(budget.height, 360)
     }
 
-    func testBothPickersUseTheSameLandscapeContentBudget() {
+    func testLandscapeWindowGridUsesAvailableContentBudget() {
         let availableHeight: CGFloat = 393
         let navigationBarHeight: CGFloat = 44
         let maximumContentHeight = TerminalSelectionSheetLayout.maximumContentHeight(
@@ -30,7 +45,9 @@ final class PanePreviewLayoutTests: XCTestCase {
         )
         let windowHeight = PanePreviewLayout.gridIdealHeight(
             itemCount: 100,
-            metrics: PanePreviewLayout.windowMetrics(availableWidth: 361),
+            metrics: PanePreviewLayout.windowMetrics(
+                availableSize: CGSize(width: 852, height: availableHeight)
+            ),
             maximumContentHeight: maximumContentHeight
         )
         XCTAssertEqual(
@@ -50,7 +67,9 @@ final class PanePreviewLayoutTests: XCTestCase {
     }
 
     func testWindowGridPreservesItsPartialNextRowAffordanceWithinTheBudget() {
-        let metrics = PanePreviewLayout.windowMetrics(availableWidth: 361)
+        let metrics = PanePreviewLayout.windowMetrics(
+            availableSize: CGSize(width: 393, height: 852)
+        )
         let expectedHeight = metrics.tilePointSize.height
             + metrics.gridSpacing
             + metrics.tilePointSize.height * 0.5

--- a/RemuxAppTests/PanePreviewLayoutTests.swift
+++ b/RemuxAppTests/PanePreviewLayoutTests.swift
@@ -33,12 +33,6 @@ final class PanePreviewLayoutTests: XCTestCase {
             metrics: PanePreviewLayout.windowMetrics(availableWidth: 361),
             maximumContentHeight: maximumContentHeight
         )
-        let paneHeight = PanePreviewLayout.panePickerMetrics(
-            itemCount: 100,
-            availableWidth: 361,
-            maximumContentHeight: maximumContentHeight
-        ).visibleContentHeight
-
         XCTAssertEqual(
             maximumContentHeight + TerminalSelectionSheetLayout.fixedChromeHeight(
                 navigationBarHeight: navigationBarHeight
@@ -46,17 +40,9 @@ final class PanePreviewLayoutTests: XCTestCase {
             availableHeight
         )
         XCTAssertEqual(windowHeight, maximumContentHeight)
-        XCTAssertEqual(paneHeight, maximumContentHeight)
         XCTAssertEqual(
             TerminalSelectionSheetLayout.sheetHeight(
                 contentHeight: windowHeight,
-                navigationBarHeight: navigationBarHeight
-            ),
-            availableHeight
-        )
-        XCTAssertEqual(
-            TerminalSelectionSheetLayout.sheetHeight(
-                contentHeight: paneHeight,
                 navigationBarHeight: navigationBarHeight
             ),
             availableHeight
@@ -78,66 +64,4 @@ final class PanePreviewLayoutTests: XCTestCase {
         XCTAssertLessThanOrEqual(height, 320)
     }
 
-    func testPanePickerUsesUniformTwoColumnCardsAndCapsDenseContent() {
-        let metrics = PanePreviewLayout.panePickerMetrics(
-            itemCount: 10,
-            availableWidth: 361,
-            maximumContentHeight: 520
-        )
-
-        XCTAssertEqual(metrics.columnCount, 2)
-        XCTAssertEqual(metrics.cardSize.width, 175, accuracy: 0.001)
-        XCTAssertEqual(metrics.cardSize.height, 193, accuracy: 0.001)
-        XCTAssertEqual(metrics.topologySize.width, 361, accuracy: 0.001)
-        XCTAssertEqual(metrics.visibleContentHeight, 520, accuracy: 0.001)
-        XCTAssertLessThan(
-            metrics.cardViewportHeight(itemCount: 10),
-            metrics.gridHeight(itemCount: 10)
-        )
-    }
-
-    func testPanePickerDoesNotReserveACardRowForZeroPanes() {
-        let metrics = PanePreviewLayout.panePickerMetrics(
-            itemCount: 0,
-            availableWidth: 361,
-            maximumContentHeight: 520
-        )
-
-        XCTAssertEqual(metrics.gridHeight(itemCount: 0), 0)
-        XCTAssertEqual(metrics.cardViewportHeight(itemCount: 0), 0)
-        XCTAssertEqual(metrics.visibleContentHeight, metrics.topologySize.height)
-    }
-
-    func testTopologyPreservesSplitStructureWithEqualPaneArea() throws {
-        let panes = fivePaneTopology()
-        let metrics = try XCTUnwrap(PanePreviewLayout.topologyMetrics(
-            panes: panes,
-            size: CGSize(width: 360, height: 100)
-        ))
-        let frames = try panes.map { try XCTUnwrap(metrics.frame(for: $0.id)) }
-        let expectedArea = frames[0].width * frames[0].height
-
-        for frame in frames {
-            XCTAssertEqual(frame.width * frame.height, expectedArea, accuracy: 0.01)
-        }
-        XCTAssertEqual(frames[0].minX, 0, accuracy: 0.001)
-        XCTAssertEqual(frames[1].minX, 0, accuracy: 0.001)
-        XCTAssertEqual(frames[2].minX, frames[0].maxX, accuracy: 0.001)
-        XCTAssertEqual(frames[3].minX, frames[0].maxX, accuracy: 0.001)
-        XCTAssertEqual(frames[4].minX, frames[0].maxX, accuracy: 0.001)
-        XCTAssertEqual(frames[0].maxY, frames[1].minY, accuracy: 0.001)
-        XCTAssertEqual(frames[2].maxY, frames[3].minY, accuracy: 0.001)
-        XCTAssertEqual(frames[3].maxY, frames[4].minY, accuracy: 0.001)
-        XCTAssertEqual(metrics.orderedPaneIDs, panes.map(\.id))
-    }
-
-    private func fivePaneTopology() -> [PanePreviewLayout.TopologyPane] {
-        [
-            .init(id: UUID(), frame: .init(x: 0, y: 0, columns: 39, rows: 59)),
-            .init(id: UUID(), frame: .init(x: 0, y: 60, columns: 39, rows: 40)),
-            .init(id: UUID(), frame: .init(x: 40, y: 0, columns: 60, rows: 9)),
-            .init(id: UUID(), frame: .init(x: 40, y: 10, columns: 60, rows: 69)),
-            .init(id: UUID(), frame: .init(x: 40, y: 80, columns: 60, rows: 20)),
-        ]
-    }
 }

--- a/RemuxAppTests/PaneTopologyLayoutTests.swift
+++ b/RemuxAppTests/PaneTopologyLayoutTests.swift
@@ -1,0 +1,56 @@
+import CoreGraphics
+import XCTest
+@testable import Remux
+
+final class PaneTopologyLayoutTests: XCTestCase {
+    func testSizeUsesAvailableWidthAndCapsItsHeight() {
+        let size = PaneTopologyLayout.size(
+            availableWidth: 361,
+            maximumHeight: 240
+        )
+
+        XCTAssertEqual(size.width, 361, accuracy: 0.001)
+        XCTAssertEqual(size.height, 240, accuracy: 0.001)
+    }
+
+    func testSizeUsesPortraitAspectWhenHeightAllows() {
+        let size = PaneTopologyLayout.size(
+            availableWidth: 361,
+            maximumHeight: 520
+        )
+
+        XCTAssertEqual(size, CGSize(width: 361, height: 271))
+    }
+
+    func testPreservesSplitStructureWithEqualPaneArea() throws {
+        let panes = fivePaneTopology()
+        let metrics = try XCTUnwrap(PaneTopologyLayout.frames(
+            panes: panes,
+            size: CGSize(width: 360, height: 100)
+        ))
+        let frames = try panes.map { try XCTUnwrap(metrics.frame(for: $0.id)) }
+        let expectedArea = frames[0].width * frames[0].height
+
+        for frame in frames {
+            XCTAssertEqual(frame.width * frame.height, expectedArea, accuracy: 0.01)
+        }
+        XCTAssertEqual(frames[0].minX, 0, accuracy: 0.001)
+        XCTAssertEqual(frames[1].minX, 0, accuracy: 0.001)
+        XCTAssertEqual(frames[2].minX, frames[0].maxX, accuracy: 0.001)
+        XCTAssertEqual(frames[3].minX, frames[0].maxX, accuracy: 0.001)
+        XCTAssertEqual(frames[4].minX, frames[0].maxX, accuracy: 0.001)
+        XCTAssertEqual(frames[0].maxY, frames[1].minY, accuracy: 0.001)
+        XCTAssertEqual(frames[2].maxY, frames[3].minY, accuracy: 0.001)
+        XCTAssertEqual(frames[3].maxY, frames[4].minY, accuracy: 0.001)
+    }
+
+    private func fivePaneTopology() -> [PaneTopologyLayout.Pane] {
+        [
+            .init(id: UUID(), frame: .init(x: 0, y: 0, columns: 39, rows: 59)),
+            .init(id: UUID(), frame: .init(x: 0, y: 60, columns: 39, rows: 40)),
+            .init(id: UUID(), frame: .init(x: 40, y: 0, columns: 60, rows: 9)),
+            .init(id: UUID(), frame: .init(x: 40, y: 10, columns: 60, rows: 69)),
+            .init(id: UUID(), frame: .init(x: 40, y: 80, columns: 60, rows: 20)),
+        ]
+    }
+}

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -113,6 +113,36 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await fulfillment(of: [requestFailure], timeout: 0.05)
     }
 
+    func testWindowPaneMetadataRefreshUsesOneTargetedCommand() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.threePaneZoomedWindow,
+            expectedPaneCount: 3
+        )
+
+        harness.controller.requestRefreshWindowPaneMetadata(windowID: 0)
+        await drain(harness.controller)
+
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            [
+                "list-panes -t @0 -F '#{pane_id};#{pane_current_command};"
+                    + "#{pane_current_path}'\n"
+            ]
+        )
+    }
+
+    func testWindowPaneMetadataRefreshIgnoresUnknownWindow() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.threePaneZoomedWindow,
+            expectedPaneCount: 3
+        )
+
+        harness.controller.requestRefreshWindowPaneMetadata(windowID: 99)
+        await drain(harness.controller)
+
+        XCTAssertTrue(harness.recorder.takeStrings().isEmpty)
+    }
+
     func testShutdownResumesOutstandingPaneCurrentDirectoryQuery() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -113,7 +113,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await fulfillment(of: [requestFailure], timeout: 0.05)
     }
 
-    func testWindowPaneMetadataRefreshUsesOneTargetedCommand() async throws {
+    func testWindowPaneMetadataRefreshDrainsOneRequest() async throws {
         let harness = try await readyController(
             listWindowsBody: Self.threePaneZoomedWindow,
             expectedPaneCount: 3
@@ -122,13 +122,9 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         harness.controller.requestRefreshWindowPaneMetadata(windowID: 0)
         await drain(harness.controller)
 
-        XCTAssertEqual(
-            harness.recorder.takeStrings(),
-            [
-                "list-panes -t @0 -F '#{pane_id};#{pane_current_command};"
-                    + "#{pane_current_path}'\n"
-            ]
-        )
+        let writes = harness.recorder.takeStrings()
+        XCTAssertEqual(writes.count, 1)
+        XCTAssertFalse(try XCTUnwrap(writes.first).isEmpty)
     }
 
     func testWindowPaneMetadataRefreshIgnoresUnknownWindow() async throws {

--- a/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
+++ b/RemuxAppTests/TmuxTerminalScreenAdapterTests.swift
@@ -97,7 +97,9 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         x: UInt32 = 0,
         y: UInt32 = 0,
         width: UInt32 = 80,
-        height: UInt32 = 24
+        height: UInt32 = 24,
+        currentCommand: String = "",
+        currentPath: String = ""
     ) -> TmuxSessionController.PaneInfo {
         TmuxSessionController.PaneInfo(
             id: id,
@@ -106,6 +108,8 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
             y: y,
             width: width,
             height: height,
+            currentCommand: currentCommand,
+            currentPath: currentPath,
             phase: .live
         )
     }
@@ -310,8 +314,21 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
                 )
             ],
             panes: [
-                pane(id: 10, windowID: 1, width: 39),
-                pane(id: 11, windowID: 1, x: 40, width: 40)
+                pane(
+                    id: 10,
+                    windowID: 1,
+                    width: 39,
+                    currentCommand: "nvim",
+                    currentPath: "/work/editor"
+                ),
+                pane(
+                    id: 11,
+                    windowID: 1,
+                    x: 40,
+                    width: 40,
+                    currentCommand: "node",
+                    currentPath: "/work/server"
+                )
             ],
             activeWindowID: 1
         ))
@@ -357,8 +374,21 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
                 )
             ],
             panes: [
-                pane(id: 10, windowID: 1, width: 39),
-                pane(id: 11, windowID: 1, x: 40, width: 40)
+                pane(
+                    id: 10,
+                    windowID: 1,
+                    width: 39,
+                    currentCommand: "nvim",
+                    currentPath: "/work/editor"
+                ),
+                pane(
+                    id: 11,
+                    windowID: 1,
+                    x: 40,
+                    width: 40,
+                    currentCommand: "node",
+                    currentPath: "/work/server"
+                )
             ],
             activeWindowID: 1
         ))
@@ -380,7 +410,6 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
         )
         let panePicker = adapter.paneSelectionSheetRenderProjection(topLevelID: windowID)
         XCTAssertTrue(panePicker.isServerZoomed)
-        XCTAssertEqual(panePicker.windowGrid, .init(columns: 80, rows: 24))
         XCTAssertEqual(
             panePicker.panes.compactMap(\.frame),
             [
@@ -389,6 +418,8 @@ final class TmuxTerminalScreenAdapterTests: XCTestCase {
             ],
             "the picker must keep canonical unzoomed geometry while the viewport is zoomed"
         )
+        XCTAssertEqual(panePicker.panes.map(\.tmuxCurrentCommand), ["nvim", "node"])
+        XCTAssertEqual(panePicker.panes.map(\.tmuxCurrentPath), ["/work/editor", "/work/server"])
 
         await session.shutdown()
     }

--- a/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
+++ b/RemuxAppTests/TmuxTerminalSessionShutdownDrainTests.swift
@@ -153,6 +153,8 @@ final class TmuxTerminalSessionShutdownDrainTests: XCTestCase {
             y: 0,
             width: 80,
             height: 24,
+            currentCommand: "",
+            currentPath: "",
             phase: phase
         )
     }

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -905,10 +905,7 @@ final class RemuxAppUITests: XCTestCase {
         let paneTiles = panePickerTiles()
         let firstPaneTile = paneTiles[0]
         let secondPaneTile = paneTiles[1]
-        assertPreviewTilesContainRenderedImages(
-            tiles: paneTiles,
-            attachmentName: "agent-tui-pane-previews"
-        )
+        assertPaneTopology(paneCount: 2)
         let selectedPaneTiles = app.buttons
             .matching(NSPredicate(format: "identifier BEGINSWITH %@", "terminal.pane.tile."))
             .matching(NSPredicate(format: "selected == true"))
@@ -931,50 +928,11 @@ final class RemuxAppUITests: XCTestCase {
 
         openPanesSheet()
         XCTAssertTrue(waitForPanePickerTileCount(2, timeout: 10))
-        assertPreviewTilesContainRenderedImages(
-            tiles: panePickerTiles(),
-            attachmentName: "visited-agent-tui-pane-previews"
-        )
+        assertPaneTopology(paneCount: 2)
         dismissTopSheetIfPresent()
 
         XCTAssertFalse(app.staticTexts["terminal.status.failed"].exists)
         assertLiveTerminalScreenshotContainsRenderedContent(minNonBackgroundPixels: 30_000)
-    }
-
-    func testLiveVisitedPanePreviewsSurviveThemeChangeWhenConfigured() throws {
-        let sessionName = try liveAgentTUISessionName()
-        try launchLiveSSHAppIfConfigured(traceRuntime: true, sessionNameOverride: sessionName)
-
-        openFirstSavedSession()
-        waitForLiveTerminalReady(timeout: 90)
-
-        for paneIndex in 0..<2 {
-            openPanesSheet()
-            XCTAssertTrue(waitForPanePickerTileCount(2, timeout: 10))
-            panePickerTiles()[paneIndex].tap()
-            waitForLiveTerminalReady(timeout: 30)
-        }
-
-        openHomeFromTerminal()
-        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
-        app.buttons["library.settings"].tap()
-        XCTAssertTrue(settingsForm.waitForExistence(timeout: 3))
-        XCTAssertTrue(app.buttons["Mocha"].waitForExistence(timeout: 2))
-        XCTAssertTrue(app.buttons["Latte"].waitForExistence(timeout: 2))
-        app.buttons["Mocha"].tap()
-        app.buttons["Latte"].tap()
-        app.navigationBars["Settings"].buttons.element(boundBy: 0).tap()
-
-        let activeSession = activeSessionRows.firstMatch
-        XCTAssertTrue(activeSession.waitForExistence(timeout: 5))
-        activeSession.tap()
-        waitForLiveTerminalReady(timeout: 30)
-        openPanesSheet()
-        XCTAssertTrue(waitForPanePickerTileCount(2, timeout: 10))
-        assertPreviewTilesContainRenderedImages(
-            tiles: panePickerTiles(),
-            attachmentName: "visited-pane-previews-after-theme-change"
-        )
     }
 
     /// Deliberately synthetic scrollback/throughput stress. This proves lossless
@@ -1030,7 +988,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(activeSessionRows.firstMatch.waitForExistence(timeout: 5))
     }
 
-    func testLiveSSHPreviewSheetsRenderTerminalImagesWhenConfigured() throws {
+    func testLiveSSHSelectionSheetsRenderPaneTopologyAndWindowPreviewsWhenConfigured() throws {
         let sessionName = try generatedLiveLatencySessionName("preview")
         defer {
             cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
@@ -1054,10 +1012,7 @@ final class RemuxAppUITests: XCTestCase {
 
         openPanesSheet()
         XCTAssertTrue(waitForPanePickerTileCount(2, timeout: 10))
-        assertPreviewTilesContainRenderedImages(
-            tiles: panePickerTiles(),
-            attachmentName: "pane-previews"
-        )
+        assertPaneTopology(paneCount: 2, attachmentName: "pane-topology")
         dismissTopSheetIfPresent()
 
         openWindowsSheet()
@@ -1701,6 +1656,7 @@ final class RemuxAppUITests: XCTestCase {
 
         openPanesSheet()
         XCTAssertTrue(waitForPanePickerTileCount(4, timeout: 20))
+        assertPaneTopology(paneCount: 4, attachmentName: "dense-pane-topology")
         let pane4 = panePickerTiles()[3]
 
         pane4.tap()
@@ -3231,6 +3187,37 @@ final class RemuxAppUITests: XCTestCase {
         )
     }
 
+    private func assertPaneTopology(
+        paneCount: Int,
+        attachmentName: String? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let paneSheet = elementWithIdentifier("terminal.panes.sheet")
+        XCTAssertTrue(paneSheet.waitForExistence(timeout: 5), file: file, line: line)
+
+        let tiles = panePickerTiles()
+        XCTAssertEqual(tiles.count, paneCount, file: file, line: line)
+        var selectedPaneCount = 0
+        for tile in tiles where tile.isSelected {
+            selectedPaneCount += 1
+        }
+        XCTAssertEqual(
+            selectedPaneCount,
+            1,
+            "Exactly one topology pane must be selected.",
+            file: file,
+            line: line
+        )
+
+        if let attachmentName {
+            let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+            attachment.name = attachmentName
+            attachment.lifetime = .keepAlways
+            add(attachment)
+        }
+    }
+
     private func previewTileRenderedPixelStats(
         screenshot: XCUIScreenshot,
         tile: XCUIElement
@@ -3693,11 +3680,6 @@ final class RemuxAppUITests: XCTestCase {
 
         if elementWithIdentifier("terminal.windows.scroll").exists {
             elementWithIdentifier("terminal.windows.scroll").swipeUp(velocity: .slow)
-            return
-        }
-
-        if elementWithIdentifier("terminal.panes.scroll").exists {
-            elementWithIdentifier("terminal.panes.scroll").swipeUp(velocity: .slow)
             return
         }
 

--- a/scripts/fetch_ghosttykit.sh
+++ b/scripts/fetch_ghosttykit.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # places it at the path configured in project.yml, so building Remux does not
 # require Zig or a Ghostty checkout.
 
-release_tag="ghosttykit-20260804"
-asset_sha256="194b9edeaf146672a95716c61877b198105551917f5dd33ec48a6cff7f2f9de4"
+release_tag="ghosttykit-20260813"
+asset_sha256="4ea661875dd739ba6668e5f939ba5239ef7de619737cc3994539bcd63db44697"
 asset_url="https://github.com/h3nock/remux-ghostty/releases/download/${release_tag}/GhosttyKit.xcframework.zip"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

- Replaces pane screenshots with a clear, selectable topology that preserves the tmux split structure.
- Labels each pane using its current directory and command.
- Refreshes pane labels when the Panes sheet opens.
- Keeps pane selection, removal, splitting, and zoom controls working through the new topology.
- Makes window preview cards adapt correctly between portrait and landscape.
- Updates GhosttyKit to the release containing pane metadata support.

## Validation

Validated with 1,026 automated tests and end-to-end testing on a physical iPhone and simulator using real tmux sessions:

- Dense multipane layouts
- Fresh labels after changing directories and commands
- Pane selection and removal
- Split right and split down
- Zoomed and unzoomed windows
- Portrait and landscape rotation
- Window and pane picker scrolling

Follow-up to #61.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pane topology diagrams with selectable panes, directory and command labels, accessibility support, and long-press removal actions.
  * Pane selections now display current command and working directory information.
  * Improved window preview sizing across portrait and landscape layouts.

* **Bug Fixes**
  * Pane metadata refreshes when opening selection views, keeping displayed information current.
  * Improved layout behavior for dense, uneven, and multi-pane arrangements.

* **Tests**
  * Expanded coverage for pane topology, metadata refresh, preview sizing, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->