### PR TITLE
organize settings and unify shortcut management

### DIFF
--- a/Remux.xcodeproj/project.pbxproj
+++ b/Remux.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		B056E6334A9EFBDB7FA305B3 /* TerminalPreviewCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66FB23E143EA43A7AB28A323 /* TerminalPreviewCandidateTests.swift */; };
 		B3BF6CDA8110A71C8BDF0F85 /* GhosttyTmuxPrefixInputBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A510F3E8FC22231ACA4A8A99 /* GhosttyTmuxPrefixInputBuffer.swift */; };
 		B64AE1F77F8F69A612E230AD /* GhosttyTerminalResponderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05107088F3540B7C04D2007 /* GhosttyTerminalResponderViewTests.swift */; };
+		B68637E57C6D9A68925D5C08 /* RemuxAppChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCB6407CF893F00857381C6 /* RemuxAppChrome.swift */; };
 		B6A5A3D0FFED9CD4D416591E /* GhosttyComposeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49261496FE7B949CF84D913B /* GhosttyComposeBar.swift */; };
 		B781685DD2926C3C37781ACC /* RemuxSSHExecSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810D178FA878A5BEA4265D7E /* RemuxSSHExecSession.swift */; };
 		B820C559D6A916B1172DE76B /* SSHPublicKeyRemoteInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD16711790E09A2358816EA /* SSHPublicKeyRemoteInstaller.swift */; };
@@ -376,6 +377,7 @@
 		AC550DCE031B69C4EDD3C6F5 /* GhosttyAttachmentImageMarkupEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyAttachmentImageMarkupEditor.swift; sourceTree = "<group>"; };
 		AD50E6815BED6CB2E3B793C9 /* SSHCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHCredentialStore.swift; sourceTree = "<group>"; };
 		AE5B67646A0F14933B3FD8D8 /* ApplicationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStorage.swift; sourceTree = "<group>"; };
+		AFCB6407CF893F00857381C6 /* RemuxAppChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemuxAppChrome.swift; sourceTree = "<group>"; };
 		B1861094273B802BF30CB94A /* TmuxTerminalScreenAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxTerminalScreenAdapterTests.swift; sourceTree = "<group>"; };
 		B1AAF15C6761B24466DD78D6 /* TerminalRuntimeStatusPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalRuntimeStatusPresentationTests.swift; sourceTree = "<group>"; };
 		B38F49B9EC49FF6E9791967C /* GhosttyKeyboardVisibilityProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyKeyboardVisibilityProjection.swift; sourceTree = "<group>"; };
@@ -499,6 +501,7 @@
 				E683A3CF94359C176CCEA22A /* RemuxActiveSessionCollection.swift */,
 				76659C49175055C3E15DB226 /* RemuxActiveSessionRuntimeReducer.swift */,
 				947084E6DA45D9EFB946CF51 /* RemuxApp.swift */,
+				AFCB6407CF893F00857381C6 /* RemuxAppChrome.swift */,
 				2CCD1093451DAA47FF649549 /* RemuxAppDependencies.swift */,
 				2693DBF11402EDAEC946123A /* RemuxLibrarySSHPrewarmCoordinator.swift */,
 				F5AA752EADDB9E6FBA8140A4 /* RemuxLibrarySSHPrewarmPlanner.swift */,
@@ -1003,6 +1006,7 @@
 				9AE92F88C80E1E5758A9C342 /* RemuxActiveSessionCollection.swift in Sources */,
 				9592BA50118FAF15A3B1A792 /* RemuxActiveSessionRuntimeReducer.swift in Sources */,
 				8AEEBAE61E93788016C85F9F /* RemuxApp.swift in Sources */,
+				B68637E57C6D9A68925D5C08 /* RemuxAppChrome.swift in Sources */,
 				C3A8DE373D7176A8536D9523 /* RemuxAppDependencies.swift in Sources */,
 				97E03948DDE68AB3A9057BBF /* RemuxCitadelSFTPClient.swift in Sources */,
 				C5524C488C1300697E572AD5 /* RemuxLibrarySSHPrewarmCoordinator.swift in Sources */,

--- a/RemuxApp/Sources/App/RemuxAppChrome.swift
+++ b/RemuxApp/Sources/App/RemuxAppChrome.swift
@@ -47,6 +47,15 @@ extension View {
             .background(RemuxAppPalette.background.ignoresSafeArea())
     }
 
+    @ViewBuilder
+    func remuxSheetPresentationBackground() -> some View {
+        if #available(iOS 26.0, *) {
+            self
+        } else {
+            presentationBackground(.regularMaterial)
+        }
+    }
+
     func libraryHomeListRowSurface() -> some View {
         remuxAppListRowSurface()
     }

--- a/RemuxApp/Sources/App/RemuxAppChrome.swift
+++ b/RemuxApp/Sources/App/RemuxAppChrome.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import UIKit
+
+enum RemuxAppPalette {
+    static let background = Color(uiColor: .remuxAppBackground)
+    static let rowSurface = Color(uiColor: .remuxAppRowSurface)
+    static let separator = Color(uiColor: .remuxAppSeparator)
+    static let sectionHeader = Color(uiColor: .remuxAppSectionHeader)
+    static let toolbarTint = Color(uiColor: .remuxAppToolbarTint)
+    static let controlAccent = Color(uiColor: .remuxAppControlAccent)
+    static let rowIconForeground = Color(uiColor: .remuxAppRowIconForeground)
+    static let rowIconSurface = Color(uiColor: .remuxAppRowIconSurface)
+}
+
+typealias LibraryHomePalette = RemuxAppPalette
+
+extension TerminalTheme {
+    var remuxAppColorScheme: ColorScheme {
+        switch self {
+        case .remuxLight:
+            .light
+        case .ghosttyDefault, .remuxDark:
+            .dark
+        }
+    }
+
+    var libraryColorScheme: ColorScheme {
+        remuxAppColorScheme
+    }
+}
+
+extension View {
+    func remuxAppListRowSurface() -> some View {
+        listRowBackground(RemuxAppPalette.rowSurface)
+            .listRowSeparatorTint(RemuxAppPalette.separator)
+    }
+
+    func remuxAppChrome(theme: TerminalTheme) -> some View {
+        preferredColorScheme(theme.remuxAppColorScheme)
+            .tint(RemuxAppPalette.toolbarTint)
+            .toolbarBackground(RemuxAppPalette.background, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+    }
+
+    func remuxAppGroupedScrollBackground() -> some View {
+        scrollContentBackground(.hidden)
+            .background(RemuxAppPalette.background.ignoresSafeArea())
+    }
+
+    func libraryHomeListRowSurface() -> some View {
+        remuxAppListRowSurface()
+    }
+
+    func libraryHomeChrome(theme: TerminalTheme) -> some View {
+        remuxAppChrome(theme: theme)
+    }
+
+    func libraryHomeGroupedScrollBackground() -> some View {
+        remuxAppGroupedScrollBackground()
+    }
+}
+
+private extension UIColor {
+    static let remuxAppBackground = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.15, green: 0.17, blue: 0.21, alpha: 1.0)
+        default:
+            .systemGroupedBackground
+        }
+    }
+
+    static let remuxAppRowSurface = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.21, green: 0.23, blue: 0.28, alpha: 1.0)
+        default:
+            .secondarySystemGroupedBackground
+        }
+    }
+
+    static let remuxAppSeparator = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor.white.withAlphaComponent(0.08)
+        default:
+            .separator
+        }
+    }
+
+    static let remuxAppSectionHeader = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.72, green: 0.74, blue: 0.80, alpha: 1.0)
+        default:
+            .secondaryLabel
+        }
+    }
+
+    static let remuxAppToolbarTint = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.91, green: 0.93, blue: 0.98, alpha: 1.0)
+        default:
+            .label
+        }
+    }
+
+    static let remuxAppControlAccent = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.39, green: 0.64, blue: 1.0, alpha: 1.0)
+        default:
+            .systemBlue
+        }
+    }
+
+    static let remuxAppRowIconForeground = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor(red: 0.79, green: 0.83, blue: 0.91, alpha: 1.0)
+        default:
+            .secondaryLabel
+        }
+    }
+
+    static let remuxAppRowIconSurface = UIColor { traits in
+        switch traits.userInterfaceStyle {
+        case .dark:
+            UIColor.white.withAlphaComponent(0.07)
+        default:
+            .tertiarySystemFill
+        }
+    }
+}

--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -275,10 +275,16 @@ final class RemuxRootModel: ObservableObject {
         case failed(String)
     }
 
+    enum TerminalSettingsUpdateIssue: Equatable {
+        case saveFailed
+        case applyFailed
+    }
+
     @Published private(set) var state: State = .loading
     @Published private(set) var connectionSetup: ConnectionSetupState?
     @Published private(set) var library: ConnectionLibrarySnapshot = .empty
     @Published private(set) var terminalSettings: TerminalSettings = .default
+    @Published private(set) var terminalSettingsUpdateIssue: TerminalSettingsUpdateIssue?
     @Published private(set) var activeSessions: [ActiveTerminalSession] = []
     @Published private(set) var isSetupActionInProgress = false
     @Published private(set) var tmuxSessionDiscoveryStates: [SavedServer.ID: TmuxSessionDiscoveryState] = [:]
