### PR TITLE
bring toolbar customization into main

### DIFF
--- a/RemuxApp/Sources/App/RemuxRootModel.swift
+++ b/RemuxApp/Sources/App/RemuxRootModel.swift
@@ -95,6 +95,7 @@ struct ActiveTerminalScreenEntry: Identifiable {
             workspaceID: session.target.workspace.id,
             sessionName: session.target.workspace.sessionName,
             terminalTheme: session.target.terminalSettings.theme,
+            toolbarKeys: session.target.terminalSettings.toolbarKeys,
             loadingTitle: TerminalRuntimeStatusPresentation.projection(
                 for: session.runtimeState
             ).loadingTitle ?? TerminalRuntimeStatusPresentation.defaultLoadingTitle

--- a/RemuxApp/Sources/App/RootView.swift
+++ b/RemuxApp/Sources/App/RootView.swift
@@ -1900,6 +1900,24 @@ private struct TerminalSettingsView: View {
 
             Section("Keyboard") {
                 NavigationLink {
+                    TerminalToolbarKeysSettingsView(
+                        toolbarKeys: toolbarKeysBinding,
+                        theme: settings.theme
+                    )
+                } label: {
+                    Label {
+                        LabeledContent("Toolbar Keys") {
+                            Text(settings.toolbarKeys.compactSummary)
+                                .foregroundStyle(.secondary)
+                        }
+                    } icon: {
+                        Image(systemName: "keyboard.badge.ellipsis")
+                    }
+                }
+                .accessibilityIdentifier("settings.toolbar-keys")
+                .accessibilityValue(settings.toolbarKeys.summary)
+
+                NavigationLink {
                     ShortcutsSettingsView(
                         store: shortcutStore,
                         theme: settings.theme
@@ -1989,6 +2007,91 @@ private struct TerminalSettingsView: View {
             set: { value in
                 settings.zoomMultipaneWindowsByDefault = value
                 sourceSettings = settings
+            }
+        )
+    }
+
+    private var toolbarKeysBinding: Binding<TerminalToolbarKeys> {
+        Binding(
+            get: { settings.toolbarKeys },
+            set: { value in
+                settings.toolbarKeys = value
+                sourceSettings = settings
+            }
+        )
+    }
+}
+
+private struct TerminalToolbarKeysSettingsView: View {
+    @Binding var toolbarKeys: TerminalToolbarKeys
+    let theme: TerminalTheme
+
+    var body: some View {
+        Form {
+            Section {
+                toolbarKeyPicker(
+                    "First Key",
+                    selection: binding(for: \.first),
+                    identifier: "settings.toolbar-keys.slot.0"
+                )
+                toolbarKeyPicker(
+                    "Second Key",
+                    selection: binding(for: \.second),
+                    identifier: "settings.toolbar-keys.slot.1"
+                )
+                toolbarKeyPicker(
+                    "Third Key",
+                    selection: binding(for: \.third),
+                    identifier: "settings.toolbar-keys.slot.2"
+                )
+            } header: {
+                Text("Key Layout")
+            } footer: {
+                Text(
+                    "These keys appear on the left side of the terminal toolbar. "
+                        + "Touch and hold the first key to open Shortcuts."
+                )
+            }
+            .libraryHomeListRowSurface()
+
+            if toolbarKeys != .default {
+                Section {
+                    Button("Reset to Defaults") {
+                        toolbarKeys = .default
+                    }
+                    .accessibilityIdentifier("settings.toolbar-keys.reset")
+                }
+                .libraryHomeListRowSurface()
+            }
+        }
+        .libraryHomeGroupedScrollBackground()
+        .libraryHomeChrome(theme: theme)
+        .navigationTitle("Toolbar Keys")
+        .navigationBarTitleDisplayMode(.inline)
+        .accessibilityIdentifier("settings.toolbar-keys.form")
+    }
+
+    private func toolbarKeyPicker(
+        _ title: String,
+        selection: Binding<TerminalToolbarKey>,
+        identifier: String
+    ) -> some View {
+        Picker(title, selection: selection) {
+            ForEach(TerminalToolbarKey.allCases, id: \.self) { key in
+                Text(key.settingsTitle).tag(key)
+            }
+        }
+        .pickerStyle(.navigationLink)
+        .accessibilityIdentifier(identifier)
+    }
+
+    private func binding(
+        for keyPath: WritableKeyPath<TerminalToolbarKeys, TerminalToolbarKey>
+    ) -> Binding<TerminalToolbarKey> {
+        Binding(
+            get: { toolbarKeys[keyPath: keyPath] },
+            set: { value in
+                toolbarKeys[keyPath: keyPath] = value
             }
         )
     }

--- a/RemuxApp/Sources/Domain/TerminalSettings.swift
+++ b/RemuxApp/Sources/Domain/TerminalSettings.swift
@@ -125,6 +125,122 @@ enum TerminalTheme: String, CaseIterable, Codable, Identifiable, Sendable {
     }
 }
 
+enum TerminalToolbarKey: String, CaseIterable, Codable, Sendable {
+    case control
+    case escape
+    case tab
+    case enter
+    case backspace
+    case delete
+    case arrowUp
+    case arrowDown
+    case arrowLeft
+    case arrowRight
+    case home
+    case end
+    case pageUp
+    case pageDown
+
+    var settingsTitle: String {
+        switch self {
+        case .control:
+            "Control"
+        case .escape:
+            "Escape"
+        case .tab:
+            "Tab"
+        case .enter:
+            "Enter"
+        case .backspace:
+            "Backspace"
+        case .delete:
+            "Delete"
+        case .arrowUp:
+            "Up Arrow"
+        case .arrowDown:
+            "Down Arrow"
+        case .arrowLeft:
+            "Left Arrow"
+        case .arrowRight:
+            "Right Arrow"
+        case .home:
+            "Home"
+        case .end:
+            "End"
+        case .pageUp:
+            "Page Up"
+        case .pageDown:
+            "Page Down"
+        }
+    }
+
+    var toolbarTitle: String {
+        switch self {
+        case .control:
+            "ctrl"
+        case .escape:
+            "esc"
+        case .tab:
+            "tab"
+        case .enter:
+            "enter"
+        case .backspace:
+            "⌫"
+        case .delete:
+            "del"
+        case .arrowUp:
+            "↑"
+        case .arrowDown:
+            "↓"
+        case .arrowLeft:
+            "←"
+        case .arrowRight:
+            "→"
+        case .home:
+            "home"
+        case .end:
+            "end"
+        case .pageUp:
+            "pgup"
+        case .pageDown:
+            "pgdn"
+        }
+    }
+
+    var shortcutKey: ShortcutKey? {
+        guard self != .control else { return nil }
+        return ShortcutKey(rawValue: rawValue)
+    }
+}
+
+struct TerminalToolbarKeys: Equatable, Codable, Sendable {
+    static let `default` = Self(
+        first: .control,
+        second: .escape,
+        third: .tab
+    )
+
+    var first: TerminalToolbarKey
+    var second: TerminalToolbarKey
+    var third: TerminalToolbarKey
+
+    var values: [TerminalToolbarKey] {
+        [first, second, third]
+    }
+
+    var summary: String {
+        values.map(\.settingsTitle).joined(separator: ", ")
+    }
+
+    var compactSummary: String {
+        values.map(\.toolbarTitle).joined(separator: " · ")
+    }
+
+    var containsControl: Bool {
+        values.contains(.control)
+    }
+}
+
 struct TerminalSettings: Equatable, Codable, Sendable {
     static let minimumFontSize: Float32 = 8
     static let maximumFontSize: Float32 = 24
@@ -143,16 +259,22 @@ struct TerminalSettings: Equatable, Codable, Sendable {
     /// or this global preference changes.
     var zoomMultipaneWindowsByDefault: Bool
 
+    /// The three configurable keys shown on the leading side of the terminal
+    /// toolbar. The first key owns the long-press shortcut-palette gesture.
+    var toolbarKeys: TerminalToolbarKeys
+
     init(
         fontSize: Float32?,
         theme: TerminalTheme,
         allowInsecureRSAHostKeys: Bool = false,
-        zoomMultipaneWindowsByDefault: Bool = false
+        zoomMultipaneWindowsByDefault: Bool = false,
+        toolbarKeys: TerminalToolbarKeys = .default
     ) {
         self.fontSize = Self.normalizedFontSize(fontSize)
         self.theme = theme
         self.allowInsecureRSAHostKeys = allowInsecureRSAHostKeys
         self.zoomMultipaneWindowsByDefault = zoomMultipaneWindowsByDefault
+        self.toolbarKeys = toolbarKeys
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -160,6 +282,7 @@ struct TerminalSettings: Equatable, Codable, Sendable {
         case theme
         case allowInsecureRSAHostKeys
         case zoomMultipaneWindowsByDefault
+        case toolbarKeys
     }
 
     // Custom decoding keeps older persisted settings (written before these keys
@@ -173,7 +296,11 @@ struct TerminalSettings: Equatable, Codable, Sendable {
             zoomMultipaneWindowsByDefault: try container.decodeIfPresent(
                 Bool.self,
                 forKey: .zoomMultipaneWindowsByDefault
-            ) ?? decoder.userInfo[.terminalSettingsDefaultMultipaneZoom] as? Bool ?? false
+            ) ?? decoder.userInfo[.terminalSettingsDefaultMultipaneZoom] as? Bool ?? false,
+            toolbarKeys: try container.decodeIfPresent(
+                TerminalToolbarKeys.self,
+                forKey: .toolbarKeys
+            ) ?? .default
         )
     }
 

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -144,6 +144,7 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     let isInteractionLocked: Bool
     let isCompact: Bool
     let isControlArmed: Bool
+    let toolbarKeys: TerminalToolbarKeys
     let selectedWindowIndex: Int?
     let windowCount: Int
     let paneCount: Int
@@ -251,20 +252,18 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
     private var terminalKeyControls: some View {
         controlGroup {
             HStack(spacing: isCompact ? 1 : 2) {
-                accessoryKey(
-                    title: "ctrl",
-                    accessibilityIdentifier: "terminal.ctrl",
-                    isActive: isControlArmed,
-                    onLongPress: onShowShortcuts
-                ) {
-                    onToggleControl()
-                    return true
-                }
-                accessoryKey(title: "esc", accessibilityIdentifier: "terminal.esc") {
-                    sendKey(.init(keyCode: .escape))
-                }
-                accessoryKey(title: "tab", accessibilityIdentifier: "terminal.tab") {
-                    sendKey(.init(keyCode: .tab))
+                ForEach(Array(toolbarKeys.values.enumerated()), id: \.offset) { index, key in
+                    accessoryKey(
+                        title: key.toolbarTitle,
+                        accessibilityLabel: key.settingsTitle,
+                        accessibilityHint: toolbarKeyAccessibilityHint(key),
+                        accessibilityIdentifier: "terminal.toolbar-key.\(index)",
+                        accessibilityValue: key == .control && isControlArmed ? "Armed" : nil,
+                        isActive: key == .control && isControlArmed,
+                        onLongPress: index == 0 ? onShowShortcuts : nil
+                    ) {
+                        activateToolbarKey(key)
+                    }
                 }
             }
         }
@@ -334,14 +333,20 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
 
     private func accessoryKey(
         title: String,
+        accessibilityLabel: String,
+        accessibilityHint: String? = nil,
         accessibilityIdentifier: String,
+        accessibilityValue: String? = nil,
         isActive: Bool = false,
         onLongPress: (() -> Void)? = nil,
         action: @escaping () -> Bool
     ) -> some View {
         GhosttyKeyboardKeyButton(
             title: title,
+            accessibilityLabel: accessibilityLabel,
+            accessibilityHint: accessibilityHint,
             accessibilityIdentifier: accessibilityIdentifier,
+            accessibilityValue: accessibilityValue,
             chromeStyle: chromeStyle,
             fontSize: 12,
             width: dockButtonWidth,
@@ -351,6 +356,23 @@ struct GhosttyKeyboardChrome<ComposerContent: View>: View {
             onLongPress: onLongPress,
             action: action
         )
+    }
+
+    private func activateToolbarKey(_ key: TerminalToolbarKey) -> Bool {
+        if key == .control {
+            onToggleControl()
+            return true
+        }
+
+        guard let keyCode = key.shortcutKey?.ghosttyKeyCode else { return false }
+        return sendKey(.init(keyCode: keyCode))
+    }
+
+    private func toolbarKeyAccessibilityHint(_ key: TerminalToolbarKey) -> String {
+        if key == .control {
+            return "Arms Control for the next terminal input."
+        }
+        return "Sends \(key.settingsTitle) to the terminal."
     }
 
     private var dockButtonWidth: CGFloat {
@@ -450,7 +472,10 @@ private struct GhosttyKeyboardChromeDockButton: View {
 
 private struct GhosttyKeyboardKeyButton: View {
     let title: String
+    let accessibilityLabel: String
+    let accessibilityHint: String?
     let accessibilityIdentifier: String
+    let accessibilityValue: String?
     let chromeStyle: GhosttyTerminalChromeStyle
     var fontSize: CGFloat = 13
     var width: CGFloat = GhosttyKeyboardChromeSizing.dockButtonWidth
@@ -479,9 +504,16 @@ private struct GhosttyKeyboardKeyButton: View {
             .scaleEffect(isPressed && isEnabled ? 0.96 : 1)
             .opacity(isEnabled ? 1 : 0.42)
             .contentShape(Rectangle())
-            .accessibilityLabel(title)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint(accessibilityHint ?? "")
+            .accessibilityValue(accessibilityValue ?? "")
             .accessibilityIdentifier(accessibilityIdentifier)
             .accessibilityAddTraits(.isButton)
+            .accessibilityActions {
+                if let onLongPress {
+                    Button("Open Shortcuts", action: onLongPress)
+                }
+            }
             .onTapGesture {
                 guard isEnabled else { return }
                 isPressed = false

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -486,7 +486,6 @@ private struct GhosttyKeyboardKeyButton: View {
     let action: () -> Bool
 
     @State private var isPressed = false
-    @State private var didLongPress = false
 
     var body: some View {
         Text(title)
@@ -517,10 +516,6 @@ private struct GhosttyKeyboardKeyButton: View {
             .onTapGesture {
                 guard isEnabled else { return }
                 isPressed = false
-                if didLongPress {
-                    didLongPress = false
-                    return
-                }
                 _ = action()
             }
             .onLongPressGesture(
@@ -535,7 +530,6 @@ private struct GhosttyKeyboardKeyButton: View {
                 },
                 perform: {
                     guard isEnabled, let onLongPress else { return }
-                    didLongPress = true
                     Haptic.tap(.medium)
                     onLongPress()
                 }

--- a/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyKeyboardChrome.swift
@@ -510,7 +510,7 @@ private struct GhosttyKeyboardKeyButton: View {
             .accessibilityIdentifier(accessibilityIdentifier)
             .accessibilityAddTraits(.isButton)
             .accessibilityActions {
-                if let onLongPress {
+                if isEnabled, let onLongPress {
                     Button("Open Shortcuts", action: onLongPress)
                 }
             }
@@ -534,12 +534,13 @@ private struct GhosttyKeyboardKeyButton: View {
                     isPressed = pressing
                 },
                 perform: {
-                    guard let onLongPress else { return }
+                    guard isEnabled, let onLongPress else { return }
                     didLongPress = true
                     Haptic.tap(.medium)
                     onLongPress()
                 }
             )
+            .disabled(!isEnabled)
     }
 }
 

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceKeyEvent.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceKeyEvent.swift
@@ -115,3 +115,36 @@ struct GhosttySurfaceKeyEvent: Equatable {
         return body(event)
     }
 }
+
+extension ShortcutKey {
+    var ghosttyKeyCode: GhosttySurfaceKeyEvent.KeyCode {
+        switch self {
+        case .escape:
+            .escape
+        case .tab:
+            .tab
+        case .enter:
+            .enter
+        case .backspace:
+            .backspace
+        case .delete:
+            .delete
+        case .arrowUp:
+            .arrowUp
+        case .arrowDown:
+            .arrowDown
+        case .arrowLeft:
+            .arrowLeft
+        case .arrowRight:
+            .arrowRight
+        case .home:
+            .home
+        case .end:
+            .end
+        case .pageUp:
+            .pageUp
+        case .pageDown:
+            .pageDown
+        }
+    }
+}

--- a/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttySurfaceScreen.swift
@@ -10,6 +10,7 @@ struct GhosttySurfaceScreenPresentation: Equatable {
     let workspaceID: SavedWorkspace.ID
     let sessionName: String
     let terminalTheme: TerminalTheme
+    let toolbarKeys: TerminalToolbarKeys
     let loadingTitle: String
 }
 
@@ -426,6 +427,7 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                             isInteractionLocked: composer.isSubmitting,
                             isCompact: chrome.isCompact,
                             isControlArmed: terminalInputController.isControlArmed,
+                            toolbarKeys: presentation.toolbarKeys,
                             selectedWindowIndex: interactionProjection.selectedWindowIndex,
                             windowCount: interactionProjection.windowCount,
                             paneCount: interactionProjection.paneCount,
@@ -468,6 +470,9 @@ struct GhosttySurfaceScreen<Model: GhosttyTerminalScreenModeling>: View {
                 GhosttyRuntimeTrace.tmuxViewport(
                     "viewport.bottomChrome old=\(previousHeight.traceLabel) new=\(bottomChromeReservation.settledHeight.traceLabel) rendered=\(renderedHeight.traceLabel) keyboardMode=\(inputCoordinator.keyboardMode.traceLabel) renderedMode=\(renderedKeyboardMode.traceLabel) softwareKeyboardVisible=\(inputCoordinator.isSoftwareKeyboardVisible) overlap=\(softwareKeyboardOverlapHeight.traceLabel)"
                 )
+            }
+            .onChange(of: presentation.toolbarKeys) { _, toolbarKeys in
+                terminalInputController.reconcileToolbarKeys(toolbarKeys)
             }
             .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) {
                 guard shouldHandleTerminalKeyboardNotification else { return }

--- a/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
+++ b/RemuxApp/Sources/Ghostty/GhosttyTerminalInputCoordinator.swift
@@ -146,6 +146,12 @@ struct GhosttyTerminalInputController: Equatable {
         modifierState.clearControl()
     }
 
+    mutating func reconcileToolbarKeys(_ toolbarKeys: TerminalToolbarKeys) {
+        if !toolbarKeys.containsControl {
+            clearControl()
+        }
+    }
+
     mutating func receiveText(_ text: String) -> TextAction {
         let outbound = modifierState.apply(to: text)
         switch tmuxPrefixInputBuffer.handleText(outbound) {

--- a/RemuxApp/Sources/Ghostty/ShortcutExecutor.swift
+++ b/RemuxApp/Sources/Ghostty/ShortcutExecutor.swift
@@ -63,39 +63,6 @@ struct ShortcutExecutor {
     }
 }
 
-private extension ShortcutKey {
-    var ghosttyKeyCode: GhosttySurfaceKeyEvent.KeyCode {
-        switch self {
-        case .escape:
-            .escape
-        case .tab:
-            .tab
-        case .enter:
-            .enter
-        case .backspace:
-            .backspace
-        case .delete:
-            .delete
-        case .arrowUp:
-            .arrowUp
-        case .arrowDown:
-            .arrowDown
-        case .arrowLeft:
-            .arrowLeft
-        case .arrowRight:
-            .arrowRight
-        case .home:
-            .home
-        case .end:
-            .end
-        case .pageUp:
-            .pageUp
-        case .pageDown:
-            .pageDown
-        }
-    }
-}
-
 private extension ShortcutModifiers {
     var ghosttyModifiers: GhosttySurfaceKeyEvent.Mods {
         var result: GhosttySurfaceKeyEvent.Mods = []

--- a/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
+++ b/RemuxAppTests/GhosttyTerminalInputCoordinatorTests.swift
@@ -616,6 +616,29 @@ final class GhosttyTerminalInputCoordinatorTests: XCTestCase {
         XCTAssertFalse(controller.isControlArmed)
     }
 
+    func testInputControllerClearsArmedControlWhenToolbarNoLongerContainsControl() {
+        var controller = GhosttyTerminalInputController()
+        controller.toggleControl()
+
+        controller.reconcileToolbarKeys(
+            TerminalToolbarKeys(first: .escape, second: .tab, third: .arrowUp)
+        )
+
+        XCTAssertFalse(controller.isControlArmed)
+        XCTAssertEqual(controller.receiveText("c"), .submit("c"))
+    }
+
+    func testInputControllerKeepsArmedControlWhenToolbarStillContainsControl() {
+        var controller = GhosttyTerminalInputController()
+        controller.toggleControl()
+
+        controller.reconcileToolbarKeys(
+            TerminalToolbarKeys(first: .escape, second: .control, third: .tab)
+        )
+
+        XCTAssertTrue(controller.isControlArmed)
+    }
+
     func testInputControllerPrefixArmsFlushWithoutSubmitting() {
         var controller = GhosttyTerminalInputController()
 

--- a/RemuxAppTests/RemuxRootModelTests.swift
+++ b/RemuxAppTests/RemuxRootModelTests.swift
@@ -3670,8 +3670,26 @@ final class RemuxRootModelTests: XCTestCase {
         XCTAssertEqual(rsaRefreshedSession.instanceID, originalSession.instanceID)
         XCTAssertEqual(rsaRefreshedSession.target.terminalSettings, rsaUpdated)
         XCTAssertTrue(originalModel === harness.model.terminalScreenModel(for: rsaRefreshedSession))
+
+        var toolbarUpdated = rsaUpdated
+        toolbarUpdated.toolbarKeys = TerminalToolbarKeys(
+            first: .pageDown,
+            second: .control,
+            third: .home
+        )
+        await harness.model.updateTerminalSettings { settings in
+            settings = toolbarUpdated
+        }
+
+        let toolbarRefreshedSession = try XCTUnwrap(harness.model.activeSessions.first)
+        let toolbarEntry = try XCTUnwrap(harness.model.activeTerminalScreenEntries.first)
+        XCTAssertEqual(toolbarRefreshedSession.instanceID, originalSession.instanceID)
+        XCTAssertEqual(toolbarEntry.runtimeAttemptKey, originalKey)
+        XCTAssertEqual(toolbarEntry.presentation.toolbarKeys, toolbarUpdated.toolbarKeys)
+        XCTAssertTrue(originalModel === harness.model.terminalScreenModel(for: toolbarRefreshedSession))
+        XCTAssertEqual(factory.createdKeys, [originalKey])
         let savedSettings = try await harness.settingsRepository.loadSettings()
-        XCTAssertEqual(savedSettings, rsaUpdated)
+        XCTAssertEqual(savedSettings, toolbarUpdated)
     }
 
     private func makeHarness(

--- a/RemuxAppTests/TerminalSettingsRepositoryTests.swift
+++ b/RemuxAppTests/TerminalSettingsRepositoryTests.swift
@@ -44,7 +44,12 @@ final class TerminalSettingsRepositoryTests: XCTestCase {
             fontSize: 16,
             theme: .remuxLight,
             allowInsecureRSAHostKeys: true,
-            zoomMultipaneWindowsByDefault: true
+            zoomMultipaneWindowsByDefault: true,
+            toolbarKeys: TerminalToolbarKeys(
+                first: .pageDown,
+                second: .control,
+                third: .pageDown
+            )
         )
 
         try await repository.saveSettings(saved)

--- a/RemuxAppTests/TerminalSettingsTests.swift
+++ b/RemuxAppTests/TerminalSettingsTests.swift
@@ -25,6 +25,51 @@ final class TerminalSettingsTests: XCTestCase {
 
         XCTAssertFalse(settings.allowInsecureRSAHostKeys)
         XCTAssertFalse(settings.zoomMultipaneWindowsByDefault)
+        XCTAssertEqual(settings.toolbarKeys, .default)
+    }
+
+    func testToolbarKeysExposeCompactAndAccessibleTitles() {
+        XCTAssertEqual(TerminalToolbarKey.control.toolbarTitle, "ctrl")
+        XCTAssertEqual(TerminalToolbarKey.control.settingsTitle, "Control")
+        XCTAssertEqual(TerminalToolbarKey.pageDown.toolbarTitle, "pgdn")
+        XCTAssertEqual(TerminalToolbarKey.pageDown.settingsTitle, "Page Down")
+    }
+
+    func testToolbarKeysReuseShortcutKeyDomainForTerminalEvents() {
+        let mappings: [(TerminalToolbarKey, ShortcutKey, GhosttySurfaceKeyEvent.KeyCode)] = [
+            (.escape, .escape, .escape),
+            (.tab, .tab, .tab),
+            (.enter, .enter, .enter),
+            (.backspace, .backspace, .backspace),
+            (.delete, .delete, .delete),
+            (.arrowUp, .arrowUp, .arrowUp),
+            (.arrowDown, .arrowDown, .arrowDown),
+            (.arrowLeft, .arrowLeft, .arrowLeft),
+            (.arrowRight, .arrowRight, .arrowRight),
+            (.home, .home, .home),
+            (.end, .end, .end),
+            (.pageUp, .pageUp, .pageUp),
+            (.pageDown, .pageDown, .pageDown),
+        ]
+
+        for (toolbarKey, shortcutKey, keyCode) in mappings {
+            XCTAssertEqual(toolbarKey.shortcutKey, shortcutKey)
+            XCTAssertEqual(shortcutKey.ghosttyKeyCode, keyCode)
+        }
+        XCTAssertNil(TerminalToolbarKey.control.shortcutKey)
+    }
+
+    func testToolbarKeysAllowDuplicatesAndNoControl() {
+        let keys = TerminalToolbarKeys(
+            first: .escape,
+            second: .escape,
+            third: .pageDown
+        )
+
+        XCTAssertEqual(keys.values, [.escape, .escape, .pageDown])
+        XCTAssertFalse(keys.containsControl)
+        XCTAssertEqual(keys.summary, "Escape, Escape, Page Down")
+        XCTAssertEqual(keys.compactSummary, "esc · esc · pgdn")
     }
 
     func testTerminalAppearanceComparisonIgnoresNonAppearanceSettings() {
@@ -41,9 +86,15 @@ final class TerminalSettingsTests: XCTestCase {
             theme: .remuxDark,
             zoomMultipaneWindowsByDefault: true
         )
+        let toolbarKeysChanged = TerminalSettings(
+            fontSize: 13,
+            theme: .remuxDark,
+            toolbarKeys: TerminalToolbarKeys(first: .escape, second: .tab, third: .enter)
+        )
 
         XCTAssertTrue(settings.hasSameTerminalAppearance(as: rsaOnly))
         XCTAssertTrue(settings.hasSameTerminalAppearance(as: multipaneDefaultChanged))
+        XCTAssertTrue(settings.hasSameTerminalAppearance(as: toolbarKeysChanged))
         XCTAssertFalse(settings.hasSameTerminalAppearance(as: fontChanged))
         XCTAssertFalse(settings.hasSameTerminalAppearance(as: themeChanged))
     }

--- a/RemuxAppUITests/RemuxAppUITests.swift
+++ b/RemuxAppUITests/RemuxAppUITests.swift
@@ -46,6 +46,50 @@ final class RemuxAppUITests: XCTestCase {
         _ = waitForTerminalHomeButton()
     }
 
+    func testToolbarKeysUpdateRetainedSimulatorTerminalAndFirstSlotOpensShortcuts() {
+        launchSeededSimulatorTerminal()
+
+        XCTAssertEqual(app.buttons["terminal.toolbar-key.0"].label, "Control")
+        openHomeFromTerminal()
+        app.buttons["library.settings"].tap()
+        let toolbarKeys = app.buttons["settings.toolbar-keys"]
+        if !toolbarKeys.waitForExistence(timeout: 1) {
+            settingsForm.swipeUp()
+        }
+        toolbarKeys.tap()
+        app.buttons["settings.toolbar-keys.slot.0"].tap()
+        selectToolbarKey("Page Down")
+        app.buttons["settings.toolbar-keys.slot.1"].tap()
+        selectToolbarKey("Control")
+        app.buttons["settings.toolbar-keys.slot.2"].tap()
+        selectToolbarKey("Home")
+        app.navigationBars["Toolbar Keys"].buttons.firstMatch.tap()
+        app.navigationBars["Settings"].buttons.firstMatch.tap()
+
+        let retainedSession = app.buttons["library.active-session.show"].firstMatch
+        XCTAssertTrue(retainedSession.waitForExistence(timeout: 5))
+        retainedSession.tap()
+
+        let first = app.buttons["terminal.toolbar-key.0"]
+        let control = app.buttons["terminal.toolbar-key.1"]
+        let third = app.buttons["terminal.toolbar-key.2"]
+        XCTAssertTrue(first.waitForExistence(timeout: 5))
+        XCTAssertEqual(first.label, "Page Down")
+        XCTAssertEqual(control.label, "Control")
+        XCTAssertEqual(third.label, "Home")
+
+        attachScreenshot(named: "toolbar-keys-control-moved")
+
+        first.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 1.2)
+        XCTAssertTrue(app.buttons["terminal.shortcuts.settings"].waitForExistence(timeout: 2))
+        attachScreenshot(named: "toolbar-keys-first-slot-shortcuts")
+        app.otherElements["terminal.screen"]
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
+            .tap()
+        XCTAssertFalse(app.buttons["terminal.shortcuts.settings"].waitForExistence(timeout: 1))
+    }
+
     func testComposerDictationStopAndCancelFlow() {
         let transcript = "Review the current changes and run the focused tests"
         app.launchEnvironment["REMUX_DEBUG_DICTATION_TRANSCRIPT"] = transcript
@@ -601,6 +645,57 @@ final class RemuxAppUITests: XCTestCase {
         attachScreenshot(named: "settings-shortcuts-shared-chrome")
     }
 
+    func testSettingsConfigureAndResetToolbarKeys() {
+        launchSimulatorApp()
+        XCTAssertTrue(app.buttons["library.settings"].waitForExistence(timeout: 5))
+        app.buttons["library.settings"].tap()
+
+        let toolbarKeys = app.buttons["settings.toolbar-keys"]
+        if !toolbarKeys.waitForExistence(timeout: 1) {
+            settingsForm.swipeUp()
+        }
+        XCTAssertTrue(toolbarKeys.waitForExistence(timeout: 2))
+        XCTAssertEqual(toolbarKeys.value as? String, "Control, Escape, Tab")
+        attachScreenshot(named: "settings-toolbar-keys-row-default")
+        toolbarKeys.tap()
+
+        XCTAssertTrue(app.navigationBars["Toolbar Keys"].waitForExistence(timeout: 2))
+        let first = app.buttons["settings.toolbar-keys.slot.0"]
+        let second = app.buttons["settings.toolbar-keys.slot.1"]
+        let third = app.buttons["settings.toolbar-keys.slot.2"]
+        XCTAssertEqual(first.value as? String, "Control")
+        XCTAssertEqual(second.value as? String, "Escape")
+        XCTAssertEqual(third.value as? String, "Tab")
+        attachScreenshot(named: "settings-toolbar-keys-default")
+
+        first.tap()
+        XCTAssertTrue(app.navigationBars["First Key"].waitForExistence(timeout: 2))
+        attachScreenshot(named: "settings-toolbar-keys-picker")
+        selectToolbarKey("Page Down")
+        XCTAssertEqual(first.value as? String, "Page Down")
+
+        second.tap()
+        XCTAssertTrue(app.navigationBars["Second Key"].waitForExistence(timeout: 2))
+        selectToolbarKey("Page Down")
+        XCTAssertEqual(second.value as? String, "Page Down")
+
+        third.tap()
+        XCTAssertTrue(app.navigationBars["Third Key"].waitForExistence(timeout: 2))
+        selectToolbarKey("Home")
+        XCTAssertEqual(third.value as? String, "Home")
+        attachScreenshot(named: "settings-toolbar-keys-customized")
+
+        let reset = app.buttons["settings.toolbar-keys.reset"]
+        XCTAssertTrue(reset.waitForExistence(timeout: 2))
+        reset.tap()
+
+        XCTAssertEqual(first.value as? String, "Control")
+        XCTAssertEqual(second.value as? String, "Escape")
+        XCTAssertEqual(third.value as? String, "Tab")
+        XCTAssertFalse(reset.exists)
+        attachScreenshot(named: "settings-toolbar-keys-reset")
+    }
+
     func testPrivateKeyAuthenticationFlowShowsActionsUntilKeySelected() {
         app.launchEnvironment["REMUX_UI_TEST_PUBLIC_KEY_INSTALL_OUTCOME"] = "passwordRequired"
         launchSimulatorApp()
@@ -779,7 +874,7 @@ final class RemuxAppUITests: XCTestCase {
         waitForLiveTerminalReady(timeout: 60)
         waitForLiveTerminalInputReady(timeout: 10)
 
-        let control = app.buttons["terminal.ctrl"]
+        let control = app.buttons["terminal.toolbar-key.0"]
         XCTAssertTrue(control.waitForExistence(timeout: 5))
         control.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
             .press(forDuration: 1.2)
@@ -812,6 +907,133 @@ final class RemuxAppUITests: XCTestCase {
             sessionName: sessionName,
             paneIndex: 1,
             marker: "REMUXS"
+        )
+    }
+
+    func testLiveCustomizedToolbarKeysExecuteAndRetainSessionWhenConfigured() throws {
+        let sessionName = try generatedLiveLatencySessionName("toolbar-keys")
+        defer {
+            cleanupGeneratedLiveLatencySessionIfPossible(sessionName)
+        }
+
+        try launchLiveSSHAppIfConfigured(traceRuntime: true, sessionNameOverride: sessionName)
+        openFirstSavedSession()
+        waitForLiveTerminalReady(timeout: 60)
+
+        let initialFirst = app.buttons["terminal.toolbar-key.0"]
+        XCTAssertTrue(initialFirst.waitForExistence(timeout: 5))
+        XCTAssertEqual(initialFirst.label, "Control")
+
+        openHomeFromTerminal()
+        app.buttons["library.settings"].tap()
+        let toolbarKeys = app.buttons["settings.toolbar-keys"]
+        if !toolbarKeys.waitForExistence(timeout: 1) {
+            settingsForm.swipeUp()
+        }
+        XCTAssertTrue(toolbarKeys.waitForExistence(timeout: 2))
+        toolbarKeys.tap()
+
+        let firstSetting = app.buttons["settings.toolbar-keys.slot.0"]
+        let secondSetting = app.buttons["settings.toolbar-keys.slot.1"]
+        let thirdSetting = app.buttons["settings.toolbar-keys.slot.2"]
+        firstSetting.tap()
+        selectToolbarKey("Escape")
+        secondSetting.tap()
+        selectToolbarKey("Control")
+        thirdSetting.tap()
+        selectToolbarKey("Up Arrow")
+
+        app.navigationBars["Toolbar Keys"].buttons.firstMatch.tap()
+        app.navigationBars["Settings"].buttons.firstMatch.tap()
+        let retainedSession = app.buttons["library.active-session.show"].firstMatch
+        XCTAssertTrue(retainedSession.waitForExistence(timeout: 5))
+        retainedSession.tap()
+        waitForLiveTerminalReady(timeout: 10)
+
+        let escape = app.buttons["terminal.toolbar-key.0"]
+        let control = app.buttons["terminal.toolbar-key.1"]
+        let arrowUp = app.buttons["terminal.toolbar-key.2"]
+        XCTAssertTrue(escape.waitForExistence(timeout: 5))
+        XCTAssertEqual(escape.label, "Escape")
+        XCTAssertEqual(control.label, "Control")
+        XCTAssertEqual(arrowUp.label, "Up Arrow")
+
+        sendTerminalCommand(
+            "python3 -c 'import os,select,sys,termios,tty; f=sys.stdin.fileno(); o=termios.tcgetattr(f); tty.setraw(f); r=select.select([f],[],[],3)[0]; b=os.read(f,1) if r else b\"\"; termios.tcsetattr(f,termios.TCSADRAIN,o); print(\"REMUX_LONG_PRESS_OK\" if not b else \"REMUX_LONG_PRESS_BAD\")'"
+        )
+        escape.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 1.2)
+        XCTAssertTrue(app.buttons["terminal.shortcuts.settings"].waitForExistence(timeout: 2))
+        app.otherElements["terminal.screen"]
+            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12))
+            .tap()
+        XCTAssertFalse(app.buttons["terminal.shortcuts.settings"].waitForExistence(timeout: 1))
+        RunLoop.current.run(until: Date().addingTimeInterval(2))
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUX_LONG_PRESS_OK"
+        )
+
+        sendTerminalCommand(
+            "python3 -c 'import os,sys,termios,tty; f=sys.stdin.fileno(); o=termios.tcgetattr(f); tty.setraw(f); b=os.read(f,1); termios.tcsetattr(f,termios.TCSADRAIN,o); print(\"REMUX_ESCAPE_OK\" if b and b[0]==27 else \"REMUX_ESCAPE_BAD\")'"
+        )
+        escape.tap()
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUX_ESCAPE_OK"
+        )
+
+        sendTerminalCommand("sleep 10")
+        control.tap()
+        waitForLiveTerminalInputReady(timeout: 10)
+        app.typeText("c")
+        sendTerminalCommand("echo REMUX_CTRL_MOVED_OK")
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUX_CTRL_MOVED_OK"
+        )
+
+        sendTerminalCommand("echo REMUX_ARROW_UP_OK")
+        sendTerminalCommand("clear")
+        arrowUp.tap()
+        arrowUp.tap()
+        waitForLiveTerminalInputReady(timeout: 10)
+        app.typeText("\n")
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUX_ARROW_UP_OK"
+        )
+
+        sendTerminalCommand(
+            "python3 -c 'import os,sys,termios,tty; f=sys.stdin.fileno(); o=termios.tcgetattr(f); tty.setraw(f); b=os.read(f,1); termios.tcsetattr(f,termios.TCSADRAIN,o); print(\"REMUX_PLAIN_C_OK\" if b and b[0]==99 else \"REMUX_PLAIN_C_BAD\")'"
+        )
+        control.tap()
+        openHomeFromTerminal()
+        app.buttons["library.settings"].tap()
+        let changedToolbarKeys = app.buttons["settings.toolbar-keys"]
+        if !changedToolbarKeys.waitForExistence(timeout: 1) {
+            settingsForm.swipeUp()
+        }
+        changedToolbarKeys.tap()
+        app.buttons["settings.toolbar-keys.slot.1"].tap()
+        selectToolbarKey("Tab")
+        app.navigationBars["Toolbar Keys"].buttons.firstMatch.tap()
+        app.navigationBars["Settings"].buttons.firstMatch.tap()
+        app.buttons["library.active-session.show"].firstMatch.tap()
+        waitForLiveTerminalReady(timeout: 10)
+        waitForLiveTerminalInputReady(timeout: 10)
+        app.typeText("c")
+        RunLoop.current.run(until: Date().addingTimeInterval(1))
+        recordLiveTmuxPaneCaptureExpectation(
+            sessionName: sessionName,
+            paneIndex: 1,
+            marker: "REMUX_PLAIN_C_OK"
         )
     }
 
@@ -2313,7 +2535,7 @@ final class RemuxAppUITests: XCTestCase {
         keyboard.tap()
         XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 8))
 
-        let ctrl = app.buttons["terminal.ctrl"]
+        let ctrl = app.buttons["terminal.toolbar-key.0"]
         XCTAssertTrue(ctrl.waitForExistence(timeout: 5))
         ctrl.tap()
         waitForLiveTerminalInputReady(timeout: 10)
@@ -2793,6 +3015,33 @@ final class RemuxAppUITests: XCTestCase {
     private func launchSimulatorApp() {
         app.launchEnvironment["REMUX_UI_TESTING"] = "1"
         app.launch()
+    }
+
+    private func launchSeededSimulatorTerminal() {
+        app.launchEnvironment.merge(
+            [
+                "REMUX_UI_TESTING": "1",
+                "REMUX_DEBUG_SEED_CONNECTION": "1",
+                "REMUX_DEBUG_SERVER_NAME": "UI Test Server",
+                "REMUX_DEBUG_SERVER_HOST": "example.com",
+                "REMUX_DEBUG_SERVER_USERNAME": "tester",
+                "REMUX_DEBUG_SERVER_PASSWORD": "password",
+                "REMUX_DEBUG_TMUX_SESSION": "ui-test",
+            ],
+            uniquingKeysWith: { _, new in new }
+        )
+        app.launch()
+
+        let session = app.descendants(matching: .any)["library.session.resume"].firstMatch
+        XCTAssertTrue(session.waitForExistence(timeout: 5))
+        session.tap()
+        XCTAssertTrue(app.buttons["terminal.toolbar-key.0"].waitForExistence(timeout: 5))
+    }
+
+    private func selectToolbarKey(_ title: String) {
+        let option = app.collectionViews.buttons[title].firstMatch
+        XCTAssertTrue(option.waitForExistence(timeout: 2))
+        option.tap()
     }
 
     private func launchLiveSSHAppIfConfigured(
@@ -4295,7 +4544,7 @@ final class RemuxAppUITests: XCTestCase {
         attach(name: "23-grouped-terminal-dock-keyboard")
 
         // Capture the grouped dock with ctrl armed (modifier feedback).
-        let ctrlButton = app.buttons["terminal.ctrl"]
+        let ctrlButton = app.buttons["terminal.toolbar-key.0"]
         if ctrlButton.exists, ctrlButton.isHittable {
             ctrlButton.tap()
             sleep(1)

--- a/RemuxAppUITests/ShortcutPaletteUITests.swift
+++ b/RemuxAppUITests/ShortcutPaletteUITests.swift
@@ -165,8 +165,15 @@ final class ShortcutPaletteUITests: XCTestCase {
         app.buttons["Key"].tap()
         XCTAssertTrue(app.buttons["Key, Esc"].waitForExistence(timeout: 2))
         app.buttons["Key, Esc"].tap()
-        XCTAssertTrue(app.buttons["Tab"].waitForExistence(timeout: 2))
-        app.buttons["Tab"].tap()
+        let tabOption = app.buttons.matching(
+            NSPredicate(
+                format: "label == %@ AND identifier != %@",
+                "Tab",
+                "terminal.toolbar-key.2"
+            )
+        ).firstMatch
+        XCTAssertTrue(tabOption.waitForExistence(timeout: 2))
+        tabOption.tap()
         app.scrollViews.firstMatch.swipeUp()
         app.switches["Ctrl"].tap()
         XCTAssertTrue(waitForValue(app.switches["Ctrl"], expected: "1"))
@@ -292,7 +299,7 @@ final class ShortcutPaletteUITests: XCTestCase {
         XCTAssertTrue(session.waitForExistence(timeout: 5))
         session.tap()
 
-        XCTAssertTrue(app.buttons["terminal.ctrl"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["terminal.toolbar-key.0"].waitForExistence(timeout: 5))
     }
 
     private func attachScreenshot(named name: String) {
@@ -303,7 +310,7 @@ final class ShortcutPaletteUITests: XCTestCase {
     }
 
     private func openShortcutPalette() {
-        let control = app.buttons["terminal.ctrl"]
+        let control = app.buttons["terminal.toolbar-key.0"]
         XCTAssertTrue(control.waitForExistence(timeout: 5))
         control.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).press(forDuration: 1.2)
 


### PR DESCRIPTION
## Summary

Bring the already-reviewed toolbar customization from #78 into main while preserving its original commits.

PR #78 was stacked on feature/unified-settings. It merged there after #77 had already merged into main, so its changes were not included in main.

- Include configurable toolbar keys and the associated long-press fixes from #78.
- Preserve the newer shortcut-editor keyboard-focus fix (#81) and window-picker viewport fix (#82).
- No new feature code or manual conflict resolution; the branches merged cleanly.

## Validation

- Reviewed the integration diff and confirmed the newer main fixes remain intact.
- All 1,055 unit tests passed on the combined simulator build.
- Existing simulator UI checks passed for configuring/resetting toolbar keys and opening shortcut collections from Settings (2 tests, 0 failures).
- Real SSH/tmux toolbar validation was performed for #78; this integration does not change its key handling. That live-server matrix was not rerun for this integration.

This PR does not bump the build number or upload a TestFlight build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal toolbar keys with support for selecting three keys from Settings.
  * Added a reset-to-default option for toolbar key selections.
  * Terminal toolbars now reflect customized keys and support additional navigation and editing keys.
  * Toolbar key changes persist across sessions and remain available in active terminals.
* **Accessibility**
  * Improved labels, hints, values, and long-press actions for toolbar key buttons.
* **Tests**
  * Added coverage for customization, persistence, reset behavior, key execution, and accessibility interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->