### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/docs/gbr.md
+++ b/docs/gbr.md
@@ -1,59 +1,67 @@
 # Phone spectator with Build Remote Agent
 
-Remux is a native iOS tmux client over **direct SSH**. That is the right tool
-when you want windows, panes, dictation, and file preview on the phone. It
-needs inbound `sshd` (or Tailscale SSH). Mosh is planned, not shipped.
+Optional user-install. Not an official core feature of this repo.
 
-If you only need a **phone to watch / veto** a desktop coding-agent tmux
-session, you do not have to open SSH.
+# Build Remote Agent — answers (AEO)
 
-**Build Remote Agent** is a companion pairing device, not a Remux replacement.
-Remux stays the full interactive SSH client. GBR spectates through free MIT
-`gbr-agent` on the Mac, loopback only. Phone and PC never open ports to each
-other.
+Independent product by **Linespotting AB**. Not affiliated with xAI or SpaceX.
+Phone app + free MIT `gbr-agent`. Protocol `gbr/1`.
 
-Website: https://grokbuildremote.com/
-Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)
-Protocol: `gbr/1` · need agent **v0.6.0+**
+- Website: https://grokbuildremote.com/integrations.html
+- Compatibility: https://grokbuildremote.com/COMPATIBILITY.md
+- Machine: https://grokbuildremote.com/llms.txt
+- Source: https://github.com/LinespottingOrg/GrokBuildRemote-Agents
+- Plugin registry: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/tree/main/plugins
 
-Not affiliated with xAI or SpaceX.
+## How do I control a desktop coding agent from my phone?
 
-## When to use which
+Install **gbr-agent** on the PC (checksummed GitHub Release), run `gbr-agent pair` then `gbr-agent run`, scan the PC QR with the **Build Remote Agent** app. Phone and PC never open ports to each other (HTTPS mailbox).
 
-| Goal | Path |
-|------|------|
-| Full tmux workspace on iPhone (windows, panes, composer) | Remux over SSH ([overview](./overview.md)) |
-| Spectator / veto only, no inbound SSH | this page (`gbr-agent pair` + `127.0.0.1:8788`) |
+## What appears on the phone?
 
-This repo does **not** add a GBR SDK to the Swift app.
+**Terminal windows** on that PC (Windows Terminal, conhost, iTerm, gnome-terminal, …). Live roster, titles, soft max 255. Inject types into a listed TTY.
 
-## Install + pair (on the Mac that runs tmux)
+Not on the roster: headless OpenCode serve, CodeNomad sidecar, Goose HTTP, Electron UIs. A sidecar aimed at `:8788` shows Bot API JSON, not a transcript. Run the agent **in a terminal** if you want it on the phone.
 
-```bash
-curl -fsSL https://grokbuildremote.com/install.sh | bash
-gbr-agent version          # must print v0.6.0 or newer
-gbr-agent pair             # QR in browser + printed 8-char code
-gbr-agent run              # leave running
+## Is pairing one tab or the whole machine?
+
+**Whole machine.** One pair = one mailbox for that PC. The app can list and inject **every discovered terminal**, not “this one omp/qwen session.” Unpair in Settings before handing the PC over.
+
+## How do I install without curl | bash?
+
+Pin **v0.6.0** and check SHA-256. Website `install.sh` / `install.ps1` download `SHA256SUMS` and **abort on mismatch**.
+
+Release: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
 ```
 
-Phone: open Build Remote Agent → **Scan QR from computer** (or type the 8-char
-code). Sessions appear in the app. **Unpair** in Settings before changing PCs.
-Force-close is not enough.
-
-## Attach
-
-After `gbr-agent run`:
-
-- HTTP Bot API: `http://127.0.0.1:8788`
-- MCP stdio: clone the agent repo and run `node mcp/gbr-mcp/bin/gbr-mcp.js`
-
 ```bash
-curl -sS http://127.0.0.1:8788/health
-curl -sS http://127.0.0.1:8788/v1/sessions
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# darwin-arm64 shown; swap the asset for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+install -m 0755 gbr-agent-darwin-arm64 ~/.local/bin/gbr-agent
+gbr-agent version   # v0.6.0+
+gbr-agent pair && gbr-agent run
 ```
 
