### PR TITLE
fix keyboard focus in shortcut sheets

### DIFF
--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -689,7 +689,10 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
     }
 
     private var isTransientInputOwnerPresented: Bool {
-        isAttachmentInputOwnerPresented || terminalCoverPhase.ownsTerminalInput
+        isAttachmentInputOwnerPresented
+            || isShortcutsSettingsPresented
+            || shortcutEditorRequest != nil
+            || terminalCoverPhase.ownsTerminalInput
     }
 
     private var selectionSheetBinding: Binding<GhosttySurfaceSelectionSheet?> {


### PR DESCRIPTION
## Summary

Fix typing in the shortcut editor going to the terminal behind it when opened with the keyboard already visible.

The terminal now yields keyboard focus while the shortcut editor or shortcut settings sheet is presented. Dismissing the sheet restores the existing terminal keyboard behavior.

Uses the existing presentation state and focus policy; no new timers or state.

Related to #75.

## Validation

- Verified creating and editing shortcuts with the keyboard already open.
- Verified Title, Hint, and command text stay in the form.
- Verified save, cancel, swipe dismissal, and nested settings.
- Verified the keyboard returns to its previous open/hidden state.
- Verified shortcut execution and terminal input over SSH/tmux.
- 66 existing focus/input regression tests passed.
- Installed and checked on a physical iPhone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard focus handling while shortcut settings sheets or shortcut editors are open.
  - Terminal input and keyboard viewport behavior now correctly account for these temporary interface states, preventing unintended focus or layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->