@@ -1515,16 +1521,32 @@ final class RemuxRootModel: ObservableObject {
     }
 
     func updateTerminalSettings(_ mutation: (inout TerminalSettings) -> Void) async {
+        var updated = terminalSettings
+        mutation(&updated)
+
         do {
-            var updated = terminalSettings
-            mutation(&updated)
             try await dependencies.settingsRepository.saveSettings(updated)
-            terminalSettings = updated
-            dependencies.applyHostKeyPolicy(allowInsecureRSA: updated.allowInsecureRSAHostKeys)
-            try applyTerminalSettingsToActiveSessions(updated)
         } catch {
-            transitionToFailed(error)
+            NSLog("Remux terminal settings save failed: %@", String(describing: error))
+            terminalSettingsUpdateIssue = .saveFailed
+            return
         }
+
+        terminalSettings = updated
+        dependencies.applyHostKeyPolicy(allowInsecureRSA: updated.allowInsecureRSAHostKeys)
+
+        do {
+            try applyTerminalSettingsToActiveSessions(updated)
+            terminalSettingsUpdateIssue = nil
+        } catch {
+            NSLog("Remux terminal settings apply failed: %@", String(describing: error))
+            terminalSettingsUpdateIssue = .applyFailed
+        }
+    }
+
+    func dismissTerminalSettingsUpdateIssue(_ issue: TerminalSettingsUpdateIssue) {
+        guard terminalSettingsUpdateIssue == issue else { return }
+        terminalSettingsUpdateIssue = nil
     }
 
     func makeTransport(for target: TmuxConnectionTarget) -> any TmuxControlTransport {

--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -275,16 +275,11 @@ final class RemuxRootModel: ObservableObject {
         case failed(String)
     }
 
-    enum TerminalSettingsUpdateIssue: Equatable {
-        case saveFailed
-        case applyFailed
-    }
-
     @Published private(set) var state: State = .loading
     @Published private(set) var connectionSetup: ConnectionSetupState?
     @Published private(set) var library: ConnectionLibrarySnapshot = .empty
     @Published private(set) var terminalSettings: TerminalSettings = .default
-    @Published private(set) var terminalSettingsUpdateIssue: TerminalSettingsUpdateIssue?
+    @Published private(set) var terminalSettingsSaveFailed = false
     @Published private(set) var activeSessions: [ActiveTerminalSession] = []
     @Published private(set) var isSetupActionInProgress = false
     @Published private(set) var tmuxSessionDiscoveryStates: [SavedServer.ID: TmuxSessionDiscoveryState] = [:]
@@ -1528,32 +1523,25 @@ final class RemuxRootModel: ObservableObject {
             try await dependencies.settingsRepository.saveSettings(updated)
         } catch {
             NSLog("Remux terminal settings save failed: %@", String(describing: error))
-            terminalSettingsUpdateIssue = .saveFailed
+            terminalSettingsSaveFailed = true
             return
         }
 
+        terminalSettingsSaveFailed = false
         terminalSettings = updated
         dependencies.applyHostKeyPolicy(allowInsecureRSA: updated.allowInsecureRSAHostKeys)
-
-        do {
-            try applyTerminalSettingsToActiveSessions(updated)
-            terminalSettingsUpdateIssue = nil
-        } catch {
-            NSLog("Remux terminal settings apply failed: %@", String(describing: error))
-            terminalSettingsUpdateIssue = .applyFailed
-        }
+        applyTerminalSettingsToActiveSessions(updated)
     }
 
