### PR TITLE
Add shift accessory key to the terminal toolbar

### DIFF
--- a/RemuxApp/Sources/App/Haptic.swift
+++ b/RemuxApp/Sources/App/Haptic.swift
@@ -41,7 +41,7 @@ enum Haptic {
         chromeSelection?.prepare()
     }
 
-    /// Touch-down feedback for an accessory key (ctrl / esc / tab).
+    /// Touch-down feedback for an accessory key (ctrl / shift / esc / tab).
     /// Audio defaults to OFF: a normal-app view cannot honor iOS Settings >
     /// Keyboard Feedback > Sound, so we ship visual + haptic only and leave
     /// the audio click as an explicit caller opt-in.

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -34,7 +34,47 @@ enum GhosttyKeyboardChromeSizing {
     static let dockButtonHeight: CGFloat = 38
     static let dockButtonWidth: CGFloat = 38
     static let compactDockButtonWidth: CGFloat = 35
+    static let minimumDockButtonWidth: CGFloat = 30
     static let controlGroupVerticalPadding: CGFloat = 4
+
+    /// Buttons per control group in the standard selector row: terminal keys
+    /// (ctrl / shift / esc / tab), navigation, and input controls.
+    static let standardRowGroupButtonCounts = [4, 3, 3]
+
+    static func groupSpacing(isCompact: Bool) -> CGFloat {
+        isCompact ? 6 : 10
+    }
+
+    static func buttonSpacing(isCompact: Bool) -> CGFloat {
+        isCompact ? 1 : 2
+    }
+
+    static func groupHorizontalPadding(isCompact: Bool) -> CGFloat {
+        isCompact ? 3 : 5
+    }
+
+    /// Total width of the standard selector row when every dock button is
+    /// `dockButtonWidth` wide.
+    static func standardRowWidth(dockButtonWidth: CGFloat, isCompact: Bool) -> CGFloat {
+        let groupCount = standardRowGroupButtonCounts.count
+        let buttonCount = standardRowGroupButtonCounts.reduce(0, +)
+        return CGFloat(buttonCount) * dockButtonWidth
+            + CGFloat(buttonCount - groupCount) * buttonSpacing(isCompact: isCompact)
+            + CGFloat(groupCount) * 2 * groupHorizontalPadding(isCompact: isCompact)
+            + CGFloat(max(groupCount - 1, 0)) * groupSpacing(isCompact: isCompact)
+    }
+
+    /// Widest dock button, up to the preferred width for the chrome density,
+    /// that still lets the standard selector row fit inside `availableWidth`.
+    static func fittedDockButtonWidth(availableWidth: CGFloat, isCompact: Bool) -> CGFloat {
+        let preferred = isCompact ? compactDockButtonWidth : dockButtonWidth
+        guard availableWidth.isFinite, availableWidth > 0 else { return preferred }
+
+        let buttonCount = standardRowGroupButtonCounts.reduce(0, +)
+        let fixedWidth = standardRowWidth(dockButtonWidth: 0, isCompact: isCompact)
+        let fitted = floor((availableWidth - fixedWidth) / CGFloat(buttonCount))
+        return min(preferred, max(minimumDockButtonWidth, fitted))
+    }
 
     /// Fallback reservation before the bottom chrome reports its intrinsic
     /// height. Settled chrome subsequently owns its full measured footprint.
@@ -143,7 +183,9 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     let isEnabled: Bool
     let isInteractionLocked: Bool
     let isCompact: Bool
+    let dockButtonWidth: CGFloat
     let isControlArmed: Bool
+    let isShiftArmed: Bool
     let selectedWindowIndex: Int?
     let windowCount: Int
     let paneCount: Int
@@ -155,6 +197,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     let onOpenComposer: () -> Void
     let onToggleKeyboard: () -> Void
     let onToggleControl: () -> Void
+    let onToggleShift: () -> Void
     let onShowShortcuts: () -> Void
     let sendKey: (GhosttySurfaceKeyEvent) -> Bool
     let composerContent: () -> ComposerContent
@@ -177,7 +220,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     @ViewBuilder
     private var standardSelectorRowContainer: some View {
         if #available(iOS 26.0, *) {
-            GlassEffectContainer(spacing: isCompact ? 6 : 10) {
+            GlassEffectContainer(spacing: groupSpacing) {
                 standardSelectorRow
             }
         } else {
@@ -186,7 +229,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     }
 
     private var standardSelectorRow: some View {
-        HStack(spacing: isCompact ? 6 : 10) {
+        HStack(spacing: groupSpacing) {
             terminalKeyControls
             navigationControls
             inputControls
@@ -202,7 +245,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
 
     private var navigationControls: some View {
         controlGroup {
-            HStack(spacing: isCompact ? 1 : 2) {
+            HStack(spacing: buttonSpacing) {
                 GhosttyKeyboardChromeDockButton(
                     systemName: "rectangle.stack",
                     badge: nil,
@@ -250,7 +293,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
 
     private var terminalKeyControls: some View {
         controlGroup {
-            HStack(spacing: isCompact ? 1 : 2) {
+            HStack(spacing: buttonSpacing) {
                 accessoryKey(
                     title: "ctrl",
                     accessibilityIdentifier: "terminal.ctrl",
@@ -258,6 +301,14 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
                     onLongPress: onShowShortcuts
                 ) {
                     onToggleControl()
+                    return true
+                }
+                accessoryKey(
+                    title: "shift",
+                    accessibilityIdentifier: "terminal.shift",
+                    isActive: isShiftArmed
+                ) {
+                    onToggleShift()
                     return true
                 }
                 accessoryKey(title: "esc", accessibilityIdentifier: "terminal.esc") {
@@ -272,7 +323,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
 
     private var inputControls: some View {
         controlGroup {
-            HStack(spacing: isCompact ? 1 : 2) {
+            HStack(spacing: buttonSpacing) {
                 GhosttyKeyboardChromeDockButton(
                     systemName: "house",
                     badge: nil,
@@ -327,7 +378,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
 
     private func controlGroup<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         content()
-            .padding(.horizontal, isCompact ? 3 : 5)
+            .padding(.horizontal, groupHorizontalPadding)
             .padding(.vertical, GhosttyKeyboardChromeSizing.controlGroupVerticalPadding)
             .ghosttyToolbarGroupSurface()
     }
@@ -353,10 +404,16 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
         )
     }
 
-    private var dockButtonWidth: CGFloat {
-        isCompact
-            ? GhosttyKeyboardChromeSizing.compactDockButtonWidth
-            : GhosttyKeyboardChromeSizing.dockButtonWidth
+    private var groupSpacing: CGFloat {
+        GhosttyKeyboardChromeSizing.groupSpacing(isCompact: isCompact)
+    }
+
+    private var buttonSpacing: CGFloat {
+        GhosttyKeyboardChromeSizing.buttonSpacing(isCompact: isCompact)
+    }
+
+    private var groupHorizontalPadding: CGFloat {
+        GhosttyKeyboardChromeSizing.groupHorizontalPadding(isCompact: isCompact)
     }
 
     private var windowDetail: String? {

--- a/RemuxApp/Sources/Ghostty/GhosttyModifierState.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyModifierState.swift
@@ -2,38 +2,78 @@ import Foundation
 
 struct GhosttyModifierState: Equatable {
     private(set) var controlArmed = false
+    private(set) var shiftArmed = false
 
     var isControlArmed: Bool {
         controlArmed
+    }
+
+    var isShiftArmed: Bool {
+        shiftArmed
+    }
+
+    private var isAnyModifierArmed: Bool {
+        controlArmed || shiftArmed
     }
 
     mutating func toggleControl() {
         controlArmed.toggle()
     }
 
-    mutating func clearControl() {
+    mutating func toggleShift() {
+        shiftArmed.toggle()
+    }
+
+    mutating func clearModifiers() {
         controlArmed = false
+        shiftArmed = false
     }
 
     mutating func apply(to text: String) -> String {
-        guard controlArmed else { return text }
-        defer { controlArmed = false }
-        return Self.controlText(for: text) ?? text
+        guard isAnyModifierArmed else { return text }
+        defer { clearModifiers() }
+
+        var outbound = text
+        if shiftArmed {
+            outbound = Self.shiftText(for: outbound) ?? outbound
+        }
+        if controlArmed {
+            outbound = Self.controlText(for: outbound) ?? outbound
+        }
+        return outbound
     }
 
     mutating func apply(to event: GhosttySurfaceKeyEvent) -> GhosttySurfaceKeyEvent {
-        guard controlArmed else { return event }
-        defer { controlArmed = false }
+        guard isAnyModifierArmed else { return event }
+        defer { clearModifiers() }
+
+        var mods = event.mods
+        if controlArmed {
+            mods.insert(.ctrl)
+        }
+        if shiftArmed {
+            mods.insert(.shift)
+        }
 
         return GhosttySurfaceKeyEvent(
             action: event.action,
             keyCode: event.keyCode,
             text: event.text,
             composing: event.composing,
-            mods: event.mods.union(.ctrl),
+            mods: mods,
             consumedMods: event.consumedMods,
             unshiftedCodepoint: event.unshiftedCodepoint
         )
+    }
+
+    /// Shift applied to soft-keyboard text: a single character is uppercased.
+    /// Anything else (digits, punctuation, multi-character input) has no
+    /// layout-independent shifted form, so callers fall back to the original.
+    static func shiftText(for text: String) -> String? {
+        guard text.count == 1 else { return nil }
+        let shifted = text.uppercased()
+        guard shifted.count == 1, shifted != text else { return nil }
+        return shifted
     }
 
     static func controlText(for text: String) -> String? {

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -425,7 +425,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             isEnabled: interactionProjection.isInputAvailable,
                             isInteractionLocked: composer.isSubmitting,
                             isCompact: chrome.isCompact,
+                            dockButtonWidth: chrome.dockButtonWidth,
                             isControlArmed: terminalInputController.isControlArmed,
+                            isShiftArmed: terminalInputController.isShiftArmed,
                             selectedWindowIndex: interactionProjection.selectedWindowIndex,
                             windowCount: interactionProjection.windowCount,
                             paneCount: interactionProjection.paneCount,
@@ -439,6 +441,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             onOpenComposer: openComposer,
                             onToggleKeyboard: toggleKeyboardChrome,
                             onToggleControl: toggleControlModifier,
+                            onToggleShift: toggleShiftModifier,
                             onShowShortcuts: showShortcutPalette,
                             sendKey: sendTerminalKeyEvent
                         ) {
@@ -1388,7 +1391,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private func showShortcutPalette() {
-        terminalInputController.clearControl()
+        terminalInputController.clearModifiers()
         isShortcutPalettePresented = true
     }
 
@@ -1407,6 +1410,13 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     private func toggleControlModifier() {
         terminalInputController.toggleControl()
         if terminalInputController.isControlArmed, inputCoordinator.keyboardMode == .hidden {
+            showSystemKeyboard()
+        }
+    }
+
+    private func toggleShiftModifier() {
+        terminalInputController.toggleShift()
+        if terminalInputController.isShiftArmed, inputCoordinator.keyboardMode == .hidden {
             showSystemKeyboard()
         }
     }
@@ -1601,7 +1611,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 ),
                 makeAttachmentTransferService: attachmentTransferServiceFactory,
                 prepareTerminalInput: {
-                    terminalInputController.clearControl()
+                    terminalInputController.clearModifiers()
                     scrollComposerDestinationToBottom(surfaceID)
                 },
                 sendPaste: { text in
@@ -2427,6 +2437,15 @@ struct GhosttyPhoneChromeLayout: Equatable {
 
     var surfaceHorizontalPadding: CGFloat {
         isCompact ? 8 : 12
+    }
+
+    /// Dock button width that keeps the standard selector row inside the
+    /// screen once the surface padding is applied.
+    var dockButtonWidth: CGFloat {
+        GhosttyKeyboardChromeSizing.fittedDockButtonWidth(
+            availableWidth: screenSize.width - surfaceHorizontalPadding * 2,
+            isCompact: isCompact
+        )
     }
 
     var bottomPadding: CGFloat {

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
@@ -138,12 +138,20 @@ struct GhosttyTerminalInputController: Equatable {
         modifierState.isControlArmed
     }
 
+    var isShiftArmed: Bool {
+        modifierState.isShiftArmed
+    }
+
     mutating func toggleControl() {
         modifierState.toggleControl()
     }
 
-    mutating func clearControl() {
-        modifierState.clearControl()
+    mutating func toggleShift() {
+        modifierState.toggleShift()
+    }
+
+    mutating func clearModifiers() {
+        modifierState.clearModifiers()
     }
 
     mutating func receiveText(_ text: String) -> TextAction {

--- a/RemuxAppTests/GhosttyModifierStateTests.swift
+++ b/RemuxAppTests/GhosttyModifierStateTests.swift
@@ -46,4 +46,85 @@ final class GhosttyModifierStateTests: XCTestCase {
         XCTAssertFalse(state.isControlArmed)
     }
 
+    func testShiftLatchUppercasesLetterAndClears() {
+        var state = GhosttyModifierState()
+        state.toggleShift()
+
+        XCTAssertEqual(state.apply(to: "a"), "A")
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testShiftLatchFallsBackToPlainTextAndClears() {
+        var state = GhosttyModifierState()
+        state.toggleShift()
+
+        XCTAssertEqual(state.apply(to: "7"), "7")
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testShiftLatchLeavesMultiCharacterTextUntouched() {
+        var state = GhosttyModifierState()
+        state.toggleShift()
+
+        XCTAssertEqual(state.apply(to: "ls"), "ls")
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testShiftLatchAddsShiftModifierToKeyEvent() {
+        var state = GhosttyModifierState()
+        state.toggleShift()
+        let event = GhosttySurfaceKeyEvent(keyCode: .tab)
+
+        XCTAssertEqual(
+            state.apply(to: event),
+            GhosttySurfaceKeyEvent(keyCode: .tab, mods: [.shift])
+        )
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testControlAndShiftLatchesCombineOnKeyEventAndClear() {
+        var state = GhosttyModifierState()
+        state.toggleControl()
+        state.toggleShift()
+        let event = GhosttySurfaceKeyEvent(keyCode: .arrowUp)
+
+        XCTAssertEqual(
+            state.apply(to: event),
+            GhosttySurfaceKeyEvent(keyCode: .arrowUp, mods: [.ctrl, .shift])
+        )
+        XCTAssertFalse(state.isControlArmed)
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testControlAndShiftLatchesCombineOnTextAndClear() {
+        var state = GhosttyModifierState()
+        state.toggleControl()
+        state.toggleShift()
+
+        XCTAssertEqual(state.apply(to: "a"), "\u{01}")
+        XCTAssertFalse(state.isControlArmed)
+        XCTAssertFalse(state.isShiftArmed)
+    }
+
+    func testTogglingControlLeavesShiftLatchAlone() {
+        var state = GhosttyModifierState()
+        state.toggleShift()
+        state.toggleControl()
+        state.toggleControl()
+
+        XCTAssertTrue(state.isShiftArmed)
+        XCTAssertFalse(state.isControlArmed)
+    }
+
+    func testClearModifiersDisarmsBothLatches() {
+        var state = GhosttyModifierState()
+        state.toggleControl()
+        state.toggleShift()
+
+        state.clearModifiers()
+
+        XCTAssertFalse(state.isControlArmed)
+        XCTAssertFalse(state.isShiftArmed)
+        XCTAssertEqual(state.apply(to: "a"), "a")
+    }
 }

--- a/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
+++ b/RemuxAppTests/GhosttyPhoneChromeLayoutTests.swift
@@ -34,6 +34,52 @@ final class GhosttyPhoneChromeLayoutTests: XCTestCase {
         XCTAssertEqual(layout.bottomPadding, 2)
     }
 
+    func testDockButtonWidthShrinksSoStandardRowFitsNarrowPhone() {
+        let layout = GhosttyPhoneChromeLayout(
+            screenSize: CGSize(width: 375, height: 667)
+        )
+
+        XCTAssertEqual(layout.dockButtonWidth, 32)
+        XCTAssertLessThanOrEqual(
+            GhosttyKeyboardChromeSizing.standardRowWidth(
+                dockButtonWidth: layout.dockButtonWidth,
+                isCompact: layout.isCompact
+            ),
+            375 - layout.surfaceHorizontalPadding * 2
+        )
+    }
+
+    func testDockButtonWidthShrinksSoStandardRowFitsExpandedChrome() {
+        let layout = GhosttyPhoneChromeLayout(
+            screenSize: CGSize(width: 430, height: 932)
+        )
+
+        XCTAssertFalse(layout.isCompact)
+        XCTAssertEqual(layout.dockButtonWidth, 34)
+        XCTAssertLessThanOrEqual(
+            GhosttyKeyboardChromeSizing.standardRowWidth(
+                dockButtonWidth: layout.dockButtonWidth,
+                isCompact: layout.isCompact
+            ),
+            430 - layout.surfaceHorizontalPadding * 2
+        )
+    }
+
+    func testDockButtonWidthKeepsPreferredWidthWhenStandardRowFits() {
+        let layout = GhosttyPhoneChromeLayout(
+            screenSize: CGSize(width: 844, height: 390)
+        )
+
+        XCTAssertEqual(layout.dockButtonWidth, GhosttyKeyboardChromeSizing.compactDockButtonWidth)
+    }
+
+    func testDockButtonWidthNeverDropsBelowMinimum() {
+        XCTAssertEqual(
+            GhosttyKeyboardChromeSizing.fittedDockButtonWidth(availableWidth: 200, isCompact: true),
+            GhosttyKeyboardChromeSizing.minimumDockButtonWidth
+        )
+    }
+
     func testKeyboardFrameInsideScreenIsVisible() {
         XCTAssertTrue(
             GhosttySoftwareKeyboardVisibility.isVisible(

--- a/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
+++ b/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
@@ -616,6 +616,38 @@ final class GhosttyTerminalInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(controller.isControlArmed)
     }
 
+    func testInputControllerShiftTextSubmitsUppercasedInputAndClearsShift() {
+        var controller = GhosttyTerminalInputController()
+        controller.toggleShift()
+
+        XCTAssertEqual(controller.receiveText("a"), .submit("A"))
+
+        XCTAssertFalse(controller.isShiftArmed)
+    }
+
+    func testInputControllerShiftKeyAddsShiftModifierAndClearsShift() {
+        var controller = GhosttyTerminalInputController()
+        controller.toggleShift()
+        let event = GhosttySurfaceKeyEvent(keyCode: .tab)
+
+        let action = controller.receiveKeyEvent(event)
+
+        XCTAssertNil(action.pendingPrefixInput)
+        XCTAssertEqual(action.event, GhosttySurfaceKeyEvent(keyCode: .tab, mods: [.shift]))
+        XCTAssertFalse(controller.isShiftArmed)
+    }
+
+    func testInputControllerClearModifiersDisarmsControlAndShift() {
+        var controller = GhosttyTerminalInputController()
+        controller.toggleControl()
+        controller.toggleShift()
+
+        controller.clearModifiers()
+
+        XCTAssertFalse(controller.isControlArmed)
+        XCTAssertFalse(controller.isShiftArmed)
+    }
+
     func testInputControllerPrefixArmsFlushWithoutSubmitting() {
         var controller = GhosttyTerminalInputController()
 


### PR DESCRIPTION
Adds a sticky **shift** key next to **ctrl** in the terminal key group (ctrl / shift / esc / tab).

- Works like ctrl: tap to arm, applies to the next key or character, then clears. Tap again to disarm.
- Key events gain the shift modifier bit, so shift+tab (backtab), shift+arrows, shift+enter, and shift+esc reach the terminal.
- Typed single letters from the soft keyboard are uppercased. Digits, punctuation, and multi-character input pass through unchanged since the shifted symbol depends on keyboard layout.
- Ctrl and shift can be armed together and both apply to the same key.
- Arming shift with the keyboard hidden reveals the system keyboard, matching ctrl.
- Opening the shortcut palette or submitting from the composer now clears both latches (`clearControl` renamed to `clearModifiers`).
- Accessibility identifier: `terminal.shift`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Shift accessory key to the terminal keyboard controls.
  * Shift can be latched independently or combined with Control.
  * Latched Shift automatically uppercases eligible single-character text and applies Shift to key events.
  * Modifier state is cleared after shortcut-palette actions and composer submission.
  * Dock buttons now adapt their width to fit narrower screens.

* **Documentation**
  * Updated keyboard feedback documentation to include Shift.

* **Tests**
  * Added coverage for Shift behavior, modifier clearing, and responsive dock button sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->