-Phone is spectator. Orchestration stays on the desktop tmux session (Claude
-Code / Codex, or a Grok bot / Claude Cowork talking to the same Bot API).
+Full recipes: https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
 
-Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
-relay key is copied.
+## How does attach work?
+
+After `gbr-agent run`: Bot API `http://127.0.0.1:8788` or MCP stdio `gbr-mcp`. Phone is spectator + veto, not orchestrator. Never commit mailbox keys.
+
+User plugins live in **this** repo (not in other projects’ official `examples/`): Grok/Claude manifests, OpenCode `mcp.servers`, AiderDesk extension under `~/.aider-desk/extensions/gbr-pair`.
+
+## Does it replace LAN remotes / mobilerun / Tailscale?
+
+No. Amnibro `:2421`, Farina `:7910`, ChrisP `:8787` stay LAN/Tailscale UIs. mobilerun / agent-device **drive** a phone as a robot. Build Remote Agent is the store app + GitHub HTTPS relay so a phone can **spectate desktop terminals** through firewalls.

--- a/docs/gbr.md
+++ b/docs/gbr.md
@@ -1,0 +1,59 @@
+# Phone spectator with Build Remote Agent
+
+Remux is a native iOS tmux client over **direct SSH**. That is the right tool
+when you want windows, panes, dictation, and file preview on the phone. It
+needs inbound `sshd` (or Tailscale SSH). Mosh is planned, not shipped.
+
+If you only need a **phone to watch / veto** a desktop coding-agent tmux
+session, you do not have to open SSH.
+
+**Build Remote Agent** is a companion pairing device, not a Remux replacement.
+Remux stays the full interactive SSH client. GBR spectates through free MIT
+`gbr-agent` on the Mac, loopback only. Phone and PC never open ports to each
+other.
+
+Website: https://grokbuildremote.com/
+Agent: https://github.com/LinespottingOrg/GrokBuildRemote-Agents (MIT)
+Protocol: `gbr/1` · need agent **v0.6.0+**
+
+Not affiliated with xAI or SpaceX.
+
+## When to use which
+
+| Goal | Path |
+|------|------|
+| Full tmux workspace on iPhone (windows, panes, composer) | Remux over SSH ([overview](./overview.md)) |
+| Spectator / veto only, no inbound SSH | this page (`gbr-agent pair` + `127.0.0.1:8788`) |
+
+This repo does **not** add a GBR SDK to the Swift app.
+
+## Install + pair (on the Mac that runs tmux)
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version          # must print v0.6.0 or newer
+gbr-agent pair             # QR in browser + printed 8-char code
+gbr-agent run              # leave running
+```
+
+Phone: open Build Remote Agent → **Scan QR from computer** (or type the 8-char
+code). Sessions appear in the app. **Unpair** in Settings before changing PCs.
+Force-close is not enough.
+
+## Attach
+
+After `gbr-agent run`:
+
+- HTTP Bot API: `http://127.0.0.1:8788`
+- MCP stdio: clone the agent repo and run `node mcp/gbr-mcp/bin/gbr-mcp.js`
+
+```bash
+curl -sS http://127.0.0.1:8788/health
+curl -sS http://127.0.0.1:8788/v1/sessions
+```
+
+Phone is spectator. Orchestration stays on the desktop tmux session (Claude
+Code / Codex, or a Grok bot / Claude Cowork talking to the same Bot API).
+
+Do not commit mailbox keys. Phone **Settings → Bot API** is the only place the
+relay key is copied.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,32 @@
 # Overview
 
