### PR TITLE
fix window picker selection being undone by viewport resizing

### DIFF
--- a/RemuxApp/Sources/Tmux/TmuxSessionController.swift
+++ b/RemuxApp/Sources/Tmux/TmuxSessionController.swift
@@ -1293,8 +1293,10 @@ final class TmuxSessionController: @unchecked Sendable {
               !hasOutstandingViewportClaim
         else { return false }
 
+        // Resolve the current window on tmux so a viewport claim cannot
+        // undo navigation while our topology snapshot is still stale.
         let (result, token) = enqueueCommandTokenOnWriter(
-            "select-window -t @\(activeWindowID.rawValue)",
+            "select-window",
             client: client
         )
         guard result == GHOSTTY_TMUX_RESULT_OK else {

--- a/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
+++ b/RemuxAppTests/TmuxSessionControllerClientSizeTests.swift
@@ -757,7 +757,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         harness.controller.reclaimActiveViewport()
         await drain(harness.controller)
-        XCTAssertEqual(harness.recorder.takeStrings(), ["select-window -t @0\n"])
+        XCTAssertEqual(harness.recorder.takeStrings(), ["select-window\n"])
 
         harness.controller.pump(Data(responseBlock(
             commandNumber: &nextCommandNumber
@@ -768,7 +768,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["select-window -t @0\n"],
+            ["select-window\n"],
             "a matching reclaim must not wait for a layout change that tmux will not emit"
         )
     }
@@ -789,7 +789,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["select-window -t @0\nsend-keys -H -t %0 61\n"]
+            ["select-window\nsend-keys -H -t %0 61\n"]
         )
 
         XCTAssertTrue(harness.controller.sendInput(paneID: 0, Data("b".utf8)))
@@ -829,7 +829,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
         await drain(harness.controller)
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["select-window -t @0\nsend-keys -H -t %0 64\n"]
+            ["select-window\nsend-keys -H -t %0 64\n"]
         )
     }
 
@@ -848,7 +848,31 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["refresh-client -C 100x40\nselect-window -t @0\n"]
+            ["refresh-client -C 100x40\nselect-window\n"]
+        )
+    }
+
+    func testViewportClaimDoesNotRetargetWindowWhileSelectionReplyIsPending() async throws {
+        let harness = try await readyController(
+            listWindowsBody: Self.twoSinglePaneWindows,
+            expectedPaneCount: 2
+        )
+
+        harness.controller.requestSelectWindow(windowID: 1)
+        await drain(harness.controller)
+        XCTAssertEqual(harness.recorder.takeStrings(), ["select-window -t @1\n"])
+
+        // Leave the selection reply and topology update pending during the resize.
+        harness.controller.setClientSize(
+            cols: 100,
+            rows: 40,
+            claimActiveViewport: true
+        )
+        await drain(harness.controller)
+
+        XCTAssertEqual(
+            harness.recorder.takeStrings(),
+            ["refresh-client -C 100x40\nselect-window\n"]
         )
     }
 
@@ -868,7 +892,7 @@ final class TmuxSessionControllerClientSizeTests: XCTestCase {
 
         XCTAssertEqual(
             harness.recorder.takeStrings(),
-            ["select-window -t @0\nnew-window\n"]
+            ["select-window\nnew-window\n"]
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #74.

Selecting a window could briefly switch to it and then return to the previous window. When dismissing the picker triggered a viewport resize before tmux’s selection reply arrived, the automatic viewport claim explicitly reselected the old window from Remux’s stale topology snapshot.

Viewport claims now use `select-window` without an explicit target, letting tmux resolve its current window when executing the command. User-initiated navigation retains explicit targets.

No additional commands, round trips, timers, or state.

## Validation

- Reproduced the original failure on the simulator against a real SSH/tmux server with delayed replies.
- Verified window selection with the keyboard visible and hidden, swiping, pane selection, splitting, zooming, typing, and pane/window removal.
- Verified viewport reclamation with another attached client and after returning from another iOS app.
- All 47 controller tests passed.
- Added a regression test for resizing while a window-selection reply is pending; it fails before the fix and passed 10 consecutive runs afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved viewport claiming to preserve the window currently selected in tmux, even when local session information is temporarily out of date.
  - Prevented viewport claims from unexpectedly changing the user’s active window while a selection update is still pending.
  - Added coverage to verify window selection remains stable during these transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->