-    func dismissTerminalSettingsUpdateIssue(_ issue: TerminalSettingsUpdateIssue) {
-        guard terminalSettingsUpdateIssue == issue else { return }
-        terminalSettingsUpdateIssue = nil
+    func dismissTerminalSettingsSaveFailure() {
+        terminalSettingsSaveFailed = false
     }
 
     func makeTransport(for target: TmuxConnectionTarget) -> any TmuxControlTransport {
         preparedTransportCoordinator.claimOrCreateTransport(for: target)
     }
 
-    private func applyTerminalSettingsToActiveSessions(_ settings: TerminalSettings) throws {
+    private func applyTerminalSettingsToActiveSessions(_ settings: TerminalSettings) {
         RemuxActiveSessionCollection.refreshTerminalSettings(
             settings,
             in: &activeSessions
@@ -1562,7 +1550,11 @@ final class RemuxRootModel: ObservableObject {
         for session in activeSessions {
             let key = TerminalRuntimeAttemptKey(session: session)
             guard let model = terminalScreenModels[key] else { continue }
-            try model.applyTerminalSettings(settings)
+            do {
+                try model.applyTerminalSettings(settings)
+            } catch {
+                NSLog("Remux terminal settings apply failed: %@", String(describing: error))
+            }
         }
     }
 

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -219,49 +219,25 @@ private struct RemuxWorkspaceShell: View {
                 )
         }
         .alert(
-            terminalSettingsUpdateIssueTitle,
-            isPresented: terminalSettingsUpdateIssueIsPresented,
-            presenting: model.terminalSettingsUpdateIssue
-        ) { issue in
+            "Settings Couldn’t Be Saved",
+            isPresented: terminalSettingsSaveFailureIsPresented
+        ) {
             Button("OK", role: .cancel) {
-                model.dismissTerminalSettingsUpdateIssue(issue)
+                model.dismissTerminalSettingsSaveFailure()
             }
-        } message: { issue in
-            Text(terminalSettingsUpdateIssueMessage(issue))
+        } message: {
+            Text("Your previous settings are still in use. Try again.")
         }
     }
 
-    private var terminalSettingsUpdateIssueIsPresented: Binding<Bool> {
+    private var terminalSettingsSaveFailureIsPresented: Binding<Bool> {
         Binding(
-            get: { model.terminalSettingsUpdateIssue != nil },
+            get: { model.terminalSettingsSaveFailed },
             set: { isPresented in
-                guard !isPresented, let issue = model.terminalSettingsUpdateIssue else { return }
-                model.dismissTerminalSettingsUpdateIssue(issue)
+                guard !isPresented else { return }
+                model.dismissTerminalSettingsSaveFailure()
             }
         )
-    }
-
-    private var terminalSettingsUpdateIssueTitle: String {
-        switch model.terminalSettingsUpdateIssue {
-        case .saveFailed:
-            "Settings Couldn’t Be Saved"
-        case .applyFailed:
-            "Settings Couldn’t Be Applied"
-        case nil:
-            "Settings"
-        }
-    }
-
-    private func terminalSettingsUpdateIssueMessage(
-        _ issue: RemuxRootModel.TerminalSettingsUpdateIssue
-    ) -> String {
-        switch issue {
-        case .saveFailed:
-            "Your previous settings are still in use. Try again."
-        case .applyFailed:
-            "The settings were saved, but couldn’t be applied to every active terminal. "
-                + "Reconnect affected sessions to apply them."
-        }
     }
 
     private var connectionSetupSheetIsPresented: Binding<Bool> {

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -560,6 +560,7 @@ private struct RemuxWorkspaceShell: View {
                 activeSessions: model.activeSessions,
                 discoveryStates: model.tmuxSessionDiscoveryStates,
                 terminalSettings: terminalSettingsBinding,
+                shortcutStore: shortcutStore,
                 presentedServerID: $presentedServerID,
                 onAddServer: model.beginNewServer,
                 onAddWorkspace: { serverID, showsServerSummary in
@@ -846,6 +847,7 @@ private struct ConnectionLibraryView: View {
     let activeSessions: [ActiveTerminalSession]
     let discoveryStates: [SavedServer.ID: TmuxSessionDiscoveryState]
     @Binding var terminalSettings: TerminalSettings
+    let shortcutStore: ShortcutStore
     @Binding var presentedServerID: SavedServer.ID?
     let onAddServer: () -> Void
     let onAddWorkspace: (SavedServer.ID, Bool) -> Void
@@ -896,7 +898,10 @@ private struct ConnectionLibraryView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 NavigationLink {
-                    TerminalSettingsView(settings: $terminalSettings)
+                    TerminalSettingsView(
+                        settings: $terminalSettings,
+                        shortcutStore: shortcutStore
+                    )
                 } label: {
                     Image(systemName: "gearshape")
                 }
@@ -1940,10 +1945,15 @@ private func serverSummary(
 
 private struct TerminalSettingsView: View {
     @Binding private var sourceSettings: TerminalSettings
+    private let shortcutStore: ShortcutStore
     @State private var settings: TerminalSettings
 
-    init(settings: Binding<TerminalSettings>) {
+    init(
+        settings: Binding<TerminalSettings>,
+        shortcutStore: ShortcutStore
+    ) {
         _sourceSettings = settings
+        self.shortcutStore = shortcutStore
         _settings = State(initialValue: settings.wrappedValue)
     }
 
@@ -1999,6 +2009,16 @@ private struct TerminalSettingsView: View {
                     "You can override this per window from Panes. Remux normally clears zooms "
                         + "it applied when closing. If one remains on the server, use prefix + z."
                 )
+            }
+            .libraryHomeListRowSurface()
+
+            Section("Keyboard") {
+                NavigationLink {
+                    ShortcutsSettingsView(store: shortcutStore)
+                } label: {
+                    Label("Shortcuts", systemImage: "keyboard")
+                }
+                .accessibilityIdentifier("settings.shortcuts")
             }
             .libraryHomeListRowSurface()
 

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -200,7 +200,7 @@ private struct RemuxWorkspaceShell: View {
                 onRefresh: model.refreshTmuxSessions,
                 discoveryStates: model.tmuxSessionDiscoveryStates
             )
-            .terminalSelectionSheetPresentationBackground()
+            .remuxSheetPresentationBackground()
             .ghosttyTerminalChromePresentation(
                 model.terminalSettings.theme.terminalChromeColorScheme,
                 chromeStyle: model.terminalSettings.theme.terminalChromeStyle
@@ -296,7 +296,7 @@ private struct RemuxWorkspaceShell: View {
             }
             .presentationDetents(presentationDetents(for: setup.mode))
             .presentationDragIndicator(.visible)
-            .terminalSelectionSheetPresentationBackground()
+            .remuxSheetPresentationBackground()
             .ghosttyTerminalChromePresentation(
                 model.terminalSettings.theme.terminalChromeColorScheme,
                 chromeStyle: model.terminalSettings.theme.terminalChromeStyle

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1209,50 +1209,11 @@ private struct ConnectionLibraryView: View {
     }
 }
 
-private enum LibraryHomePalette {
-    static let background = Color(uiColor: .libraryHomeBackground)
-    static let rowSurface = Color(uiColor: .libraryHomeRowSurface)
-    static let separator = Color(uiColor: .libraryHomeSeparator)
-    static let sectionHeader = Color(uiColor: .libraryHomeSectionHeader)
-    static let toolbarTint = Color(uiColor: .libraryHomeToolbarTint)
-    static let controlAccent = Color(uiColor: .libraryHomeControlAccent)
-    static let rowIconForeground = Color(uiColor: .libraryHomeRowIconForeground)
-    static let rowIconSurface = Color(uiColor: .libraryHomeRowIconSurface)
-}
-
-private extension TerminalTheme {
-    var libraryColorScheme: ColorScheme {
-        switch self {
-        case .remuxLight:
-            .light
-        case .ghosttyDefault, .remuxDark:
-            .dark
-        }
-    }
-}
-
 private extension View {
-    func libraryHomeListRowSurface() -> some View {
-        listRowBackground(LibraryHomePalette.rowSurface)
-            .listRowSeparatorTint(LibraryHomePalette.separator)
-    }
-
-    func libraryHomeChrome(theme: TerminalTheme) -> some View {
-        preferredColorScheme(theme.libraryColorScheme)
-            .tint(LibraryHomePalette.toolbarTint)
-            .toolbarBackground(LibraryHomePalette.background, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-    }
-
-    func libraryHomeGroupedScrollBackground() -> some View {
-        scrollContentBackground(.hidden)
-            .background(LibraryHomePalette.background.ignoresSafeArea())
-    }
-
     @ViewBuilder
     func connectionSetupListRowSurface(usesLibraryChrome: Bool) -> some View {
         if usesLibraryChrome {
-            libraryHomeListRowSurface()
+            remuxAppListRowSurface()
         } else {
             listRowBackground(Color.clear)
                 .listRowSeparatorTint(TerminalSelectionSheetPalette.stroke)
@@ -1265,8 +1226,8 @@ private extension View {
         theme: TerminalTheme
     ) -> some View {
         if usesLibraryChrome {
-            libraryHomeGroupedScrollBackground()
-                .libraryHomeChrome(theme: theme)
+            remuxAppGroupedScrollBackground()
+                .remuxAppChrome(theme: theme)
         } else {
             scrollContentBackground(.hidden)
         }
@@ -1286,81 +1247,6 @@ private struct LibraryHomeSectionHeader: View {
             .foregroundStyle(LibraryHomePalette.sectionHeader)
             .textCase(nil)
     }
-}
-
-private extension UIColor {
-    static let libraryHomeBackground = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.15, green: 0.17, blue: 0.21, alpha: 1.0)
-        default:
-            .systemGroupedBackground
-        }
-    }
-
-    static let libraryHomeRowSurface = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.21, green: 0.23, blue: 0.28, alpha: 1.0)
-        default:
-            .secondarySystemGroupedBackground
-        }
-    }
-
-    static let libraryHomeSeparator = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor.white.withAlphaComponent(0.08)
-        default:
-            .separator
-        }
-    }
-
-    static let libraryHomeSectionHeader = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.72, green: 0.74, blue: 0.80, alpha: 1.0)
-        default:
-            .secondaryLabel
-        }
-    }
-
-    static let libraryHomeToolbarTint = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.91, green: 0.93, blue: 0.98, alpha: 1.0)
-        default:
-            .label
-        }
-    }
-
-    static let libraryHomeControlAccent = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.39, green: 0.64, blue: 1.0, alpha: 1.0)
-        default:
-            .systemBlue
-        }
-    }
-
-    static let libraryHomeRowIconForeground = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor(red: 0.79, green: 0.83, blue: 0.91, alpha: 1.0)
-        default:
-            .secondaryLabel
-        }
-    }
-
-    static let libraryHomeRowIconSurface = UIColor { traits in
-        switch traits.userInterfaceStyle {
-        case .dark:
-            UIColor.white.withAlphaComponent(0.07)
-        default:
-            .tertiarySystemFill
-        }
-    }
-
 }
 
 private struct ServerDetailView: View {

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1900,7 +1900,10 @@ private struct TerminalSettingsView: View {
 
             Section("Keyboard") {
                 NavigationLink {
-                    ShortcutsSettingsView(store: shortcutStore)
+                    ShortcutsSettingsView(
+                        store: shortcutStore,
+                        theme: settings.theme
+                    )
                 } label: {
                     Label("Shortcuts", systemImage: "keyboard")
                 }

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -218,6 +218,50 @@ private struct RemuxWorkspaceShell: View {
                     isActive: true
                 )
         }
+        .alert(
+            terminalSettingsUpdateIssueTitle,
+            isPresented: terminalSettingsUpdateIssueIsPresented,
+            presenting: model.terminalSettingsUpdateIssue
+        ) { issue in
+            Button("OK", role: .cancel) {
+                model.dismissTerminalSettingsUpdateIssue(issue)
+            }
+        } message: { issue in
+            Text(terminalSettingsUpdateIssueMessage(issue))
+        }
+    }
+
+    private var terminalSettingsUpdateIssueIsPresented: Binding<Bool> {
+        Binding(
+            get: { model.terminalSettingsUpdateIssue != nil },
+            set: { isPresented in
+                guard !isPresented, let issue = model.terminalSettingsUpdateIssue else { return }
+                model.dismissTerminalSettingsUpdateIssue(issue)
+            }
+        )
+    }
+
+    private var terminalSettingsUpdateIssueTitle: String {
+        switch model.terminalSettingsUpdateIssue {
+        case .saveFailed:
+            "Settings Couldn’t Be Saved"
+        case .applyFailed:
+            "Settings Couldn’t Be Applied"
+        case nil:
+            "Settings"
+        }
+    }
+
+    private func terminalSettingsUpdateIssueMessage(
+        _ issue: RemuxRootModel.TerminalSettingsUpdateIssue
+    ) -> String {
+        switch issue {
+        case .saveFailed:
+            "Your previous settings are still in use. Try again."
+        case .applyFailed:
+            "The settings were saved, but couldn’t be applied to every active terminal. "
+                + "Reconnect affected sessions to apply them."
+        }
     }
 
     private var connectionSetupSheetIsPresented: Binding<Bool> {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -538,7 +538,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                     )
             }
             .sheet(isPresented: $isShortcutsSettingsPresented) {
-                ShortcutsSettingsSheet(store: shortcutStore)
+                ShortcutsSettingsSheet(
+                    store: shortcutStore,
+                    theme: presentation.terminalTheme
+                )
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
                     .presentationBackground(.regularMaterial)
@@ -549,7 +552,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                     )
             }
             .sheet(item: $shortcutEditorRequest) { request in
-                ShortcutEditorSheet(request: request) { shortcut, favorite in
+                ShortcutEditorSheet(
+                    request: request,
+                    theme: presentation.terminalTheme
+                ) { shortcut, favorite in
                     shortcutStore.update {
                         $0.upsertShortcut(shortcut)
                         if favorite {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -531,7 +531,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                     )
                     .presentationContentInteraction(.scrolls)
                     .presentationDragIndicator(.hidden)
-                    .terminalSelectionSheetPresentationBackground()
+                    .remuxSheetPresentationBackground()
                     .ghosttyTerminalChromePresentation(
                         presentation.terminalTheme.terminalChromeColorScheme,
                         chromeStyle: presentation.terminalTheme.terminalChromeStyle
@@ -544,8 +544,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 )
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
-                    .presentationBackground(.regularMaterial)
-                    .presentationCornerRadius(28)
+                    .remuxSheetPresentationBackground()
                     .ghosttyTerminalChromePresentation(
                         presentation.terminalTheme.terminalChromeColorScheme,
                         chromeStyle: presentation.terminalTheme.terminalChromeStyle
@@ -565,8 +564,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 }
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
-                .presentationBackground(.regularMaterial)
-                .presentationCornerRadius(28)
+                .remuxSheetPresentationBackground()
                 .ghosttyTerminalChromePresentation(
                     presentation.terminalTheme.terminalChromeColorScheme,
                     chromeStyle: presentation.terminalTheme.terminalChromeStyle
@@ -579,7 +577,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 )
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
-                .terminalSelectionSheetPresentationBackground()
+                .remuxSheetPresentationBackground()
                 .ghosttyTerminalChromePresentation(
                     presentation.terminalTheme.terminalChromeColorScheme,
                     chromeStyle: presentation.terminalTheme.terminalChromeStyle

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -356,13 +356,14 @@ private struct ShortcutSettingsEditableRow: View {
                 } label: {
                     Label("Delete", systemImage: "trash")
                 }
+                .tint(Color(uiColor: .systemRed))
 
                 Button {
                     toggleHidden()
                 } label: {
                     Label(shortcut.isHidden ? "Show" : "Hide", systemImage: shortcut.isHidden ? "eye" : "eye.slash")
                 }
-                .tint(.gray)
+                .tint(Color(uiColor: .systemIndigo))
             }
         }
     }

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -4,29 +4,28 @@ import UIKit
 #endif
 
 private enum ShortcutsSettingsSheetPalette {
-    static let background = Color(uiColor: .systemGroupedBackground)
-    static let listRowFill = GhosttyShortcutSurfacePalette.contentFill
-    static let listSeparator = GhosttyShortcutSurfacePalette.separator
-    static let iconSurface = Color(uiColor: .tertiarySystemFill)
+    static let iconSurface = RemuxAppPalette.rowIconSurface
 }
 
 private enum ShortcutEditorPalette {
-    static let sectionFill = GhosttyShortcutSurfacePalette.contentFill
-    static let sectionStroke = GhosttyShortcutSurfacePalette.contentStroke
-    static let separator = GhosttyShortcutSurfacePalette.separator
-    static let modeRailFill = Color(uiColor: .tertiarySystemFill)
-    static let modeRailStroke = GhosttyShortcutSurfacePalette.separator
+    static let sectionFill = RemuxAppPalette.rowSurface
+    static let sectionStroke = RemuxAppPalette.separator
+    static let separator = RemuxAppPalette.separator
+    static let modeRailFill = RemuxAppPalette.rowIconSurface
+    static let modeRailStroke = RemuxAppPalette.separator
     static let sectionCornerRadius = GhosttyShortcutSurfacePalette.cornerRadiusLarge
 }
 
 struct ShortcutsSettingsSheet: View {
     @ObservedObject var store: ShortcutStore
+    let theme: TerminalTheme
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         NavigationStack {
             ShortcutsSettingsView(
                 store: store,
+                theme: theme,
                 onDismiss: { dismiss() }
             )
         }
@@ -35,6 +34,7 @@ struct ShortcutsSettingsSheet: View {
 
 struct ShortcutsSettingsView: View {
     @ObservedObject var store: ShortcutStore
+    let theme: TerminalTheme
     var onDismiss: (() -> Void)?
 
     @State private var editorRequest: ShortcutEditorRequest?
@@ -44,9 +44,11 @@ struct ShortcutsSettingsView: View {
 
     init(
         store: ShortcutStore,
+        theme: TerminalTheme,
         onDismiss: (() -> Void)? = nil
     ) {
         self.store = store
+        self.theme = theme
         self.onDismiss = onDismiss
     }
 
@@ -72,7 +74,7 @@ struct ShortcutsSettingsView: View {
             } header: {
                 Text("Collections")
                     .font(GhosttyShortcutTypography.sectionLabel)
-                    .foregroundStyle(GhosttySheetPalette.secondary)
+                    .foregroundStyle(RemuxAppPalette.sectionHeader)
             }
 
             if store.snapshot.hasMissingStarterCollections {
@@ -94,8 +96,8 @@ struct ShortcutsSettingsView: View {
         .navigationTitle("Shortcuts")
         .navigationBarTitleDisplayMode(.inline)
         .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(ShortcutsSettingsSheetPalette.background)
+        .remuxAppGroupedScrollBackground()
+        .remuxAppChrome(theme: theme)
         .toolbar {
             if let onDismiss {
                 ToolbarItem(placement: .cancellationAction) {
@@ -119,7 +121,7 @@ struct ShortcutsSettingsView: View {
         }
         .environment(\.editMode, $editMode)
         .sheet(item: $collectionEditorRequest) { request in
-            ShortcutCollectionEditorSheet(request: request) { collection in
+            ShortcutCollectionEditorSheet(request: request, theme: theme) { collection in
                 store.update { $0.upsertCollection(collection) }
             }
             .presentationDetents([.medium, .large])
@@ -129,7 +131,7 @@ struct ShortcutsSettingsView: View {
             .ghosttyTerminalChromePresentation()
         }
         .sheet(item: $editorRequest) { request in
-            ShortcutEditorSheet(request: request) { shortcut, favorite in
+            ShortcutEditorSheet(request: request, theme: theme) { shortcut, favorite in
                 store.update {
                     $0.upsertShortcut(shortcut)
                     if favorite {
@@ -178,6 +180,7 @@ struct ShortcutsSettingsView: View {
         NavigationLink {
             ShortcutCollectionDetailView(
                 store: store,
+                theme: theme,
                 collectionID: collection.id,
                 addShortcut: {
                     editorRequest = .new(defaultCollection: collection.id, snapshot: store.snapshot)
@@ -211,6 +214,7 @@ struct ShortcutsSettingsView: View {
 
 private struct ShortcutCollectionDetailView: View {
     @ObservedObject var store: ShortcutStore
+    let theme: TerminalTheme
     let collectionID: ShortcutCollectionID
     let addShortcut: () -> Void
     let editShortcut: (Shortcut) -> Void
@@ -285,17 +289,15 @@ private struct ShortcutCollectionDetailView: View {
         .navigationTitle(store.snapshot.collectionTitle(collectionID))
         .navigationBarTitleDisplayMode(.inline)
         .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(ShortcutsSettingsSheetPalette.background)
+        .remuxAppGroupedScrollBackground()
+        .remuxAppChrome(theme: theme)
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
                 EditButton()
-                    .tint(GhosttySheetPalette.primary)
 
                 Button(action: addShortcut) {
                     Image(systemName: "plus")
                 }
-                .tint(GhosttySheetPalette.primary)
                 .accessibilityLabel("Add Shortcut")
 
                 Menu {
@@ -305,7 +307,6 @@ private struct ShortcutCollectionDetailView: View {
                 } label: {
                     Image(systemName: "ellipsis.circle")
                 }
-                .tint(GhosttySheetPalette.primary)
                 .accessibilityLabel("Collection Actions")
             }
         }
@@ -315,8 +316,7 @@ private struct ShortcutCollectionDetailView: View {
 
 private extension View {
     func shortcutSettingsListRowSurface() -> some View {
-        listRowBackground(ShortcutsSettingsSheetPalette.listRowFill)
-            .listRowSeparatorTint(ShortcutsSettingsSheetPalette.listSeparator)
+        remuxAppListRowSurface()
     }
 }
 
@@ -480,6 +480,7 @@ struct ShortcutCollectionEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let request: ShortcutCollectionEditorRequest
+    let theme: TerminalTheme
     let onSave: (ShortcutCollection) -> Void
 
     @State private var title: String
@@ -488,9 +489,11 @@ struct ShortcutCollectionEditorSheet: View {
 
     init(
         request: ShortcutCollectionEditorRequest,
+        theme: TerminalTheme,
         onSave: @escaping (ShortcutCollection) -> Void
     ) {
         self.request = request
+        self.theme = theme
         self.onSave = onSave
         let initialIcon = request.collection?.icon ?? .folder
         _title = State(initialValue: request.collection?.title ?? "")
@@ -525,7 +528,7 @@ struct ShortcutCollectionEditorSheet: View {
                 .padding(.bottom, 28)
             }
             .scrollDismissesKeyboard(.interactively)
-            .background(ShortcutsSettingsSheetPalette.background.ignoresSafeArea())
+            .background(RemuxAppPalette.background.ignoresSafeArea())
             .navigationTitle(request.collection == nil ? "New Collection" : "Edit Collection")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -534,7 +537,6 @@ struct ShortcutCollectionEditorSheet: View {
                         dismiss()
                     } label: {
                         Text("Cancel")
-                            .foregroundStyle(GhosttySheetPalette.primary)
                     }
                 }
 
@@ -543,12 +545,12 @@ struct ShortcutCollectionEditorSheet: View {
                         save()
                     } label: {
                         Text("Save")
-                            .foregroundStyle(canSave ? GhosttySheetPalette.primary : GhosttySheetPalette.tertiary)
                     }
                     .disabled(!canSave)
                 }
             }
         }
+        .remuxAppChrome(theme: theme)
     }
 
     private var iconSuggestions: some View {
@@ -740,6 +742,7 @@ struct ShortcutEditorSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let request: ShortcutEditorRequest
+    let theme: TerminalTheme
     let onSave: (Shortcut, Bool) -> Void
 
     @State private var collection: ShortcutCollectionID
@@ -754,9 +757,11 @@ struct ShortcutEditorSheet: View {
 
     init(
         request: ShortcutEditorRequest,
+        theme: TerminalTheme,
         onSave: @escaping (Shortcut, Bool) -> Void
     ) {
         self.request = request
+        self.theme = theme
         self.onSave = onSave
 
         let shortcut = request.shortcut
@@ -828,7 +833,7 @@ struct ShortcutEditorSheet: View {
                 .padding(.bottom, 28)
             }
             .scrollDismissesKeyboard(.interactively)
-            .background(ShortcutsSettingsSheetPalette.background.ignoresSafeArea())
+            .background(RemuxAppPalette.background.ignoresSafeArea())
             .navigationTitle(request.shortcut == nil ? "New Shortcut" : "Edit Shortcut")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -837,7 +842,6 @@ struct ShortcutEditorSheet: View {
                         dismiss()
                     } label: {
                         Text("Cancel")
-                            .foregroundStyle(GhosttySheetPalette.primary)
                     }
                 }
 
@@ -846,12 +850,12 @@ struct ShortcutEditorSheet: View {
                         save()
                     } label: {
                         Text("Save")
-                            .foregroundStyle(canSave ? GhosttySheetPalette.primary : GhosttySheetPalette.tertiary)
                     }
                     .disabled(!canSave)
                 }
             }
         }
+        .remuxAppChrome(theme: theme)
     }
 
     private var collectionRow: some View {

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -39,7 +39,6 @@ struct ShortcutsSettingsView: View {
 
     @State private var editorRequest: ShortcutEditorRequest?
     @State private var collectionEditorRequest: ShortcutCollectionEditorRequest?
-    @State private var restoreCollection: ShortcutCollectionID?
     @State private var editMode: EditMode = .inactive
 
     init(
@@ -143,31 +142,6 @@ struct ShortcutsSettingsView: View {
             .remuxSheetPresentationBackground()
             .ghosttyTerminalChromePresentation()
         }
-        .confirmationDialog(
-            "Restore Default Shortcuts",
-            isPresented: Binding(
-                get: { restoreCollection != nil },
-                set: { isPresented in
-                    if !isPresented {
-                        restoreCollection = nil
-                    }
-                }
-            ),
-            titleVisibility: .visible
-        ) {
-            if let collection = restoreCollection {
-                Button("Restore \(store.snapshot.collectionTitle(collection)) Defaults") {
-                    store.update {
-                        $0.restoreMissingStarters(in: collection, starters: StarterShortcuts.all)
-                    }
-                    restoreCollection = nil
-                }
-            }
-        } message: {
-            if let collection = restoreCollection {
-                Text("This re-adds missing default shortcuts for \(store.snapshot.collectionTitle(collection)). Existing edits stay unchanged.")
-            }
-        }
     }
 
     private func favoriteCount(in collection: ShortcutCollectionID) -> Int {
@@ -190,9 +164,6 @@ struct ShortcutsSettingsView: View {
                     if let current = store.snapshot.collection(id: collection.id) {
                         collectionEditorRequest = .edit(current)
                     }
-                },
-                restoreStarters: {
-                    restoreCollection = collection.id
                 }
             )
         } label: {
@@ -217,8 +188,16 @@ private struct ShortcutCollectionDetailView: View {
     let addShortcut: () -> Void
     let editShortcut: (Shortcut) -> Void
     let editCollection: () -> Void
-    let restoreStarters: () -> Void
     @State private var editMode: EditMode = .inactive
+
+    private var hasMissingDefaultShortcuts: Bool {
+        let existingStarterIDs = Set(
+            store.snapshot.shortcuts(in: collectionID).compactMap(\.starterID)
+        )
+        return StarterShortcuts.all.contains {
+            $0.collection == collectionID && !existingStarterIDs.contains($0.id)
+        }
+    }
 
     var body: some View {
         List {
@@ -261,17 +240,21 @@ private struct ShortcutCollectionDetailView: View {
                 Text("Swipe to favorite, hide, or delete. Use Edit to reorder.")
             }
 
-            if StarterShortcuts.collectionIDs.contains(collectionID) {
+            if hasMissingDefaultShortcuts {
                 Section {
                     Button {
-                        restoreStarters()
+                        withAnimation {
+                            store.update {
+                                $0.restoreMissingStarters(in: collectionID, starters: StarterShortcuts.all)
+                            }
+                        }
                     } label: {
                         HStack(spacing: 12) {
                             Image(systemName: "arrow.counterclockwise")
                                 .font(.system(size: 19, weight: .medium))
                                 .frame(width: 24, height: 24)
 
-                            Text("Restore Default Shortcuts")
+                            Text("Restore Missing Defaults")
                                 .font(GhosttyShortcutTypography.rowText)
 
                             Spacer(minLength: 0)
@@ -279,8 +262,9 @@ private struct ShortcutCollectionDetailView: View {
                         .foregroundStyle(GhosttySheetPalette.primary)
                         .padding(.vertical, 4)
                     }
-                    .buttonStyle(.plain)
                     .shortcutSettingsListRowSurface()
+                } footer: {
+                    Text("Re-adds deleted built-in shortcuts. Existing shortcuts and edits stay unchanged.")
                 }
             }
         }

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -126,8 +126,7 @@ struct ShortcutsSettingsView: View {
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
-            .presentationBackground(.regularMaterial)
-            .presentationCornerRadius(28)
+            .remuxSheetPresentationBackground()
             .ghosttyTerminalChromePresentation()
         }
         .sheet(item: $editorRequest) { request in
@@ -141,8 +140,7 @@ struct ShortcutsSettingsView: View {
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.visible)
-            .presentationBackground(.regularMaterial)
-            .presentationCornerRadius(28)
+            .remuxSheetPresentationBackground()
             .ghosttyTerminalChromePresentation()
         }
         .confirmationDialog(

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -191,12 +191,10 @@ private struct ShortcutCollectionDetailView: View {
     @State private var editMode: EditMode = .inactive
 
     private var hasMissingDefaultShortcuts: Bool {
-        let existingStarterIDs = Set(
-            store.snapshot.shortcuts(in: collectionID).compactMap(\.starterID)
-        )
-        return StarterShortcuts.all.contains {
-            $0.collection == collectionID && !existingStarterIDs.contains($0.id)
-        }
+        !store.snapshot.missingStarterShortcuts(
+            in: collectionID,
+            from: StarterShortcuts.all
+        ).isEmpty
     }
 
     var body: some View {

--- a/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutsSettingsSheet.swift
@@ -22,78 +22,99 @@ private enum ShortcutEditorPalette {
 struct ShortcutsSettingsSheet: View {
     @ObservedObject var store: ShortcutStore
     @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ShortcutsSettingsView(
+                store: store,
+                onDismiss: { dismiss() }
+            )
+        }
+    }
+}
+
+struct ShortcutsSettingsView: View {
+    @ObservedObject var store: ShortcutStore
+    var onDismiss: (() -> Void)?
+
     @State private var editorRequest: ShortcutEditorRequest?
     @State private var collectionEditorRequest: ShortcutCollectionEditorRequest?
     @State private var restoreCollection: ShortcutCollectionID?
     @State private var editMode: EditMode = .inactive
 
-    var body: some View {
-        NavigationStack {
-            List {
-                Section {
-                    ForEach(store.snapshot.orderedCollections) { collection in
-                        collectionRow(collection)
-                            .shortcutSettingsListRowSurface()
-                    }
-                    .onDelete { indexSet in
-                        let collections = store.snapshot.orderedCollections
-                        let collectionIDs = indexSet.map { collections[$0].id }
-                        store.update { snapshot in
-                            for id in collectionIDs {
-                                snapshot.deleteCollection(id: id)
-                            }
-                        }
-                    }
-                    .onMove { source, destination in
-                        store.update { $0.moveCollections(from: source, to: destination) }
-                    }
-                } header: {
-                    Text("Collections")
-                        .font(GhosttyShortcutTypography.sectionLabel)
-                        .foregroundStyle(GhosttySheetPalette.secondary)
-                }
+    init(
+        store: ShortcutStore,
+        onDismiss: (() -> Void)? = nil
+    ) {
+        self.store = store
+        self.onDismiss = onDismiss
+    }
 
-                if store.snapshot.hasMissingStarterCollections {
-                    Section {
-                        Button {
-                            store.update {
-                                $0.restoreMissingStarterCollections(
-                                    StarterShortcuts.collections,
-                                    starters: StarterShortcuts.all
-                                )
-                            }
-                        } label: {
-                            Label("Restore Default Collections", systemImage: "arrow.counterclockwise")
-                        }
+    var body: some View {
+        List {
+            Section {
+                ForEach(store.snapshot.orderedCollections) { collection in
+                    collectionRow(collection)
                         .shortcutSettingsListRowSurface()
+                }
+                .onDelete { indexSet in
+                    let collections = store.snapshot.orderedCollections
+                    let collectionIDs = indexSet.map { collections[$0].id }
+                    store.update { snapshot in
+                        for id in collectionIDs {
+                            snapshot.deleteCollection(id: id)
+                        }
                     }
+                }
+                .onMove { source, destination in
+                    store.update { $0.moveCollections(from: source, to: destination) }
+                }
+            } header: {
+                Text("Collections")
+                    .font(GhosttyShortcutTypography.sectionLabel)
+                    .foregroundStyle(GhosttySheetPalette.secondary)
+            }
+
+            if store.snapshot.hasMissingStarterCollections {
+                Section {
+                    Button {
+                        store.update {
+                            $0.restoreMissingStarterCollections(
+                                StarterShortcuts.collections,
+                                starters: StarterShortcuts.all
+                            )
+                        }
+                    } label: {
+                        Label("Restore Default Collections", systemImage: "arrow.counterclockwise")
+                    }
+                    .shortcutSettingsListRowSurface()
                 }
             }
-            .navigationTitle("Shortcuts")
-            .navigationBarTitleDisplayMode(.inline)
-            .listStyle(.insetGrouped)
-            .scrollContentBackground(.hidden)
-            .background(ShortcutsSettingsSheetPalette.background)
-            .toolbar {
+        }
+        .navigationTitle("Shortcuts")
+        .navigationBarTitleDisplayMode(.inline)
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(ShortcutsSettingsSheetPalette.background)
+        .toolbar {
+            if let onDismiss {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button {
-                        dismiss()
-                    } label: {
+                    Button(action: onDismiss) {
                         Image(systemName: "xmark")
                     }
                     .accessibilityLabel("Close Shortcuts")
                 }
+            }
 
-                ToolbarItemGroup(placement: .primaryAction) {
-                    EditButton()
+            ToolbarItemGroup(placement: .primaryAction) {
+                EditButton()
 
-                    Button {
-                        collectionEditorRequest = .new(snapshot: store.snapshot)
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .accessibilityLabel("Add Collection")
+                Button {
+                    collectionEditorRequest = .new(snapshot: store.snapshot)
+                } label: {
+                    Image(systemName: "plus")
                 }
+                .accessibilityLabel("Add Collection")
             }
         }
         .environment(\.editMode, $editMode)

--- a/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
+++ b/RemuxApp/Sources/Ghostty/TerminalSelectionSheetStyle.swift
@@ -217,14 +217,4 @@ extension View {
                     )
             }
     }
-
-    @ViewBuilder
-    func terminalSelectionSheetPresentationBackground() -> some View {
-        if #available(iOS 26.0, *) {
-            self
-        } else {
-            self.presentationBackground(.regularMaterial)
-        }
-    }
-
 }

--- a/RemuxApp/Sources/Persistence/ShortcutStore.swift
+++ b/RemuxApp/Sources/Persistence/ShortcutStore.swift
@@ -126,6 +126,17 @@ struct ShortcutStoreSnapshot: Codable, Equatable, Sendable {
         StarterShortcuts.collections.contains { collection(id: $0.id) == nil }
     }
 
+    func missingStarterShortcuts(
+        in collection: ShortcutCollectionID,
+        from starters: [StarterShortcut]
+    ) -> [StarterShortcut] {
+        guard self.collection(id: collection) != nil else { return [] }
+        let existingStarterIDs = Set(shortcuts.compactMap(\.starterID))
+        return starters.filter {
+            $0.collection == collection && !existingStarterIDs.contains($0.id)
+        }
+    }
+
     @discardableResult
     mutating func installMissingCollections(_ starterCollections: [ShortcutCollection]) -> Bool {
         var changed = false
@@ -205,8 +216,7 @@ struct ShortcutStoreSnapshot: Codable, Equatable, Sendable {
         deletedStarterIDs.subtract(starterIDs)
 
         var changed = false
-        let existingStarterIDs = Set(shortcuts.compactMap(\.starterID))
-        for starter in collectionStarters where !existingStarterIDs.contains(starter.id) {
+        for starter in missingStarterShortcuts(in: collection, from: starters) {
             shortcuts.append(starter.makeShortcut())
             installedStarterIDs.insert(starter.id)
             changed = true

--- a/RemuxApp/Sources/Tmux/TmuxPaneSurface.swift
+++ b/RemuxApp/Sources/Tmux/TmuxPaneSurface.swift
@@ -409,7 +409,7 @@ final class TmuxPaneSurface {
         guard lifecycle == .active, let renderer else { return false }
         let result = ghostty_terminal_surface_update_config(renderer.handle)
         guard result == GHOSTTY_TERMINAL_SURFACE_RESULT_OK else {
-            GhosttyRuntimeTrace.diagnostics(
+            NSLog(
                 "tmuxPane.configUpdate failed pane=\(paneID) result=\(String(describing: result))"
             )
             return false

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -3070,7 +3070,7 @@ final class RemuxRootModelTests: XCTestCase {
         XCTAssertNil(credential)
     }
 
-    func testFailedStateStopsOwnedTerminalModels() async throws {
+    func testFailedSettingsSaveKeepsActiveTerminalAndPreviousSettings() async throws {
         let server = SavedServer(
             displayName: "Build Host",
             host: "build.example.test",
@@ -3099,19 +3099,24 @@ final class RemuxRootModelTests: XCTestCase {
         let session = try XCTUnwrap(harness.model.activeSessions.first)
         let terminalModel = harness.model.terminalScreenModel(for: session)
         await waitForConnecting(terminalModel)
+        let previousSettings = harness.model.terminalSettings
 
         await harness.model.updateTerminalSettings { settings in
             settings.fontSize = 19
         }
 
-        guard case .failed = harness.model.state else {
-            XCTFail("expected failed state")
-            return
-        }
-        XCTAssertTrue(harness.model.activeSessions.isEmpty)
-        XCTAssertTrue(harness.model.activeTerminalScreenEntries.isEmpty)
-        XCTAssertFalse(harness.model.hasTerminalScreenModel(for: session))
-        await waitForStopped(terminalModel)
+        XCTAssertEqual(harness.model.state, .terminal(workspace.id))
+        XCTAssertEqual(harness.model.terminalSettings, previousSettings)
+        XCTAssertEqual(harness.model.activeSessions.map(\.id), [workspace.id])
+        XCTAssertEqual(harness.model.activeTerminalScreenEntries.map(\.id), [workspace.id])
+        XCTAssertTrue(harness.model.hasTerminalScreenModel(for: session))
+        XCTAssertTrue(harness.model.terminalScreenModel(for: session) === terminalModel)
+        XCTAssertNotNil(terminalModel.session)
+        XCTAssertEqual(harness.model.terminalSettingsUpdateIssue, .saveFailed)
+
+        harness.model.dismissTerminalSettingsUpdateIssue(.saveFailed)
+
+        XCTAssertNil(harness.model.terminalSettingsUpdateIssue)
     }
 
     func testRuntimeDisconnectMarksActiveSessionDisconnected() async throws {

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -3112,11 +3112,11 @@ final class RemuxRootModelTests: XCTestCase {
         XCTAssertTrue(harness.model.hasTerminalScreenModel(for: session))
         XCTAssertTrue(harness.model.terminalScreenModel(for: session) === terminalModel)
         XCTAssertNotNil(terminalModel.session)
-        XCTAssertEqual(harness.model.terminalSettingsUpdateIssue, .saveFailed)
+        XCTAssertTrue(harness.model.terminalSettingsSaveFailed)
 
-        harness.model.dismissTerminalSettingsUpdateIssue(.saveFailed)
+        harness.model.dismissTerminalSettingsSaveFailure()
 
-        XCTAssertNil(harness.model.terminalSettingsUpdateIssue)
+        XCTAssertFalse(harness.model.terminalSettingsSaveFailed)
     }
 
     func testRuntimeDisconnectMarksActiveSessionDisconnected() async throws {

--- a/RemuxAppTests/ShortcutStoreTests.swift
+++ b/RemuxAppTests/ShortcutStoreTests.swift
@@ -318,6 +318,25 @@ final class ShortcutStoreTests: XCTestCase {
         XCTAssertFalse(snapshot.deletedStarterIDs.contains("claude.compact"))
     }
 
+    func testMovedStarterIsNotMissingFromItsOriginalCollection() {
+        let starter = StarterShortcut(
+            id: "shell.interrupt",
+            collection: .shell,
+            title: "^C",
+            hint: "interrupt",
+            sequence: .control("c"),
+            sortIndex: 0
+        )
+        var movedShortcut = starter.makeShortcut()
+        movedShortcut.collection = .claude
+        var snapshot = ShortcutStoreSnapshot(shortcuts: [movedShortcut])
+
+        XCTAssertTrue(
+            snapshot.missingStarterShortcuts(in: .shell, from: [starter]).isEmpty
+        )
+        XCTAssertFalse(snapshot.restoreMissingStarters(in: .shell, starters: [starter]))
+    }
+
     func testFavoritesResolveOrderedVisibleShortcuts() {
         let first = Shortcut(
             id: UUID(),

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -581,6 +581,25 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertEqual(zoom.value as? String, "1")
     }
 
+    func testSettingsOpenShortcutCollections() {
+        launchSimulatorApp()
+        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
+        app.buttons["library.settings"].tap()
+
+        let shortcuts = app.buttons["settings.shortcuts"]
+        if !shortcuts.waitForExistence(timeout: 1) {
+            settingsForm.swipeUp()
+        }
+        XCTAssertTrue(shortcuts.waitForExistence(timeout: 2))
+        shortcuts.tap()
+
+        XCTAssertTrue(app.navigationBars["Shortcuts"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["Collections"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["Edit"].exists)
+        XCTAssertTrue(app.buttons["Add Collection"].exists)
+        XCTAssertFalse(app.buttons["Close Shortcuts"].exists)
+    }
+
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
         app.launchEnvironment["REMUX_UI_TEST_PUBLIC_KEY_INSTALL_OUTCOME"] = "passwordRequired"
         launchSimulatorApp()

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -768,6 +768,53 @@ final class RemuxAppUITests: XCTestCase {
         assertLiveTerminalScreenshotContainsRenderedContent(minNonBackgroundPixels: 30_000)
     }
 
+    func testLiveCreatedShortcutExecutesInTmuxWhenConfigured() throws {
+        let sessionName = try generatedLiveLatencySessionName("shortcut")
+        defer {
+            cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+        }
+
+        try launchLiveSSHAppIfConfigured(sessionNameOverride: sessionName)
+        openFirstSavedSession()
+        waitForLiveTerminalReady(timeout: 60)
+        waitForLiveTerminalInputReady(timeout: 10)
+
+        let control = app.buttons["terminal.ctrl"]
+        XCTAssertTrue(control.waitForExistence(timeout: 5))
+        control.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 1.2)
+
+        XCTAssertTrue(app.buttons["terminal.shortcuts.add"].waitForExistence(timeout: 2))
+        app.buttons["terminal.shortcuts.add"].tap()
+        XCTAssertTrue(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+
+        let titleField = app.textFields["Title"].firstMatch
+        XCTAssertTrue(titleField.waitForExistence(timeout: 2))
+        titleField.tap()
+        titleField.typeText("E2E")
+
+        let textField = app.textFields["Text"].firstMatch
+        XCTAssertTrue(textField.waitForExistence(timeout: 2))
+        textField.tap()
+        textField.typeText("echo REMUXS")
+        app.buttons["Save"].tap()
+        XCTAssertFalse(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+
+        control.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 1.2)
+        let shortcut = app.buttons["E2E"]
+        XCTAssertTrue(shortcut.waitForExistence(timeout: 2))
+        shortcut.tap()
+        XCTAssertFalse(app.buttons["terminal.shortcuts.settings"].waitForExistence(timeout: 2))
+
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUXS"
+        )
+    }
+
     func testLiveNewSessionBackReturnsToPresentingSessionSheetWhenConfigured() throws {
         let sessionName = try generatedLiveLatencySessionName("new-session-navigation")
         defer {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -554,9 +554,6 @@ final class RemuxAppUITests: XCTestCase {
 
         XCTAssertTrue(settingsForm.waitForExistence(timeout: 2))
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 2))
-        let legacyRSAHostKeys = app.switches["settings.allow-insecure-rsa"]
-        XCTAssertTrue(legacyRSAHostKeys.waitForExistence(timeout: 2))
-        XCTAssertEqual(legacyRSAHostKeys.label, "Allow older RSA host keys")
         tapFontDefaultToggle()
         let fontSize = app.descendants(matching: .any)["settings.font-size"]
         XCTAssertTrue(fontSize.waitForExistence(timeout: 2))
@@ -569,6 +566,13 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.descendants(matching: .any)["settings.theme.preview"].waitForExistence(timeout: 2))
         app.buttons["Mocha"].tap()
         XCTAssertTrue(app.staticTexts["Catppuccin Mocha"].waitForExistence(timeout: 2))
+
+        let legacyRSAHostKeys = app.switches["settings.allow-insecure-rsa"]
+        for _ in 0..<3 where !legacyRSAHostKeys.exists {
+            settingsForm.swipeUp()
+        }
+        XCTAssertTrue(legacyRSAHostKeys.waitForExistence(timeout: 2))
+        XCTAssertEqual(legacyRSAHostKeys.label, "Allow older RSA host keys")
     }
 
     func testFreshPhoneInstallShowsMultipaneZoomDefaultEnabled() {

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -598,6 +598,7 @@ final class RemuxAppUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Edit"].exists)
         XCTAssertTrue(app.buttons["Add Collection"].exists)
         XCTAssertFalse(app.buttons["Close Shortcuts"].exists)
+        attachScreenshot(named: "settings-shortcuts-shared-chrome")
     }
 
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {

--- a/RemuxAppUITests/ShortcutPaletteUITests.swift
+++ b/RemuxAppUITests/ShortcutPaletteUITests.swift
@@ -84,6 +84,209 @@ final class ShortcutPaletteUITests: XCTestCase {
         XCTAssertGreaterThan(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Reorder")).count, 0)
     }
 
+    func testShortcutPaletteAddEditFavoriteAndDeleteWorkflow() throws {
+        app.launch()
+
+        openTerminal()
+        openShortcutPalette()
+        addFavoriteShortcut(title: "A", text: "x")
+
+        openShortcutPalette()
+        let original = app.buttons["A"]
+        XCTAssertTrue(original.waitForExistence(timeout: 2))
+        openContextMenu(for: original)
+        app.buttons["Edit"].tap()
+
+        XCTAssertTrue(app.navigationBars["Edit Shortcut"].waitForExistence(timeout: 2))
+        appendText("2", to: app.textFields["Title"].firstMatch, expecting: "A2")
+        appendText("h", to: app.textFields["Hint"].firstMatch, expecting: "h")
+        appendText("y", to: editorActionField(), expecting: "xy")
+        app.buttons["Save"].tap()
+        XCTAssertFalse(app.navigationBars["Edit Shortcut"].waitForExistence(timeout: 2))
+
+        openShortcutPalette()
+        let editedFavorite = app.buttons["A2"]
+        XCTAssertTrue(editedFavorite.waitForExistence(timeout: 2))
+        openContextMenu(for: editedFavorite)
+        XCTAssertTrue(app.buttons["Remove from Favorites"].waitForExistence(timeout: 2))
+        app.buttons["Remove from Favorites"].tap()
+        XCTAssertFalse(app.buttons["A2"].waitForExistence(timeout: 1))
+
+        paletteTabButton(named: "Shell").tap()
+        let editedInCollection = app.buttons["A2"]
+        XCTAssertTrue(editedInCollection.waitForExistence(timeout: 2))
+        openContextMenu(for: editedInCollection)
+        XCTAssertTrue(app.buttons["Add to Favorites"].waitForExistence(timeout: 2))
+        app.buttons["Add to Favorites"].tap()
+        paletteTabButton(named: "Favorites").tap()
+        XCTAssertTrue(app.buttons["A2"].waitForExistence(timeout: 2))
+
+        let executed = app.buttons["A2"]
+        XCTAssertTrue(executed.waitForExistence(timeout: 2))
+        openContextMenu(for: executed)
+        app.buttons["Delete"].tap()
+        XCTAssertTrue(app.buttons["Delete A2"].waitForExistence(timeout: 2))
+        app.buttons["Delete A2"].tap()
+        XCTAssertFalse(app.buttons["A2"].waitForExistence(timeout: 2))
+    }
+
+    func testShortcutEditorModesValidationAndCancel() throws {
+        app.launch()
+
+        openTerminal()
+        openShortcutPalette()
+        paletteTabButton(named: "Favorites").tap()
+        app.buttons["terminal.shortcuts.add"].tap()
+
+        XCTAssertTrue(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+        let save = app.buttons["Save"]
+        XCTAssertFalse(save.isEnabled)
+
+        enterText("M", in: app.textFields["Title"].firstMatch)
+        XCTAssertFalse(save.isEnabled)
+        enterText("x", in: editorActionField())
+        XCTAssertTrue(save.isEnabled)
+        XCTAssertTrue(app.staticTexts["x⏎"].exists)
+
+        let autoSend = app.switches["Auto-send Enter"]
+        XCTAssertTrue(autoSend.exists)
+        autoSend.tap()
+        XCTAssertTrue(app.staticTexts["x"].exists)
+
+        app.buttons["Ctrl"].tap()
+        let controlField = editorActionField()
+        XCTAssertTrue(controlField.waitForExistence(timeout: 2))
+        XCTAssertTrue(waitForValue(controlField, expected: "c"))
+        XCTAssertTrue(save.isEnabled)
+        XCTAssertTrue(app.staticTexts["^C"].exists)
+        appendText("c", to: controlField, expecting: "cc")
+        XCTAssertFalse(save.isEnabled)
+
+        app.buttons["Key"].tap()
+        XCTAssertTrue(app.buttons["Key, Esc"].waitForExistence(timeout: 2))
+        app.buttons["Key, Esc"].tap()
+        XCTAssertTrue(app.buttons["Tab"].waitForExistence(timeout: 2))
+        app.buttons["Tab"].tap()
+        app.scrollViews.firstMatch.swipeUp()
+        app.switches["Ctrl"].tap()
+        XCTAssertTrue(waitForValue(app.switches["Ctrl"], expected: "1"))
+        app.switches["Opt"].tap()
+        XCTAssertTrue(waitForValue(app.switches["Opt"], expected: "1"))
+        app.switches["Shift"].tap()
+        XCTAssertTrue(waitForValue(app.switches["Shift"], expected: "1"))
+        XCTAssertTrue(app.staticTexts["Ctrl-Opt-Shift-Tab"].waitForExistence(timeout: 2))
+        XCTAssertTrue(save.isEnabled)
+
+        app.buttons["Cancel"].tap()
+        XCTAssertFalse(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+        openShortcutPalette()
+        XCTAssertFalse(app.buttons["M"].exists)
+    }
+
+    func testShortcutSettingsCollectionAndShortcutLifecycle() throws {
+        app.launch()
+
+        openTerminal()
+        openShortcutPalette()
+        app.buttons["terminal.shortcuts.settings"].tap()
+        XCTAssertTrue(app.navigationBars["Shortcuts"].waitForExistence(timeout: 2))
+
+        app.buttons["Add Collection"].tap()
+        XCTAssertTrue(app.navigationBars["New Collection"].waitForExistence(timeout: 2))
+        let collectionSave = app.buttons["Save"]
+        XCTAssertFalse(collectionSave.isEnabled)
+        enterText("O", in: app.textFields["Name"].firstMatch)
+        XCTAssertTrue(collectionSave.isEnabled)
+        app.buttons["terminal"].tap()
+        app.buttons["Save"].tap()
+        XCTAssertTrue(collectionRow(named: "O").waitForExistence(timeout: 2))
+
+        collectionRow(named: "O").tap()
+        XCTAssertTrue(app.navigationBars["O"].waitForExistence(timeout: 2))
+        app.buttons["Collection Actions"].tap()
+        app.buttons["Rename Collection"].tap()
+        XCTAssertTrue(app.navigationBars["Edit Collection"].waitForExistence(timeout: 2))
+        appendText("2", to: app.textFields["Name"].firstMatch, expecting: "O2")
+        XCTAssertTrue(app.buttons["Save"].isEnabled)
+        app.buttons["Save"].tap()
+        XCTAssertTrue(app.navigationBars["O2"].waitForExistence(timeout: 2))
+
+        app.buttons["Add Shortcut"].tap()
+        XCTAssertTrue(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+        enterText("R", in: app.textFields["Title"].firstMatch)
+        enterText("h", in: app.textFields["Hint"].firstMatch)
+        enterText("x", in: editorActionField())
+        app.buttons["Save"].tap()
+        XCTAssertTrue(shortcutRow(named: "R").waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["h"].exists)
+
+        app.buttons["Add Shortcut"].tap()
+        enterText("S", in: app.textFields["Title"].firstMatch)
+        enterText("z", in: editorActionField())
+        app.buttons["Save"].tap()
+        XCTAssertTrue(shortcutRow(named: "S").waitForExistence(timeout: 2))
+
+        XCTAssertLessThan(shortcutRow(named: "R").frame.midY, shortcutRow(named: "S").frame.midY)
+        app.buttons["Edit"].tap()
+        dragShortcutRow(named: "R", to: "S")
+        app.buttons["Done"].tap()
+        XCTAssertGreaterThan(shortcutRow(named: "R").frame.midY, shortcutRow(named: "S").frame.midY)
+
+        shortcutRow(named: "R").tap()
+        XCTAssertTrue(app.navigationBars["Edit Shortcut"].waitForExistence(timeout: 2))
+        appendText("2", to: app.textFields["Title"].firstMatch, expecting: "R2")
+        appendText("2", to: app.textFields["Hint"].firstMatch, expecting: "h2")
+        appendText("y", to: editorActionField(), expecting: "xy")
+        app.switches["Auto-send Enter"].tap()
+        app.buttons["Save"].tap()
+        XCTAssertFalse(shortcutRow(named: "R").exists)
+        let reload = shortcutRow(named: "R2")
+        XCTAssertTrue(reload.waitForExistence(timeout: 2))
+        XCTAssertTrue(app.staticTexts["h2"].exists)
+
+        reload.swipeRight()
+        XCTAssertTrue(app.buttons["Favorite"].waitForExistence(timeout: 2))
+        app.buttons["Favorite"].tap()
+        XCTAssertTrue(reload.images["Favorite"].waitForExistence(timeout: 2))
+        reload.swipeRight()
+        XCTAssertTrue(app.buttons["Unfavorite"].waitForExistence(timeout: 2))
+        app.buttons["Unfavorite"].tap()
+        XCTAssertFalse(reload.images["Favorite"].exists)
+
+        reload.swipeLeft()
+        XCTAssertTrue(app.buttons["Hide"].waitForExistence(timeout: 2))
+        app.buttons["Hide"].tap()
+        XCTAssertTrue(reload.images["Hidden"].waitForExistence(timeout: 2))
+        reload.swipeLeft()
+        XCTAssertTrue(app.buttons["Show"].waitForExistence(timeout: 2))
+        app.buttons["Show"].tap()
+        XCTAssertFalse(reload.images["Hidden"].exists)
+
+        reload.swipeLeft()
+        XCTAssertTrue(app.buttons["Delete"].waitForExistence(timeout: 2))
+        app.buttons["Delete"].tap()
+        XCTAssertFalse(shortcutRow(named: "R2").waitForExistence(timeout: 2))
+    }
+
+    func testShortcutSettingsRestoresDeletedDefaultShortcut() throws {
+        app.launch()
+
+        openTerminal()
+        openShortcutPalette()
+        app.buttons["terminal.shortcuts.settings"].tap()
+        XCTAssertTrue(app.navigationBars["Shortcuts"].waitForExistence(timeout: 2))
+        collectionRow(named: "Shell").tap()
+        XCTAssertTrue(app.navigationBars["Shell"].waitForExistence(timeout: 2))
+        let interrupt = shortcutRow(named: "^C")
+        XCTAssertTrue(interrupt.waitForExistence(timeout: 2))
+        interrupt.swipeLeft()
+        app.buttons["Delete"].tap()
+        XCTAssertFalse(shortcutRow(named: "^C").waitForExistence(timeout: 1))
+        app.buttons["Restore Missing Defaults"].tap()
+        XCTAssertTrue(shortcutRow(named: "^C").waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["Restore Missing Defaults"].exists)
+    }
+
     private func openTerminal() {
         let session = app.descendants(matching: .any)["library.session.resume"].firstMatch
         XCTAssertTrue(session.waitForExistence(timeout: 5))
@@ -125,16 +328,70 @@ final class ShortcutPaletteUITests: XCTestCase {
 
         let titleField = app.textFields["Title"].firstMatch
         XCTAssertTrue(titleField.waitForExistence(timeout: 2))
-        titleField.tap()
-        titleField.typeText(title)
+        enterText(title, in: titleField)
 
         let textField = app.textFields["Text"].firstMatch
         XCTAssertTrue(textField.waitForExistence(timeout: 2))
         textField.tap()
-        textField.typeText(text)
+        for character in text {
+            app.typeText(String(character))
+        }
+        XCTAssertTrue(app.staticTexts["\(text)⏎"].waitForExistence(timeout: 2))
 
         app.buttons["Save"].tap()
         XCTAssertFalse(app.navigationBars["New Shortcut"].waitForExistence(timeout: 2))
+    }
+
+    private func openContextMenu(for element: XCUIElement) {
+        element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).press(forDuration: 1.2)
+    }
+
+    private func enterText(_ text: String, in field: XCUIElement) {
+        if !field.waitForExistence(timeout: 1) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(field.waitForExistence(timeout: 2))
+        field.tap()
+        var entered = ""
+        for character in text {
+            entered.append(character)
+            field.typeText(String(character))
+            XCTAssertTrue(
+                waitForValue(field, expected: entered),
+                "Expected \(field.label) to contain \(entered)"
+            )
+        }
+    }
+
+    private func appendText(_ text: String, to field: XCUIElement, expecting expected: String) {
+        if !field.waitForExistence(timeout: 1) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(field.waitForExistence(timeout: 2))
+        field.tap()
+        field.typeText(text)
+        XCTAssertTrue(waitForValue(field, expected: expected))
+    }
+
+    private func editorActionField() -> XCUIElement {
+        app.textFields.element(boundBy: 2)
+    }
+
+    private func waitForValue(
+        _ field: XCUIElement,
+        expected: String,
+        timeout: TimeInterval = 2
+    ) -> Bool {
+        let predicate = NSPredicate { object, _ in
+            guard let element = object as? XCUIElement else { return false }
+            let value = element.value as? String
+            if expected.isEmpty {
+                return value == nil || value == "" || value == element.placeholderValue
+            }
+            return value == expected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: field)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
     private func paletteTabButton(named title: String) -> XCUIElement {
@@ -173,6 +430,19 @@ final class ShortcutPaletteUITests: XCTestCase {
             )
     }
 
+    private func dragShortcutRow(named source: String, to destination: String) {
+        let sourceHandle = app.buttons["Reorder \(source)"]
+        let destinationHandle = app.buttons["Reorder \(destination)"]
+        XCTAssertTrue(sourceHandle.waitForExistence(timeout: 2), "Missing source shortcut \(source)")
+        XCTAssertTrue(destinationHandle.waitForExistence(timeout: 2), "Missing destination shortcut \(destination)")
+
+        sourceHandle.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(
+                forDuration: 0.8,
+                thenDragTo: destinationHandle.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 1.25))
+            )
+    }
+
     private func deleteCollectionWithNativeControls(named title: String) {
         let row = collectionRow(named: title)
         XCTAssertTrue(row.waitForExistence(timeout: 2))
@@ -184,6 +454,10 @@ final class ShortcutPaletteUITests: XCTestCase {
     }
 
     private func collectionRow(named title: String) -> XCUIElement {
+        app.cells.containing(.staticText, identifier: title).firstMatch
+    }
+
+    private func shortcutRow(named title: String) -> XCUIElement {
         app.cells.containing(.staticText, identifier: title).firstMatch
     }
 }

--- a/RemuxAppUITests/ShortcutPaletteUITests.swift
+++ b/RemuxAppUITests/ShortcutPaletteUITests.swift
@@ -27,6 +27,7 @@ final class ShortcutPaletteUITests: XCTestCase {
         app.buttons["terminal.shortcuts.settings"].tap()
         XCTAssertTrue(app.navigationBars["Shortcuts"].waitForExistence(timeout: 2))
         XCTAssertFalse(app.staticTexts["Upload"].exists)
+        attachScreenshot(named: "terminal-shortcuts-shared-chrome")
     }
 
     func testShortcutPaletteFavoritesAndSettingsEditWorkflow() throws {
@@ -89,6 +90,13 @@ final class ShortcutPaletteUITests: XCTestCase {
         session.tap()
 
         XCTAssertTrue(app.buttons["terminal.ctrl"].waitForExistence(timeout: 5))
+    }
+
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 
     private func openShortcutPalette() {


### PR DESCRIPTION
## Stack

1 of 2. This PR targets `main`. Follow-up #78 is stacked on this branch and adds customizable terminal toolbar keys.

Updated with main at 6893d28 after #79 merged; the contributor's original font-size commit is preserved. #78 now includes this branch's latest fixes.

## Summary

- expose shortcut organization as a first-class destination in the main Settings hierarchy while preserving the terminal long-press entry point
- extract shared app chrome and adaptive sheet presentation so Settings, shortcut collections, and terminal sheets use the same theme-aware surfaces
- fix swipe-action contrast across supported themes and keep shortcut actions readable in destructive and non-destructive states
- restore missing default shortcuts inline using global starter IDs, so moving a default to another collection does not expose a no-op restore action
- continue applying saved settings to later active terminals if one update fails; log live-application failures and reserve alerts for settings-save failures
- expand UI and live-session coverage for shortcut creation, editing, hiding, deletion, restoration, and execution

## User-visible behavior

Settings now provides a consistent path to Shortcuts and collection organization. The terminal palette remains a lightweight bottom sheet, while deeper collection management uses the grouped Settings presentation. Missing defaults can be restored when relevant without presenting an unnecessary confirmation flow. A default that exists in another collection is not considered missing. Live appearance updates are best-effort per terminal; failure in one does not stop updates to the others.

## Testing

- exercised shortcut creation, editing, hiding, deletion, and missing-default restoration in the iOS Simulator
- reviewed Settings, collection pages, palette sheets, and swipe actions across the supported app themes
- built and installed the result on a physical iPhone for manual validation
- exercised shortcut execution against a real SSH/tmux session
- ran the focused unit and UI coverage added for Settings and shortcut workflows

No private local connection details or test credentials are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Keyboard settings with shortcut collection management.
  * Added consistent themed styling across settings, sheets, lists, and navigation.
  * Added an option to restore missing default shortcuts.

* **Bug Fixes**
  * Failed settings saves now preserve the active terminal and previous settings.
  * Terminal settings application continues across active sessions when one update fails.
  * Added a clear alert when terminal settings cannot be saved.

* **Tests**
  * Expanded coverage for shortcut editing, collections, restoration, execution, and settings navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
