### PR TITLE
add github sponsors link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: h3nock


### PR DESCRIPTION
Add a Sponsor button to Remux linking to h3nock’s GitHub Sponsors profile through .github/FUNDING.yml. Validated the one-line configuration and checked the diff for whitespace errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Sponsors funding configuration for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->