### PR TITLE
Lower minimum terminal font size to 5

### DIFF
--- a/RemuxApp/Sources/Domain/TerminalSettings.swift
+++ b/RemuxApp/Sources/Domain/TerminalSettings.swift
@@ -126,7 +126,7 @@ enum TerminalTheme: String, CaseIterable, Codable, Identifiable, Sendable {
 }
 
 struct TerminalSettings: Equatable, Codable, Sendable {
-    static let minimumFontSize: Float32 = 8
+    static let minimumFontSize: Float32 = 5
     static let maximumFontSize: Float32 = 24
     static let defaultExplicitFontSize: Float32 = 10
     static let `default` = TerminalSettings(fontSize: nil, theme: .ghosttyDefault)

--- a/RemuxAppTests/TerminalSettingsTests.swift
+++ b/RemuxAppTests/TerminalSettingsTests.swift
@@ -18,6 +18,15 @@ final class TerminalSettingsTests: XCTestCase {
         XCTAssertNil(TerminalSettings(fontSize: .nan, theme: .ghosttyDefault).fontSize)
     }
 
+    func testSettingsAcceptBoundaryFontSizesWithoutClamping() {
+        XCTAssertEqual(TerminalSettings.minimumFontSize, 5)
+        XCTAssertEqual(TerminalSettings(fontSize: 5, theme: .ghosttyDefault).fontSize, 5)
+        XCTAssertEqual(
+            TerminalSettings(fontSize: TerminalSettings.maximumFontSize, theme: .ghosttyDefault).fontSize,
+            TerminalSettings.maximumFontSize
+        )
+    }
+
     func testDecodingOlderSettingsDefaultsLegacyRSAHostKeysToDisabled() throws {
         let data = Data(#"{"fontSize":16,"theme":"remuxLight"}"#.utf8)
 


### PR DESCRIPTION
## Summary

Lowers the floor of the terminal font size from 8 to 5 so users can fit more columns and rows on phone screens, for example dense tmux layouts.

`TerminalSettings.minimumFontSize` is the single source of truth for this limit. The Settings stepper range and the clamping applied to persisted values both read it, so changing the constant extends the range end to end with no other code changes.

## Changes

- `RemuxApp/Sources/Domain/TerminalSettings.swift`: `minimumFontSize` 8 → 5.
- `RemuxAppTests/TerminalSettingsTests.swift`: new boundary test asserting an explicit 5 is stored as-is rather than clamped, alongside the existing clamp tests.

## Notes

- The phone-only floor of 10 in `GhosttyTerminalAppearancePolicy` applies only when "Use default size" is on. An explicit user size bypasses it, so 5 reaches Ghostty directly.
- Ghostty's `font-size` config only requires a positive value, so no runtime floor blocks this.
- No docs or UI tests hard-code the previous minimum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal font sizes as small as 5 are now supported.

* **Tests**
  * Added coverage confirming minimum and maximum font sizes are accepted without unwanted adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->