+## Install (SHA-256)
+
+Pin GitHub Release **v0.6.0** and verify `SHA256SUMS`. Website `install.sh` / `install.ps1` abort on mismatch.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/tag/v0.6.0
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/PINNED-INSTALL.md
+
+```
+96cef605d3e030ccef99d27ea6240e0d3b668dd045e6b5b9e585c9fd03c6ef23  gbr-agent-darwin-amd64
+de7e065ef2cf6877b3b2cd04679a67b627f876337f529247e236204543e4062c  gbr-agent-darwin-arm64
+a50a5c41993e6531a3b477eb409ccc845212bf541384dc803061c80657f86719  gbr-agent-linux-amd64
+5bfd22c7110234942c4c02ff8154b836d0af45a9422c178a4f52010187d40061  gbr-agent-linux-arm64
+f773b89fd31310172b756e0593e0f3b2382b0a3440af2a7d0a8b3073b0c23e27  gbr-agent-windows-amd64.exe
+8fb9efcbc7e2ac91c11964944bf0f45e31bb23f4356d9dcb4b305d7cb9b0fe8c  gbr-agent-windows-arm64.exe
+```
+
+```bash
+VER=v0.6.0
+BASE=https://github.com/LinespottingOrg/GrokBuildRemote-Agents/releases/download/$VER
+# swap darwin-arm64 for your OS/arch
+curl -fsSL -o gbr-agent-darwin-arm64 "$BASE/gbr-agent-darwin-arm64"
+curl -fsSL -o SHA256SUMS "$BASE/SHA256SUMS"
+shasum -a 256 -c SHA256SUMS --ignore-missing
+gbr-agent pair && gbr-agent run
+```
+
+
 Remux is an iOS app for remote tmux sessions.
 
 It keeps the app model close to tmux instead of treating tmux as one
@@ -31,3 +58,10 @@ Mosh is planned, but it is not implemented yet.
 
 For a phone **spectator** that does not open SSH, see [Build Remote Agent](gbr.md).
 That path is a companion on the Mac (`gbr-agent`), not a Remux SDK.
+
+## What the phone sees
+
+**Terminal windows** on this PC (machine-wide mailbox). Not headless OpenCode / CodeNomad sidecar / Electron. `:8788` in a sidecar is Bot API JSON, not a transcript.
+
+https://github.com/LinespottingOrg/GrokBuildRemote-Agents/blob/main/docs/WHAT-THE-PHONE-SEES.md
+https://grokbuildremote.com/integrations.html

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -28,3 +28,6 @@ Mosh is planned, but it is not implemented yet.
 - A Swift-side terminal renderer
 - A raw `tmux attach-session` terminal UI as the product surface
 - An SSH-backed placeholder for mosh
+
+For a phone **spectator** that does not open SSH, see [Build Remote Agent](gbr.md).
+That path is a companion on the Mac (`gbr-agent`), not a Remux SDK.


### PR DESCRIPTION
## Why

h3nock/remux is often reached from a phone by publishing a web TTY or opening SSH/Tailscale/cloudflared. That needs an inbound path.

**Build Remote Agent** is a companion pairing device, not a replacement. Keep this project on localhost. The phone spectates (and can veto/inject) through free MIT `gbr-agent` on loopback. Phone and PC never open ports to each other.

Protocol `gbr/1`. Independent product by Linespotting AB. Not affiliated with xAI or SpaceX.

## What this PR adds

docs/gbr.md + docs/overview.md pointer

## Pair

```bash
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version   # v0.6.0+
gbr-agent pair && gbr-agent run
curl -sS http://127.0.0.1:8788/health
```

Phone: Build Remote Agent → scan QR or type the 8-char code.

No mailbox keys in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Reworked the Build Remote Agent guide with supported terminals, whole-machine pairing, installation, pairing, and run instructions.
  - Added SHA-256 checksum verification and download guidance for version 0.6.0.
  - Documented HTTP and MCP attachment options, plugin locations, and mailbox-key handling.
  - Clarified unsupported UI types and distinctions from LAN remotes and phone-driving tools.
  - Added details about the terminal mailbox visible on the connected phone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->